### PR TITLE
Fix for scrollbar in tables. Table and TableHead components + docs added.

### DIFF
--- a/packages/evergreen-table/docs/examples/SearchTableHeaderCell.example
+++ b/packages/evergreen-table/docs/examples/SearchTableHeaderCell.example
@@ -1,4 +1,4 @@
-<TableRow>
+<TableHead>
   <SearchTableHeaderCell borderRight={null} onChange={(e) => console.log(e)} placeholder='Search by email...' />
   <SearchTableHeaderCell autoFocus borderRight={null} onChange={(e) => console.log(e)} placeholder='Autofocus...' />
-</TableRow>
+</TableHead>

--- a/packages/evergreen-table/docs/examples/Table.example
+++ b/packages/evergreen-table/docs/examples/Table.example
@@ -1,5 +1,5 @@
-<Pane border>
-  <TableRow>
+<Table>
+  <TableHead>
     <SearchTableHeaderCell />
     <TextTableHeaderCell isSortable sortOrder="descending">
       Last Activity
@@ -7,7 +7,7 @@
     <TextTableHeaderCell textAlign="right" borderRight={null}>
       ltv
     </TextTableHeaderCell>
-  </TableRow>
+  </TableHead>
   <TableBody height={240}>
     {profiles.map(profile => (
       <TableRow key={profile.id} isSelectable>
@@ -19,4 +19,4 @@
       </TableRow>
     ))}
   </TableBody>
-</Pane>
+</Table>

--- a/packages/evergreen-table/docs/examples/TableHead.example
+++ b/packages/evergreen-table/docs/examples/TableHead.example
@@ -1,0 +1,9 @@
+<TableHead>
+  <SearchTableHeaderCell />
+  <TextTableHeaderCell isSortable sortOrder="descending">
+    Last Activity
+  </TextTableHeaderCell>
+  <TextTableHeaderCell textAlign="right" borderRight={null}>
+    ltv
+  </TextTableHeaderCell>
+</TableHead>

--- a/packages/evergreen-table/docs/examples/TableHeaderCell.example
+++ b/packages/evergreen-table/docs/examples/TableHeaderCell.example
@@ -1,3 +1,3 @@
-<TableRow>
+<TableHead>
  <TableHeaderCell borderRight={null}>You almost never want to use this component directly.</TableHeaderCell>
-</TableRow>
+</TableHead>

--- a/packages/evergreen-table/docs/examples/TextTableHeaderCell.example
+++ b/packages/evergreen-table/docs/examples/TextTableHeaderCell.example
@@ -1,4 +1,4 @@
-<TableRow>
+<TableHead>
   <TextTableHeaderCell isSortable>Age</TextTableHeaderCell>
   <TextTableHeaderCell borderRight={null}>Email</TextTableHeaderCell>
-</TableRow>
+</TableHead>

--- a/packages/evergreen-table/docs/index.js
+++ b/packages/evergreen-table/docs/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Pane } from 'evergreen-layers'
 
 /* eslint-disable import/no-duplicates, import/no-webpack-loader-syntax */
+import Table from '../src/components/Table'
 import TableCell from '../src/components/TableCell'
 import TextTableCell from '../src/components/TextTableCell'
 import TableRow from '../src/components/TableRow'
@@ -9,8 +9,10 @@ import TableHeaderCell from '../src/components/TableHeaderCell'
 import TextTableHeaderCell from '../src/components/TextTableHeaderCell'
 import SearchTableHeaderCell from '../src/components/SearchTableHeaderCell'
 import TableBody from '../src/components/TableBody'
+import TableHead from '../src/components/TableHead'
 
 /* eslint-disable import/no-unresolved */
+import sourceTable from '!raw-loader!../src/components/Table'
 import sourceTableCell from '!raw-loader!../src/components/TableCell'
 import sourceTextTableCell from '!raw-loader!../src/components/TextTableCell'
 import sourceTableRow from '!raw-loader!../src/components/TableRow'
@@ -18,16 +20,16 @@ import sourceTableHeaderCell from '!raw-loader!../src/components/TableHeaderCell
 import sourceTextTableHeaderCell from '!raw-loader!../src/components/TextTableHeaderCell'
 import sourceSearchTableHeaderCell from '!raw-loader!../src/components/SearchTableHeaderCell'
 import sourceTableBody from '!raw-loader!../src/components/TableBody'
