### PR TITLE
TextInput first pass

### DIFF
--- a/packages/evergreen-text-input/package.json
+++ b/packages/evergreen-text-input/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "evergreen-text-input",
+  "version": "1.0.0",
+  "description": "React components: TextInput, TextInputAppearances",
+  "main": "lib/index.js",
+  "keywords": [
+    "evergreen",
+    "segment",
+    "ui",
+    "react",
+    "TextInput",
+    "TextInputAppearances"
+  ],
+  "author": "Segment",
+  "license": "MIT",
+  "dependencies": {
+    "evergreen-typography": "^1.0.0",
+    "evergreen-colors": "^1.0.0",
+    "ui-box": "^0.3.5"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "prop-types": "^15.0.0"
+  }
+}

--- a/packages/evergreen-text-input/src/components/TextInput.js
+++ b/packages/evergreen-text-input/src/components/TextInput.js
@@ -1,0 +1,73 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { Text, TextStyles } from 'evergreen-typography'
+import TextInputAppearances from '../styles/text-input-appearances'
+
+const getTextStyleForTextInput = ({ height }) => {
+  if (height <= 28) return TextStyles['300']
+  if (height <= 32) return TextStyles['300']
+  if (height <= 36) return TextStyles['400']
+  if (height <= 40) return TextStyles['400']
+  if (height <= 48) return TextStyles['500']
+  if (height <= 56) return TextStyles['700']
+  return TextStyles['800']
+}
+
+const getBorderRadiusForTextInput = ({ height }) => {
+  if (height <= 28) return 3
+  if (height <= 32) return 4
+  return 5
+}
+
+export default class TextInput extends PureComponent {
+  static propTypes = {
+    ...Text.propTypes,
+    appearance: PropTypes.oneOf(Object.keys(TextInputAppearances)).isRequired,
+    disabled: PropTypes.bool.isRequired,
+    isInvalid: PropTypes.bool.isRequired,
+    spellcheck: PropTypes.bool.isRequired,
+  }
+
+  static defaultProps = {
+    type: 'text',
+    is: 'input',
+    appearance: 'default',
+    boxSizing: 'border-box',
+    height: 32,
+    width: 280,
+    disabled: false,
+    isInvalid: false,
+    spellcheck: true,
+  }
+
+  render() {
+    const {
+      css,
+      height,
+      disabled,
+      isInvalid,
+      appearance,
+      spellcheck,
+      ...props
+    } = this.props
+    const appearanceStyle = TextInputAppearances[appearance]
+    const textStyle = getTextStyleForTextInput({ height })
+    const borderRadius = getBorderRadiusForTextInput({ height })
+
+    return (
+      <Text
+        height={height}
+        disabled={disabled}
+        paddingLeft={Math.round(height / 3.2)}
+        paddingRight={Math.round(height / 3.2)}
+        borderRadius={borderRadius}
+        spellcheck={spellcheck}
+        {...(isInvalid ? { 'aria-invalid': true } : {})}
+        {...(disabled ? { color: 'extraMuted' } : {})}
+        {...textStyle}
+        css={{ ...css, ...appearanceStyle }}
+        {...props}
+      />
+    )
+  }
+}

--- a/packages/evergreen-text-input/src/index.js
+++ b/packages/evergreen-text-input/src/index.js
@@ -1,0 +1,4 @@
+export { default as TextInput } from './components/TextInput'
+export {
+  default as TextInputAppearances,
+} from './styles/text-input-appearances'

--- a/packages/evergreen-text-input/src/styles/text-input-appearances.js
+++ b/packages/evergreen-text-input/src/styles/text-input-appearances.js
@@ -1,0 +1,54 @@
+import colors from 'evergreen-colors'
+
+const TextInputAppearances = {
+  default: {
+    WebkitAppearance: 'none',
+    border: 'none',
+    backgroundColor: 'white',
+    boxShadow: `inset 0 0 0 1px ${colors.neutral[
+      '40A'
+    ]}, inset 0 1px 2px ${colors.neutral['40A']}`,
+    '&[aria-invalid]': {
+      boxShadow: `inset 0 0 0 1px ${colors.red['500']}, inset 0 1px 2px ${colors
+        .neutral['40A']}`,
+    },
+    '&::placeholder': {
+      color: colors.neutral['100A'],
+    },
+    '&:focus': {
+      outline: 'none',
+      boxShadow: `inset 0 0 2px ${colors.neutral[
+        '40A'
+      ]}, inset 0 0 0 1px ${colors.blue['150A']}, 0 0 0 2px ${colors.blue[
+        '15A'
+      ]}`,
+    },
+    '&:disabled': {
+      cursor: 'not-allowed',
+      boxShadow: `inset 0 0 0 1px ${colors.neutral['20A']}`,
+      backgroundColor: colors.neutral['5A'],
+    },
+  },
+  neutral: {
+    WebkitAppearance: 'none',
+    border: 'none',
+    backgroundColor: colors.neutral['10A'],
+    '&[aria-invalid]': {
+      boxShadow: `inset 0 0 0 1px ${colors.red['500']}`,
+    },
+    '&::placeholder': {
+      color: colors.neutral['100A'],
+    },
+    '&:focus': {
+      outline: 'none',
+      boxShadow: `0 0 0 2px ${colors.blue['150A']}`,
+    },
+    '&:disabled': {
+      cursor: 'not-allowed',
+      boxShadow: `inset 0 0 0 1px ${colors.neutral['20A']}`,
+      backgroundColor: colors.neutral['5A'],
+    },
+  },
+}
+
+export default TextInputAppearances

