### PR TITLE
Fix always true checked prop of Switch

### DIFF
--- a/packages/evergreen-switch/src/components/Switch.js
+++ b/packages/evergreen-switch/src/components/Switch.js
@@ -50,6 +50,10 @@ CheckIcon.propTypes = {
   size: PropTypes.number
 }
 
+const isControlled = component => {
+  return {}.hasOwnProperty.call(component.props, 'checked')
+}
+
 export default class Switch extends PureComponent {
   static propTypes = {
     ...position.propTypes,
@@ -85,7 +89,7 @@ export default class Switch extends PureComponent {
   }
 
   handleChange = value => {
-    if (Object.prototype.hasOwnProperty.call(this.props, 'checked')) {
+    if (isControlled(this)) {
       this.props.onChange(value)
     } else {
       this.setState({
@@ -108,7 +112,7 @@ export default class Switch extends PureComponent {
       defaultChecked,
       ...props
     } = this.props
-    const checked = checkedProps || this.state.checked
+    const checked = isControlled(this) ? checkedProps : this.state.checked
     const appearanceStyle = SwitchAppearances[appearance]
 
     return (


### PR DESCRIPTION
If initial value of `checked` is `true`, Switch component doesn't switch to disabled state, because of: `const checked = checkedProps || this.state.checked`. So if `checkedProps` is `false` (next state), it uses `this.state.checked`, which is set to initial value of `true`. As a result, Switch gets stuck forever in enabled state.