### PR TITLE
Add text style between 500 and 600

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
   "lerna": "2.0.0",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "2.18.20"
+  "version": "independent"
 }

--- a/packages/evergreen-typography/src/styles/TextStyles.js
+++ b/packages/evergreen-typography/src/styles/TextStyles.js
@@ -1,18 +1,24 @@
 export default {
-  '800': {
+  '900': {
     fontSize: '29px',
     fontWeight: 400,
     lineHeight: '32px',
     letterSpacing: '-0.2px',
   },
-  '700': {
-    fontSize: '28px',
+  '800': {
+    fontSize: '24px',
     fontWeight: 400,
     lineHeight: '28px',
     letterSpacing: '-0.2px',
   },
-  '600': {
+  '700': {
     fontSize: '20px',
+    fontWeight: 400,
+    lineHeight: '24px',
+    letterSpacing: '-0.05px',
+  },
+  '600': {
+    fontSize: '18px',
     fontWeight: 400,
     lineHeight: '24px',
     letterSpacing: '-0.05px',
@@ -20,7 +26,7 @@ export default {
   '500': {
     fontSize: '16px',
     fontWeight: 400,
-    lineHeight: '24px',
+    lineHeight: '22px',
     letterSpacing: '-0.05px',
   },
   '400': {


### PR DESCRIPTION
The sweet spot of headers are around 18 in our case, I added 18, and still maintain 20. I think having 16-18-20 all available makes a lot of sense.

This PR also sets lerna version: independent to true, which @Rowno pointed out to me 👍 