### PR TITLE
tooltip tweaks

### DIFF
--- a/packages/evergreen-tooltip/package.json
+++ b/packages/evergreen-tooltip/package.json
@@ -13,7 +13,6 @@
   "author": "Segment",
   "license": "MIT",
   "dependencies": {
-    "color": "^2.0.0",
     "evergreen-colors": "^2.18.14",
     "evergreen-positioner": "^2.18.14",
     "evergreen-typography": "^2.18.14",

--- a/packages/evergreen-tooltip/src/components/Tooltip.js
+++ b/packages/evergreen-tooltip/src/components/Tooltip.js
@@ -71,6 +71,8 @@ export default class Tooltip extends PureComponent {
         key="tooltip-positioner"
         targetRect={targetRect}
         isShown={shown}
+        initialScale={0.95}
+        targetOffset={4}
         {...props}
       >
         {({ css, style, state, getRef }) => (

--- a/packages/evergreen-tooltip/src/components/TooltipStateless.js
+++ b/packages/evergreen-tooltip/src/components/TooltipStateless.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import Color from 'color'
 import colors from 'evergreen-colors'
 import { Text } from 'evergreen-typography'
 
@@ -11,7 +10,7 @@ export default class TooltipStateless extends PureComponent {
   }
 
   static defaultProps = {
-    backgroundColor: Color(colors.neutral['900']).alpha(0.9),
+    backgroundColor: colors.neutral['400A'],
     borderRadius: 3,
     paddingX: 8,
     paddingY: 4,

--- a/packages/evergreen-tooltip/src/index.js
+++ b/packages/evergreen-tooltip/src/index.js
@@ -1,1 +1,4 @@
-export { default as Tooltip } from './components/Tooltip'
+import Tooltip from './components/Tooltip'
+
+export default Tooltip
+export { Tooltip }

--- a/packages/evergreen-tooltip/yarn.lock
+++ b/packages/evergreen-tooltip/yarn.lock
@@ -18,30 +18,6 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
-color-convert@^1.8.2:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
-  dependencies:
-    color-name "^1.1.1"
-
-color-name@^1.0.0, color-name@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-
-color-string@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.2.tgz#26e45814bc3c9a7cbd6751648a41434514a773a9"
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
-
-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-2.0.0.tgz#e0c9972d1e969857004b101eaa55ceab5961d67d"
-  dependencies:
-    color-convert "^1.8.2"
-    color-string "^1.4.0"
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -62,40 +38,41 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-evergreen-colors@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/evergreen-colors/-/evergreen-colors-2.2.6.tgz#229277e934eab18de8ac67d4fedf565f59502497"
+evergreen-colors@^2.18.14:
+  version "2.18.14"
+  resolved "https://registry.yarnpkg.com/evergreen-colors/-/evergreen-colors-2.18.14.tgz#0c4fab619733f902d0d2f62571cbc9352ecc5333"
 
-evergreen-layers@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/evergreen-layers/-/evergreen-layers-2.2.6.tgz#d65e9056ae2fc4eb41e0a73577fb7d41d4a8d672"
+evergreen-layers@^2.18.14:
+  version "2.18.14"
+  resolved "https://registry.yarnpkg.com/evergreen-layers/-/evergreen-layers-2.18.14.tgz#2bd7fcf841552ad34c9b449bac4a7d31299f10ab"
   dependencies:
-    evergreen-colors "^2.2.6"
-    ui-box "^0.4.1"
+    evergreen-colors "^2.18.14"
+    ui-box "^0.5.4"
 
-evergreen-portal@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/evergreen-portal/-/evergreen-portal-2.2.6.tgz#2bb507bf01c95dd3ce428888fe533b4d9b94df14"
+evergreen-portal@^2.18.14:
+  version "2.18.14"
+  resolved "https://registry.yarnpkg.com/evergreen-portal/-/evergreen-portal-2.18.14.tgz#bc2f11d37d1c4d61cffd5115d83cbca63ade3ecf"
   dependencies:
     dom-helpers "^3.2.1"
-    ui-box "^0.4.1"
+    ui-box "^0.5.4"
 
-evergreen-positioner@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/evergreen-positioner/-/evergreen-positioner-2.5.0.tgz#213eaf0205c76f7186a8b7e34a2590557d994549"
+evergreen-positioner@^2.18.14:
+  version "2.18.14"
+  resolved "https://registry.yarnpkg.com/evergreen-positioner/-/evergreen-positioner-2.18.14.tgz#25fe4715940d19b4dcc75666c3a024dfed05e374"
   dependencies:
-    evergreen-portal "^2.2.6"
+    evergreen-portal "^2.18.14"
     object-values "^1.0.0"
     prop-types "^15.0.0"
     react-transition-group "^2.2.1"
-    ui-box "^0.4.0"
+    ui-box "^0.5.4"
 
-evergreen-typography@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/evergreen-typography/-/evergreen-typography-2.2.6.tgz#9d7fa8a2892e353069c6f6d37eddf6843bd1f765"
+evergreen-typography@^2.18.14:
+  version "2.18.14"
+  resolved "https://registry.yarnpkg.com/evergreen-typography/-/evergreen-typography-2.18.14.tgz#e03a27f5a86ec35bb0f2056a42c70f9d303ba2a2"
   dependencies:
-    evergreen-colors "^2.2.6"
-    ui-box "^0.4.1"
+    evergreen-colors "^2.18.14"
+    lodash.mapvalues "^4.6.0"
+    prop-types "^15.0.0"
 
 fbjs@^0.8.12, fbjs@^0.8.16:
   version "0.8.16"
@@ -134,10 +111,6 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
-is-arrayish@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.1.tgz#c2dfc386abaa0c3e33c48db3fe87059e69065efd"
-
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -152,6 +125,10 @@ isomorphic-fetch@^2.1.1:
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+lodash.mapvalues@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
 
 loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
@@ -203,12 +180,6 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  dependencies:
-    is-arrayish "^0.3.1"
-
 through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -216,13 +187,6 @@ through@^2.3.8:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
-
-ui-box@^0.4.0, ui-box@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-0.4.1.tgz#410f7b14ef9abdfac10973e21ba6fc1e1d0fa072"
-  dependencies:
-    classnames "^2.2.5"
-    glamor "^2.20.22"
 
 ui-box@^0.5.4:
   version "0.5.4"


### PR DESCRIPTION
- Tweaks scale and target offset
- Gets rid of Color and uses colors.neutral['400A'] instead. which is a little too light, but will do for now.