### PR TITLE
file-picker: fix onChange prop

### DIFF
--- a/packages/evergreen-file-picker/src/components/FilePicker.js
+++ b/packages/evergreen-file-picker/src/components/FilePicker.js
@@ -38,6 +38,7 @@ export default class FilePicker extends PureComponent {
       disabled,
       capture,
       height,
+      onChange, // Remove onChange from props
       ...props
     } = this.props
     const { files } = this.state
@@ -111,10 +112,10 @@ export default class FilePicker extends PureComponent {
 
   handleFileChange = e => {
     const { onChange } = this.props
-    const files = e.target.files
-
     // Firefox returns the same array instance each time for some reason
-    this.setState({ files: [...files] })
+    const files = [...e.target.files]
+
+    this.setState({ files })
 
     if (onChange) {
       onChange(files)

--- a/packages/evergreen-file-picker/stories/index.stories.js
+++ b/packages/evergreen-file-picker/stories/index.stories.js
@@ -10,7 +10,12 @@ storiesOf('file-picker', module).add('FilePicker', () => (
       document.body.style.height = '100vh'
     })()}
 
-    <FilePicker multiple width={250} marginBottom={32} />
+    <FilePicker
+      multiple
+      width={250}
+      marginBottom={32}
+      onChange={files => console.log(files)}
+    />
 
     <FilePicker multiple width={350} height={24} marginBottom={32} />
 

--- a/packages/evergreen-file-picker/test/index.js
+++ b/packages/evergreen-file-picker/test/index.js
@@ -3,6 +3,7 @@ import React from 'react'
 import test from 'ava'
 import render from 'react-test-renderer'
 import { shallow } from 'enzyme'
+import sinon from 'sinon'
 import { FilePicker, CLASS_PREFIX } from '../src'
 
 test('snapshot', t => {
@@ -54,6 +55,19 @@ test('passes through height', t => {
 test('passes through props', t => {
   const component = shallow(<FilePicker width={20} />)
   t.is(component.find(`.${CLASS_PREFIX}-root`).prop('width'), 20)
+})
+
+test('calls onChange', t => {
+  const onChange = sinon.spy()
+  const component = shallow(<FilePicker onChange={onChange} />)
+  const e = {
+    target: {
+      files: [{ name: 'data.json' }]
+    }
+  }
+  component.find(`.${CLASS_PREFIX}-file-input`).simulate('change', e)
+  t.true(onChange.calledOnce)
+  t.deepEqual(onChange.firstCall.args[0], e.target.files)
 })
 
 test('handles 1 file selected', t => {


### PR DESCRIPTION
The onChange prop was being applied to the root element as well which caused it to be called twice due to event propagation.