+import sourceTableHead from '!raw-loader!../src/components/TableHead'
 /* eslint-enable import/no-duplicates, import/no-webpack-loader-syntax import/no-unresolved */
 
 import packageJSON from '../package.json' // eslint-disable-line import/extensions
-
-import profiles from '../stories/profiles'
+import profiles from '../stories/profiles.json' // eslint-disable-line import/extensions
 
 /**
  * Code examples
  */
-import profilesTable from './examples/profiles-table.example'
+import exampleTable from './examples/Table.example'
 import exampleTableCell from './examples/TableCell.example'
 import exampleTextTableCell from './examples/TextTableCell.example'
 import exampleTableRow from './examples/TableRow.example'
@@ -35,6 +37,7 @@ import exampleTableHeaderCell from './examples/TableHeaderCell.example'
 import exampleTextTableHeaderCell from './examples/TextTableHeaderCell.example'
 import exampleSearchTableHeaderCell from './examples/SearchTableHeaderCell.example'
 import exampleTableBody from './examples/TableBody.example'
+import exampleTableHead from './examples/TableHead.example'
 
 const title = 'Table'
 const subTitle = 'A package exporting the building blocks of a table.'
@@ -70,30 +73,71 @@ const designGuidelines = (
 
 const appearanceOptions = null
 
-const examples = [
+const components = [
   {
-    title: 'Complete table example',
+    name: 'Table',
+    source: sourceTable,
     description: (
       <p>
-        This is a complete example of using a table in Evergreen. You want to
-        make sure to use <code>borderRight={`{null}`}</code> on the last table
-        cell of each table row.
+        This component is the container of all your table components. It is
+        simply a Pane with a border and is not an actual <code>table</code>{' '}
+        element.
       </p>
     ),
-    codeText: profilesTable,
-    scope: {
-      Pane,
-      TableBody,
-      TableRow,
-      TextTableHeaderCell,
-      TextTableCell,
-      SearchTableHeaderCell,
-      profiles
-    }
-  }
-]
-
-const components = [
+    examples: [
+      {
+        title: 'Complete Table example',
+        description: (
+          <p>
+            This is a complete example of using a table in Evergreen. You want
+            to make sure to use <code>borderRight={`{null}`}</code> on the last
+            table cell of each table row.
+          </p>
+        ),
+        codeText: exampleTable,
+        scope: {
+          Table,
+          TableBody,
+          TableHead,
+          TableRow,
+          TextTableHeaderCell,
+          TextTableCell,
+          SearchTableHeaderCell,
+          profiles
+        }
+      }
+    ]
+  },
+  {
+    name: 'TableHead',
+    source: sourceTableHead,
+    description: (
+      <div>
+        <p>
+          This component is used to put your table header cells in. You
+          don&apos;t need to add a table row inside.
+        </p>
+        <p>
+          This component includes a utility that makes sure the scrollbar is
+          accounted for when enabled in the operating system. This is the case
+          for all Windows and Linux systems, as well as Mac&nbsp;OS systems that
+          have scrollbars enabled.
+        </p>
+      </div>
+    ),
+    examples: [
+      {
+        title: 'Basic TableHead example',
+        codeText: exampleTableHead,
+        scope: {
+          TableHead,
+          TextTableHeaderCell,
+          SearchTableHeaderCell,
+          profiles
+        }
+      }
+    ]
+  },
   {
     name: 'TableBody',
     source: sourceTableBody,
@@ -245,6 +289,5 @@ export default {
   subTitle,
   designGuidelines,
   appearanceOptions,
-  components,
-  examples
+  components
 }

--- a/packages/evergreen-table/package.json
+++ b/packages/evergreen-table/package.json
@@ -26,6 +26,7 @@
     "evergreen-shared-styles": "^2.19.7",
     "evergreen-typography": "^2.19.7",
     "prop-types": "^15.0.0",
+    "react-scrollbar-size": "^2.0.2",
     "ui-box": "^0.5.3"
   },
   "peerDependencies": {

--- a/packages/evergreen-table/src/components/ScrollbarSize.js
+++ b/packages/evergreen-table/src/components/ScrollbarSize.js
@@ -1,0 +1,63 @@
+/* eslint-disable react/no-unused-state */
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+
+export default class ScrollbarSize extends PureComponent {
+  static propTypes = {
+    /**
+     * Returns the size of the scrollbar by creating a hidden fixed div.
+     */
+    handleScrollbarSize: PropTypes.func
+  }
+
+  static defaultProps = {
+    handleScrollbarSize: () => {}
+  }
+
+  state = {
+    innerWidth: null,
+    outerWidth: null
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextState.innerWidth && nextState.outerWidth) {
+      this.props.handleScrollbarSize(
+        nextState.outerWidth - nextState.innerWidth
+      )
+    }
+  }
+
+  handleRef = ref => {
+    if (ref === null) return
+    const outerWidth = ref.getBoundingClientRect().width
+    this.setState({
+      outerWidth
+    })
+  }
+
+  handleInnerRef = ref => {
+    if (ref === null) return
+    const innerWidth = ref.getBoundingClientRect().width
+    this.setState({
+      innerWidth
+    })
+  }
+
+  render() {
+    return (
+      <div
+        ref={this.handleRef}
+        aria-hidden
+        style={{
+          position: 'fixed',
+          top: -500,
+          left: -500,
+          width: 100,
+          overflowY: 'scroll'
+        }}
+      >
+        <div ref={this.handleInnerRef} />
+      </div>
+    )
+  }
+}

--- a/packages/evergreen-table/src/components/Table.js
+++ b/packages/evergreen-table/src/components/Table.js
@@ -1,0 +1,20 @@
+import React, { PureComponent } from 'react'
+import { Pane } from 'evergreen-layers'
+
+export default class Table extends PureComponent {
+  static propTypes = {
+    /**
+     * Composes the Pane component as the base.
+     */
+    ...Pane.propTypes
+  }
+
+  static defaultProps = {
+    border: true
+  }
+
+  render() {
+    const { children, ...props } = this.props
+    return <Pane {...props}>{children}</Pane>
+  }
+}

--- a/packages/evergreen-table/src/components/TableHead.js
+++ b/packages/evergreen-table/src/components/TableHead.js
@@ -1,0 +1,42 @@
+/* eslint-disable react/jsx-handler-names */
+import React, { PureComponent } from 'react'
+import { Pane } from 'evergreen-layers'
+import ScrollbarSize from './ScrollbarSize'
+
+export default class TableHead extends PureComponent {
+  static propTypes = {
+    /**
+     * Composes the Pane component as the base.
+     */
+    ...Pane.propTypes
+  }
+
+  state = {
+    scrollbarWidth: 0
+  }
+
+  static defaultProps = {
+    boxSizing: 'border-box',
+    display: 'flex',
+    appearance: 'tint2',
+    borderBottom: 'extraMuted'
+  }
+
+  handleScrollbarSize = width => {
+    this.setState({
+      scrollbarWidth: width
+    })
+  }
+
+  render() {
+    const { children, ...props } = this.props
+    const { scrollbarWidth } = this.state
+
+    return (
+      <Pane paddingRight={scrollbarWidth} {...props}>
+        {children}{' '}
+        <ScrollbarSize handleScrollbarSize={this.handleScrollbarSize} />
+      </Pane>
+    )
+  }
+}

--- a/packages/evergreen-table/src/components/TableHead.js
+++ b/packages/evergreen-table/src/components/TableHead.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-handler-names */
 import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
 import { Pane } from 'evergreen-layers'
 import ScrollbarSize from './ScrollbarSize'
 
@@ -8,7 +9,17 @@ export default class TableHead extends PureComponent {
     /**
      * Composes the Pane component as the base.
      */
-    ...Pane.propTypes
+    ...Pane.propTypes,
+
+    /**
+     * This should always be true if you are using TableHead together with a TableBody.
+     * Because TableBody has `overflowY: scroll` by default.
+     */
+    accountForScrollbar: PropTypes.bool
+  }
+
+  static defaultProps = {
+    accountForScrollbar: true
   }
 
   state = {
@@ -29,13 +40,15 @@ export default class TableHead extends PureComponent {
   }
 
   render() {
-    const { children, ...props } = this.props
+    const { children, accountForScrollbar, ...props } = this.props
     const { scrollbarWidth } = this.state
 
     return (
       <Pane paddingRight={scrollbarWidth} {...props}>
         {children}{' '}
-        <ScrollbarSize handleScrollbarSize={this.handleScrollbarSize} />
+        {accountForScrollbar && (
+          <ScrollbarSize handleScrollbarSize={this.handleScrollbarSize} />
+        )}
       </Pane>
     )
   }

--- a/packages/evergreen-table/src/components/TableHeaderCell.js
+++ b/packages/evergreen-table/src/components/TableHeaderCell.js
@@ -10,9 +10,8 @@ export default class TableHeaderCell extends PureComponent {
   }
 
   static defaultProps = {
-    height: 28,
-    appearance: 'tint2',
-    overflow: 'visible'
+    overflow: 'visible',
+    borderBottom: null
   }
 
   render() {

--- a/packages/evergreen-table/src/index.js
+++ b/packages/evergreen-table/src/index.js
@@ -1,17 +1,29 @@
-import TableCell from './components/TableCell'
-import TextTableCell from './components/TextTableCell'
-import TableRow from './components/TableRow'
+import Table from './components/Table'
+
+/**
+ * Table head and contents
+ */
+import TableHead from './components/TableHead'
 import TableHeaderCell from './components/TableHeaderCell'
 import TextTableHeaderCell from './components/TextTableHeaderCell'
 import SearchTableHeaderCell from './components/SearchTableHeaderCell'
+
+/**
+ * Table body and contents
+ */
 import TableBody from './components/TableBody'
+import TableRow from './components/TableRow'
+import TableCell from './components/TableCell'
+import TextTableCell from './components/TextTableCell'
 
 export {
-  TableCell,
-  TextTableCell,
-  TableRow,
+  Table,
+  TableHead,
   TableHeaderCell,
   TextTableHeaderCell,
   SearchTableHeaderCell,
-  TableBody
+  TableBody,
+  TableRow,
+  TableCell,
+  TextTableCell
 }

--- a/packages/evergreen-table/stories/index.stories.js
+++ b/packages/evergreen-table/stories/index.stories.js
@@ -1,15 +1,16 @@
 import { storiesOf } from '@storybook/react' // eslint-disable-line import/no-extraneous-dependencies
 import React from 'react'
 import Box from 'ui-box'
-import { Pane } from 'evergreen-layers'
 import {
-  TableCell,
-  TextTableCell,
-  TableRow,
+  Table,
+  TableHead,
   TableHeaderCell,
   TextTableHeaderCell,
   SearchTableHeaderCell,
-  TableBody
+  TableBody,
+  TableRow,
+  TableCell,
+  TextTableCell
 } from '../src/'
 import profiles from './profiles'
 
@@ -20,8 +21,8 @@ storiesOf('table', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <Pane border>
-        <TableRow>
+      <Table>
+        <TableHead>
           <SearchTableHeaderCell />
           <TextTableHeaderCell isSortable sortOrder="descending">
             Last Activity
@@ -29,7 +30,7 @@ storiesOf('table', module)
           <TextTableHeaderCell textAlign="right" borderRight={null}>
             ltv
           </TextTableHeaderCell>
-        </TableRow>
+        </TableHead>
         <TableBody height={640}>
           {profiles.map(profile => (
             <TableRow key={profile.id} isSelectable>
@@ -41,7 +42,7 @@ storiesOf('table', module)
             </TableRow>
           ))}
         </TableBody>
-      </Pane>
+      </Table>
     </Box>
   ))
   .add('TableCell', () => (
@@ -60,6 +61,23 @@ storiesOf('table', module)
         document.body.style.height = '100vh'
       })()}
       <TextTableCell>TextTableCell</TextTableCell>
+    </Box>
+  ))
+  .add('TableHead', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <TableHead>
+        <SearchTableHeaderCell />
+        <TextTableHeaderCell isSortable sortOrder="descending">
+          Last Activity
+        </TextTableHeaderCell>
+        <TextTableHeaderCell textAlign="right" borderRight={null}>
+          ltv
+        </TextTableHeaderCell>
+      </TableHead>
     </Box>
   ))
   .add('TableRow', () => (

--- a/packages/evergreen-table/yarn.lock
+++ b/packages/evergreen-table/yarn.lock
@@ -6,6 +6,13 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
+babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 bowser@^1.7.3:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.1.tgz#49785777e7302febadb1a5b71d9a646520ed310d"
@@ -18,6 +25,10 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+core-js@^2.4.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
 css-in-js-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
@@ -29,6 +40,41 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
+
+evergreen-colors@^2.19.7:
+  version "2.19.7"
+  resolved "https://registry.yarnpkg.com/evergreen-colors/-/evergreen-colors-2.19.7.tgz#694c4d19bb92472cdd392347ae2030f6f1541ced"
+
+evergreen-icons@^2.19.7:
+  version "2.19.7"
+  resolved "https://registry.yarnpkg.com/evergreen-icons/-/evergreen-icons-2.19.7.tgz#2df29b089ab779aa124dcba753f2c601bcd79ff6"
+  dependencies:
+    evergreen-colors "^2.19.7"
+    ui-box "^0.5.4"
+
+evergreen-layers@^2.19.7:
+  version "2.19.7"
+  resolved "https://registry.yarnpkg.com/evergreen-layers/-/evergreen-layers-2.19.7.tgz#5c4eb448144cb75d248e76beb15cc6a2f2f928f2"
+  dependencies:
+    evergreen-colors "^2.19.7"
+    ui-box "^0.5.4"
+
+evergreen-shared-styles@^2.19.7:
+  version "2.19.7"
+  resolved "https://registry.yarnpkg.com/evergreen-shared-styles/-/evergreen-shared-styles-2.19.7.tgz#d83fdeea99073071d85986168cd4c6022eecae8e"
+  dependencies:
+    evergreen-colors "^2.19.7"
+    evergreen-typography "^2.19.7"
+    ui-box "^0.5.4"
+
+evergreen-typography@^2.19.7:
+  version "2.19.7"
+  resolved "https://registry.yarnpkg.com/evergreen-typography/-/evergreen-typography-2.19.7.tgz#b253520aab9e40925a9d6aed068564fa8e1e26fb"
+  dependencies:
+    evergreen-colors "^2.19.7"
+    lodash.mapvalues "^4.6.0"
+    prop-types "^15.0.0"
+    ui-box "^0.5.4"
 
 fbjs@^0.8.12, fbjs@^0.8.16:
   version "0.8.16"
@@ -82,6 +128,10 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+lodash.mapvalues@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
+
 loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -105,13 +155,34 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.10:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+react-event-listener@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.3.tgz#a8b492596ad601865314fcc2c18cb87b6ce3876e"
+  dependencies:
+    babel-runtime "^6.26.0"
+    fbjs "^0.8.16"
+    prop-types "^15.6.0"
+    warning "^3.0.0"
+
+react-scrollbar-size@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-scrollbar-size/-/react-scrollbar-size-2.0.2.tgz#237dd091fa39dec8e3a6f720807787703c5ebf9e"
+  dependencies:
+    babel-runtime "^6.23.0"
+    prop-types "^15.5.10"
+    react-event-listener "^0.5.0"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -125,12 +196,18 @@ ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
-ui-box@^0.5.3:
+ui-box@^0.5.3, ui-box@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-0.5.4.tgz#b8f0a4a638b541ef198d07872c785022f60b93a0"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.22"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.3"


### PR DESCRIPTION
This PR solves #105  without using native tables. I tried using native tables among a couple of different ways to solve the scrollbar issue. However, native tables lack an easy way to make TableBody scrollable. We ended up writing a utility to compensate for the scrollbar in the newly added `TableHead` component.

Adds the following components and documentation:

- `Table`
- `TableHead`

## Code example

Note the usage of `Table` and `TableHead` here.

```jsx
<Table>
  <TableHead>
    <SearchTableHeaderCell />
    <TextTableHeaderCell isSortable sortOrder="descending">
      Last Activity
    </TextTableHeaderCell>
    <TextTableHeaderCell textAlign="right" borderRight={null}>
      ltv
    </TextTableHeaderCell>
  </TableHead>
  <TableBody height={240}>
    {profiles.map(profile => (
      <TableRow key={profile.id} isSelectable>
        <TextTableCell>{profile.name}</TextTableCell>
        <TextTableCell>{profile.lastActivity}</TextTableCell>
        <TextTableCell isNumber borderRight={null}>
          {profile.ltv}
        </TextTableCell>
      </TableRow>
    ))}
  </TableBody>
</Table>
```

## Table

This component is the container of all your table components. It is simply a Pane with a border and is not an actual table element.

## TableHead

This component is used to put your table header cells in. You don't need to add a table row inside.

This component includes a utility that makes sure the scrollbar is accounted for when enabled in the operating system. This is the case for all Windows and Linux systems, as well as Mac OS systems that have scrollbars enabled.

