### PR TITLE
Fix selected-menu selection when values are numbers

### DIFF
--- a/packages/evergreen-select-menu/package.json
+++ b/packages/evergreen-select-menu/package.json
@@ -7,6 +7,7 @@
   "author": "Segment",
   "license": "MIT",
   "dependencies": {
+    "arrify": "^1.0.1",
     "evergreen-buttons": "^2.19.6",
     "evergreen-layers": "^2.19.6",
     "evergreen-popover": "^2.19.6",

--- a/packages/evergreen-select-menu/src/components/SelectMenu.js
+++ b/packages/evergreen-select-menu/src/components/SelectMenu.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Popover from 'evergreen-popover'
+import arrify from 'arrify'
 import SelectMenuContent from './SelectMenuContent'
 import OptionShapePropType from './OptionShapePropType'
 import SelectedPropType from './SelectedPropType'
@@ -42,18 +43,6 @@ export default class SelectMenu extends PureComponent {
       ...props
     } = this.props
 
-    /**
-     * Normalize selected to an array
-     */
-    let arraySelected
-    if (typeof selected === 'string') {
-      arraySelected = [selected]
-    } else if (Array.isArray(selected)) {
-      arraySelected = selected
-    } else {
-      arraySelected = []
-    }
-
     return (
       <Popover
         minWidth={width}
@@ -70,7 +59,7 @@ export default class SelectMenu extends PureComponent {
               onSelect: item => {
                 this.props.onSelect(item)
               },
-              selected: arraySelected
+              selected: arrify(selected)
             }}
             close={close}
           />

--- a/packages/evergreen-select-menu/yarn.lock
+++ b/packages/evergreen-select-menu/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -9,6 +13,10 @@ asap@~2.0.3:
 bowser@^1.7.3:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.1.tgz#49785777e7302febadb1a5b71d9a646520ed310d"
+
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
 
 classnames@^2.2.5:
   version "2.2.5"
@@ -24,11 +32,98 @@ css-in-js-utils@^2.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+dom-helpers@^3.2.0, dom-helpers@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
+
+evergreen-buttons@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-buttons/-/evergreen-buttons-2.19.6.tgz#e93a3b58eaa7e0c9dba23c19d84822abe8f76759"
+  dependencies:
+    evergreen-colors "^2.19.6"
+    evergreen-icons "^2.19.6"
+    evergreen-shared-styles "^2.19.6"
+    evergreen-typography "^2.19.6"
+    ui-box "^0.5.4"
+
+evergreen-colors@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-colors/-/evergreen-colors-2.19.6.tgz#7d5a6eb08d6c20f0c8cb1ae40b3c97031daa1272"
+
+evergreen-icons@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-icons/-/evergreen-icons-2.19.6.tgz#fce2881d1a1e53639f976c1801a7785cf8ad30b5"
+  dependencies:
+    evergreen-colors "^2.19.6"
+    ui-box "^0.5.4"
+
+evergreen-layers@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-layers/-/evergreen-layers-2.19.6.tgz#699fdfc20a816a057e7b9363e23d0e1e40661e28"
+  dependencies:
+    evergreen-colors "^2.19.6"
+    ui-box "^0.5.4"
+
+evergreen-popover@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-popover/-/evergreen-popover-2.19.6.tgz#cb7f0c2ab8f7e5957fc52240840e354a7414e8ac"
+  dependencies:
+    evergreen-layers "^2.19.6"
+    evergreen-positioner "^2.19.6"
+    prop-types "^15.0.0"
+    ui-box "^0.5.4"
+
+evergreen-portal@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-portal/-/evergreen-portal-2.19.6.tgz#92a94f0e036194a33eb71296d35511d7e32ac3ea"
+  dependencies:
+    dom-helpers "^3.2.1"
+    ui-box "^0.5.4"
+
+evergreen-positioner@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-positioner/-/evergreen-positioner-2.19.6.tgz#b2bdc42af8feddbb222199366022a20c8b0cec56"
+  dependencies:
+    evergreen-portal "^2.19.6"
+    object-values "^1.0.0"
+    prop-types "^15.0.0"
+    react-transition-group "^2.2.1"
+    ui-box "^0.5.4"
+
+evergreen-shared-styles@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-shared-styles/-/evergreen-shared-styles-2.19.6.tgz#fc3f3222149c897c783c61a514870d72a193aaea"
+  dependencies:
+    evergreen-colors "^2.19.6"
+    evergreen-typography "^2.19.6"
+    ui-box "^0.5.4"
+
+evergreen-table@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-table/-/evergreen-table-2.19.6.tgz#d3791231e00c69c68fc5ac73908e232073fae7c7"
+  dependencies:
+    evergreen-colors "^2.19.6"
+    evergreen-icons "^2.19.6"
+    evergreen-layers "^2.19.6"
+    evergreen-shared-styles "^2.19.6"
+    evergreen-typography "^2.19.6"
+    prop-types "^15.0.0"
+    ui-box "^0.5.3"
+
+evergreen-typography@^2.19.6:
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/evergreen-typography/-/evergreen-typography-2.19.6.tgz#ade3522d49dcec16afb5a0af731f72560cd834b2"
+  dependencies:
+    evergreen-colors "^2.19.6"
+    lodash.mapvalues "^4.6.0"
+    prop-types "^15.0.0"
+    ui-box "^0.5.4"
 
 fbjs@^0.8.12, fbjs@^0.8.16:
   version "0.8.16"
@@ -86,6 +181,10 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+lodash.mapvalues@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
+
 loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -103,13 +202,17 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/object-values/-/object-values-1.0.0.tgz#72af839630119e5b98c3b02bb8c27e3237158105"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.7:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -122,6 +225,17 @@ react-tiny-virtual-list@^2.1.4:
   resolved "https://registry.yarnpkg.com/react-tiny-virtual-list/-/react-tiny-virtual-list-2.1.4.tgz#a574c4dfd8ccf462e3a335f665cffbfd08ce6e7d"
   dependencies:
     prop-types "^15.5.7"
+
+react-transition-group@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
+  dependencies:
+    chain-function "^1.0.0"
+    classnames "^2.2.5"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -141,7 +255,7 @@ ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
-ui-box@^0.5.4:
+ui-box@^0.5.3, ui-box@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-0.5.4.tgz#b8f0a4a638b541ef198d07872c785022f60b93a0"
   dependencies:
@@ -157,6 +271,12 @@ unique-random-array@1.0.0:
 unique-random@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-random/-/unique-random-1.0.0.tgz#ce3e224c8242cd33a0e77b0d7180d77e6b62d0c4"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.3"


### PR DESCRIPTION
If `value` was a `Number`, menu never had a selection, because it doesn't fall into first 2 conditions when normalizing arrays. It always goes with third condition, which makes the selection empty. Instead, battle tested `arrify` is used to fix this.