--- a/packages/evergreen-text-input/stories/index.stories.js
+++ b/packages/evergreen-text-input/stories/index.stories.js
@@ -1,0 +1,81 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import Box from 'ui-box'
+import { Text, Label, Heading } from 'evergreen-typography'
+import { TextInput, TextInputAppearances } from '../src/'
+
+const Description = props =>
+  <Text is="p" marginTop={0} size={300} color="extraMuted" {...props} />
+
+storiesOf('text-input', module).add('TextInput', () =>
+  <div>
+    {Object.keys(TextInputAppearances).map(appearance =>
+      <Box>
+        <Heading marginBottom={24}>
+          Appearance: {appearance}
+        </Heading>
+        <Box marginBottom={24} width={360}>
+          <Label htmlFor={32} size={400} display="block">
+            Height 32 (default)
+          </Label>
+          <Description marginBottom={8}>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit sed do.
+          </Description>
+          <TextInput
+            appearance={appearance}
+            name={32}
+            id={32}
+            placeholder="With placeholder"
+          />
+        </Box>
+        <Box marginBottom={24} width={360}>
+          <Label htmlFor="disabled" size={400} display="block">
+            Disabled
+          </Label>
+          <TextInput
+            appearance={appearance}
+            value="This is disabled"
+            name="disabled"
+            id="disabled"
+            disabled
+          />
+        </Box>
+        <Box marginBottom={24} width={360}>
+          <Label htmlFor="isInvalid" size={400} display="block">
+            Is Invalid
+          </Label>
+          <TextInput
+            appearance={appearance}
+            name="isInvalid"
+            id="isInvalid"
+            isInvalid
+          />
+        </Box>
+        <Box marginBottom={24}>
+          <Label htmlFor={24} size={300} display="block" marginBottom={4}>
+            Height 24
+          </Label>
+          <TextInput appearance={appearance} height={24} name={24} id={24} />
+        </Box>
+        <Box marginBottom={24}>
+          <Label htmlFor={28} size={300} display="block" marginBottom={4}>
+            Height 28
+          </Label>
+          <TextInput appearance={appearance} height={28} name={28} id={28} />
+        </Box>
+        <Box marginBottom={24}>
+          <Label htmlFor={36} size={400} display="block" marginBottom={4}>
+            Height 36
+          </Label>
+          <TextInput appearance={appearance} height={36} name={36} id={36} />
+        </Box>
+        <Box marginBottom={24}>
+          <Label htmlFor={40} size={500} display="block" marginBottom={4}>
+            Height 40
+          </Label>
+          <TextInput appearance={appearance} height={40} name={40} id={40} />
+        </Box>
+      </Box>,
+    )}
+  </div>,
+)


### PR DESCRIPTION
Implements #18.


<img width="470" alt="screen shot 2017-09-19 at 10 40 43 pm" src="https://user-images.githubusercontent.com/564463/30678317-2e3875a6-9e46-11e7-8d5b-298b86a5f1dd.png">
<img width="426" alt="screen shot 2017-09-19 at 10 41 05 pm" src="https://user-images.githubusercontent.com/564463/30678318-2e392424-9e46-11e7-8834-54d9ea00529c.png">



We have the neutral color mainly for the SearchInput, that one will implement TextInput. I am not happy about the Is Invalid state, it should have a yellow border with a warning icon on the right. I descoped that for now, since we don’t have icons yet, and it’s a pain because there needs to be a wrapper Box around the actual input — this will lead to some weird prop splitting to get right.

Text size and padding left/right and border radius are automatically determined based on the height. Which might be something I will port to the buttons too — or some shared-styles package.