### PR TITLE
Fix Select background-image gradient in safari

### DIFF
--- a/packages/evergreen-select/src/styles/SelectAppearances.js
+++ b/packages/evergreen-select/src/styles/SelectAppearances.js
@@ -31,7 +31,9 @@ const SelectAppearances = {
   default: {
     ...baseStyle,
     backgroundColor: 'white',
-    backgroundImage: `linear-gradient(to top, ${colors.neutral['5A']}, white)`,
+    backgroundImage: `linear-gradient(to top, ${colors.neutral['5A']}, ${
+      colors.white['5A']
+    })`,
     boxShadow: `inset 0 0 0 1px ${colors.neutral['20A']}, inset 0 -1px 1px 0 ${
       colors.neutral['10A']
     }`,


### PR DESCRIPTION
Fixes safari background gradient issue.
![image](https://user-images.githubusercontent.com/564463/35350813-ea372206-00f3-11e8-9319-159d92f1b1a7.png)
