### PR TITLE
Changing Button CSS proptype order

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -138,8 +138,8 @@ export default class Button extends PureComponent {
         margin={0} // Removes weird margins in Safari
         {...textStyle}
         css={{
-          ...appearanceStyle
-          ...css,
+          ...appearanceStyle,
+          ...css
         }}
         height={height}
         lineHeight={`${height}px`}

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -45,7 +45,12 @@ export default class Button extends PureComponent {
     /**
      * The aim of the right icon. Useful to aim a triangle down.
      */
-    iconAfterAim: PropTypes.oneOf(Object.keys(IconAim))
+    iconAfterAim: PropTypes.oneOf(Object.keys(IconAim)),
+
+    /**
+     * A JavaScript object to override css styling
+     */
+    css: PropTypes.object
   }
 
   static defaultProps = {
@@ -133,8 +138,8 @@ export default class Button extends PureComponent {
         margin={0} // Removes weird margins in Safari
         {...textStyle}
         css={{
-          ...css,
           ...appearanceStyle
+          ...css,
         }}
         height={height}
         lineHeight={`${height}px`}


### PR DESCRIPTION
> Could not override the buttons css on evergreen, (not sure if it's the desired behaviour).
### This PR
- In Button component, changes css proptype order so it can override the props being set up by `appearanceStyle`