### PR TITLE
avatar: protect against repeated spaces

### DIFF
--- a/packages/evergreen-avatar/src/utils/getInitials.js
+++ b/packages/evergreen-avatar/src/utils/getInitials.js
@@ -2,8 +2,8 @@ export default function getInitials(name, fallback = '?') {
   if (!name || typeof name !== 'string') return fallback
   return name
     .replace(/\s+/, ' ')
-    .split(' ')
+    .split(' ') // Repeated spaces results in empty strings
     .slice(0, 2)
-    .map(v => v[0].toUpperCase())
+    .map(v => v && v[0].toUpperCase()) // Watch out for empty strings
     .join('')
 }


### PR DESCRIPTION
Currently names with repeated spaces cause errors.