### PR TITLE
openOnFocus added to combobox

### DIFF
--- a/packages/evergreen-autocomplete/src/components/Autocomplete.js
+++ b/packages/evergreen-autocomplete/src/components/Autocomplete.js
@@ -125,6 +125,7 @@ export default class Autocomplete extends PureComponent {
                   highlightedIndex,
                   selectItemAtIndex,
                 })}
+              minHeight={0}
               animationDuration={0}
               useSmartPositioning={useSmartPositioning}
             >

--- a/packages/evergreen-combobox/src/components/Combobox.js
+++ b/packages/evergreen-combobox/src/components/Combobox.js
@@ -4,18 +4,26 @@ import { TextInput } from 'evergreen-text-input'
 import { Button } from 'evergreen-buttons'
 import { TriangleIcon } from 'evergreen-icons'
 import PropTypes from 'prop-types'
-import Box from 'ui-box'
+import Box, { dimensions, spacing, position, layout } from 'ui-box'
 
 export default class Combobox extends PureComponent {
   static propTypes = {
-    ...Box.propTypes,
+    ...dimensions.propTypes,
+    ...spacing.propTypes,
+    ...position.propTypes,
+    ...layout.propTypes,
     items: PropTypes.array,
     width: PropTypes.oneOf(PropTypes.string, PropTypes.number),
     height: PropTypes.number,
     onChange: PropTypes.func,
-    autocompleteProps: PropTypes.objectOf(Autocomplete.propTypes),
     inputProps: PropTypes.objectOf(TextInput.propTypes),
     buttonProps: PropTypes.objectOf(Button.propTypes),
+    openOnFocus: PropTypes.bool.isRequired,
+    autocompleteProps: PropTypes.objectOf(Autocomplete.propTypes),
+  }
+
+  static defaultProps = {
+    openOnFocus: false,
   }
 
   constructor(props, context) {
@@ -41,6 +49,7 @@ export default class Combobox extends PureComponent {
       onChange,
       inputProps,
       buttonProps,
+      openOnFocus,
       autocompleteProps,
       ...props
     } = this.props
@@ -57,6 +66,7 @@ export default class Combobox extends PureComponent {
           key,
           getRef,
           isOpen,
+          openMenu,
           inputValue,
           getInputProps,
           getButtonProps,
@@ -73,7 +83,12 @@ export default class Combobox extends PureComponent {
               value={inputValue}
               borderTopRightRadius={0}
               borderBottomRightRadius={0}
-              {...getInputProps(inputProps)}
+              {...getInputProps({
+                ...inputProps,
+                onFocus: () => {
+                  if (openOnFocus) openMenu()
+                },
+              })}
             />
             <Button
               height={height}

--- a/packages/evergreen-combobox/stories/index.stories.js
+++ b/packages/evergreen-combobox/stories/index.stories.js
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import Box from 'ui-box'
 import starWarsNames from 'starwars-names'
+import { Heading } from 'evergreen-typography'
 import { Combobox } from '../src/'
 
 // Generate a big list of items
@@ -33,6 +34,13 @@ storiesOf('combobox', module).add('Combobox', () => (
       document.body.style.margin = '0'
       document.body.style.height = '100vh'
     })()}
-    <Combobox items={items} onChange={handleChange} />
+    <Box marginBottom={16}>
+      <Heading>Default usage</Heading>
+      <Combobox items={items} onChange={handleChange} />
+    </Box>
+    <Box marginBottom={16}>
+      <Heading>Open on focus</Heading>
+      <Combobox openOnFocus items={items} onChange={handleChange} />
+    </Box>
   </Box>
 ))


### PR DESCRIPTION
Added `openOnFocus` prop support for Combobox. Implements #58 

![combobox-open-on-focus](https://user-images.githubusercontent.com/564463/32568593-9d49d770-c473-11e7-816c-bf691ee021a7.gif)
