### PR TITLE
Improved dialog and docs + button loading

### DIFF
--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -1,18 +1,15 @@
 const path = require('path')
 const webpack = require('webpack') // eslint-disable-line import/no-extraneous-dependencies
-const globby = require('globby')
 
 const componentTemplate = path.resolve(`src/templates/component.js`)
-const componentNames = globby
-  .sync(`${__dirname}/../src/*/`, { nodir: false })
-  .map(pathname => path.basename(pathname))
+const componentNames = ['buttons', 'dialog', 'table']
 
 // Implement the Gatsby API “createPages”. This is called once the
 // data layer is bootstrapped to let plugins create pages from data.
 exports.createPages = ({ boundActionCreators }) => {
   const { createPage } = boundActionCreators
 
-  for (const componentName of componentNames) {
+  componentNames.forEach(componentName => {
     const componentPath = `/components/${componentName}`
 
     createPage({
@@ -27,7 +24,7 @@ exports.createPages = ({ boundActionCreators }) => {
         name: componentName
       }
     })
-  }
+  })
 }
 
 exports.modifyWebpackConfig = ({ config }) => {

--- a/docs/src/components/ComponentReadme.js
+++ b/docs/src/components/ComponentReadme.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import ComponentBlock from './ComponentBlock'
@@ -32,19 +33,17 @@ export default class ComponentReadme extends PureComponent {
       <article className="ComponentReadme" {...props}>
         <div className="Container ComponentReadme-inner">
           <header className="ComponentReadme-header">
-            <h1 className="ComponentReadme-title">{title}</h1>
-            <p className="ComponentReadme-subtitle">{subTitle}</p>
-            <dl>
-              <dt>Links</dt>
-              <dd>
-                <a
-                  href={`https://github.com/segmentio/evergreen/tree/master/src/${name}`}
-                  target="_blank"
-                >
-                  GitHub
-                </a>
-              </dd>
-            </dl>
+            <h1 className="ComponentReadme-title">{title} </h1>
+            <p className="ComponentReadme-subtitle">
+              {subTitle}{' '}
+              <a
+                className="ComponentReadme-githubLink"
+                href={`https://github.com/segmentio/evergreen/tree/master/src/${name}`}
+                target="_blank"
+              >
+                View on GitHub
+              </a>.
+            </p>
           </header>
           <div>
             {designGuidelines && (
@@ -99,8 +98,8 @@ export default class ComponentReadme extends PureComponent {
                 <div className="Content">
                   <h2 id="component-examples">Component Examples</h2>
                   <p>
-                    The <code>{name}</code> package exports the following
-                    documented components:
+                    The following components are exported by Evergreen for this
+                    UI pattern:
                   </p>
                   <ul>
                     {components.map(component => {

--- a/docs/src/components/ComponentReadme.js
+++ b/docs/src/components/ComponentReadme.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import ComponentBlock from './ComponentBlock'

--- a/docs/src/components/ComponentsSidebar.js
+++ b/docs/src/components/ComponentsSidebar.js
@@ -19,6 +19,10 @@ export default class ComponentsSidebar extends PureComponent {
             to: '/components/buttons'
           },
           {
+            label: 'Dialog',
+            to: '/components/dialog'
+          },
+          {
             label: 'Table',
             to: '/components/table'
           }

--- a/docs/src/components/prop-types-table/index.js
+++ b/docs/src/components/prop-types-table/index.js
@@ -31,23 +31,23 @@ export default class PropTypesTable extends PureComponent {
   render() {
     const { componentDocs } = this.state
     const propTypes = Object.keys(componentDocs.props)
-    console.log('componentDocs', componentDocs)
     return (
       <div>
         <div className="Content">
           <h3>Props</h3>
-          {componentDocs.composes.length > 0 && (
-            <div className="PropTypesTable-composes">
-              <p>
-                <strong>This component composes </strong>
-                {componentDocs.composes.map(filePath => (
-                  <code key={filePath}>
-                    {filePath.substring(filePath.indexOf('/') + 1)}
-                  </code>
-                ))}
-              </p>
-            </div>
-          )}
+          {componentDocs.composes &&
+            componentDocs.composes.length > 0 && (
+              <div className="PropTypesTable-composes">
+                <p>
+                  <strong>This component composes </strong>
+                  {componentDocs.composes.map(filePath => (
+                    <code key={filePath}>
+                      {filePath.substring(filePath.indexOf('/') + 1)}
+                    </code>
+                  ))}
+                </p>
+              </div>
+            )}
         </div>
 
         {propTypes.map(propName => {

--- a/docs/src/css/appearance-option.css
+++ b/docs/src/css/appearance-option.css
@@ -1,6 +1,6 @@
 .AppearanceOption {
   background-color: white;
-  box-shadow: inset 0 0 0 1px var(--color-border-muted);
+  box-shadow: inset 0 0 0 1px var(--color-border-default);
   padding: 16px;
   margin-bottom: 16px;
 }

--- a/docs/src/css/component-readme.css
+++ b/docs/src/css/component-readme.css
@@ -23,32 +23,15 @@
 
 .ComponentReadme-header {
   border-bottom: 1px solid var(--neutral-20A);
-  /* padding-bottom: 16px; */
+  padding-bottom: 16px;
   margin-bottom: 24px;
+}
 
-  & dl {
-    font-size: 14px;
-    margin-top: 16px;
-    margin-bottom: px;
+.ComponentReadme-githubLink {
+  color: var(--blue-500);
 
-    & dt {
-      color: var(--neutral-200);
-      width: 72px;
-      display: inline-block;
-    }
-
-    & dd {
-      width: calc(100% - 72px);
-      margin-left: 0;
-      margin-bottom: 16px;
-      display: inline-block;
-
-      & a {
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-    }
+  &:hover {
+    text-decoration: underline;
   }
 }
 

--- a/docs/src/css/component-readme.css
+++ b/docs/src/css/component-readme.css
@@ -33,6 +33,10 @@
   &:hover {
     text-decoration: underline;
   }
+
+  &:focus {
+    outline: 1px solid var(--blue-500);
+  }
 }
 
 /**

--- a/docs/src/css/content.css
+++ b/docs/src/css/content.css
@@ -67,14 +67,34 @@
     }
   }
 
+  & p {
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+
+  & li {
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+  }
+
   & p,
   & li {
     font-size: 14px;
     font-weight: 400;
     line-height: 22px;
     letter-spacing: -0.05px;
+  }
+
+  & blockquote {
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 22px;
+    letter-spacing: -0.05px;
     margin-top: 1em;
     margin-bottom: 1em;
+    border-left: 2px solid var(--green-100A);
+    padding: 12px;
+    background-color: var(--green-7A);
   }
 
   & strong {

--- a/docs/src/css/content.css
+++ b/docs/src/css/content.css
@@ -14,8 +14,13 @@
 
   & a {
     color: var(--blue-500);
+
     &:hover {
       text-decoration: underline;
+    }
+
+    &:focus {
+      outline: 1px solid var(--blue-500);
     }
   }
 

--- a/docs/src/css/main-layout.css
+++ b/docs/src/css/main-layout.css
@@ -9,7 +9,6 @@
 .MainLayout-main {
   flex: 1;
   display: flex;
-  /* background-color: var(--neutral-3); */
 
   @media (--range-palm), (--range-hand), (--range-lap) {
     flex-direction: column;

--- a/docs/src/css/main-layout.css
+++ b/docs/src/css/main-layout.css
@@ -9,7 +9,7 @@
 .MainLayout-main {
   flex: 1;
   display: flex;
-  background-color: var(--neutral-3);
+  /* background-color: var(--neutral-3); */
 
   @media (--range-palm), (--range-hand), (--range-lap) {
     flex-direction: column;

--- a/docs/src/css/nav-group.css
+++ b/docs/src/css/nav-group.css
@@ -12,6 +12,10 @@
       background-color: var(--neutral-5A);
     }
 
+    &:focus {
+      box-shadow: inset 0 0 0 1px var(--blue-100A);
+    }
+
     &:active,
     &.is-active {
       background-color: var(--blue-10A);

--- a/docs/src/css/top-bar.css
+++ b/docs/src/css/top-bar.css
@@ -46,16 +46,20 @@
   display: inline-flex;
   align-items: center;
   letter-spacing: 0.4px;
+  border-radius: 3px;
 
   &:hover {
     background-color: var(--neutral-7A);
-    border-radius: 3px;
   }
 
   &:active,
   &.is-active {
     background-color: var(--blue-7A);
     color: var(--blue-500);
+  }
+
+  &:focus {
+    box-shadow: inset 0 0 0 1px var(--blue-100A);
   }
 
   & .icon-holder {

--- a/docs/src/utils/getComponent.js
+++ b/docs/src/utils/getComponent.js
@@ -24,13 +24,14 @@ import buttonsDocs from '../../../src/buttons/docs'
 import tableDocs from '../../../src/table/docs/'
 // import sideSheetDocs from '../../src/side-sheet/docs/'
 // import radioDocs from '../../src/radio/docs/'
-// import dialogDocs from '../../src/dialog/docs/'
+import dialogDocs from '../../../src/dialog/docs/'
 // import cornerDialogDocs from '../../src/corner-dialog/docs/'
 // import alertDocs from '../../src/alert/docs/'
 
 const map = {
   buttons: buttonsDocs,
-  table: tableDocs
+  table: tableDocs,
+  dialog: dialogDocs
 }
 
 export default function getComponent(name) {

--- a/src/buttons/docs/LoadingManager.js
+++ b/src/buttons/docs/LoadingManager.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class LoadingManager extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.func
+  }
+
+  state = {
+    isLoading: false
+  }
+
+  render() {
+    return this.props.children({
+      isLoading: this.state.isLoading,
+      setLoading: () => {
+        this.setState({
+          isLoading: true
+        })
+
+        window.setTimeout(() => {
+          this.setState({
+            isLoading: false
+          })
+        }, 2000)
+      }
+    })
+  }
+}

--- a/src/buttons/docs/LoadingManager.js
+++ b/src/buttons/docs/LoadingManager.js
@@ -10,20 +10,22 @@ export default class LoadingManager extends React.PureComponent {
     isLoading: false
   }
 
+  setLoading = () => {
+    this.setState({
+      isLoading: true
+    })
+
+    window.setTimeout(() => {
+      this.setState({
+        isLoading: false
+      })
+    }, 2000)
+  }
+
   render() {
     return this.props.children({
       isLoading: this.state.isLoading,
-      setLoading: () => {
-        this.setState({
-          isLoading: true
-        })
-
-        window.setTimeout(() => {
-          this.setState({
-            isLoading: false
-          })
-        }, 2000)
-      }
+      setLoading: this.setLoading
     })
   }
 }

--- a/src/buttons/docs/examples/loading.example
+++ b/src/buttons/docs/examples/loading.example
@@ -1,0 +1,13 @@
+<LoadingManager>
+  {({ isLoading, setLoading }) => {
+    return (
+      <Button
+        marginRight={16}
+        isLoading={isLoading}
+        onClick={setLoading}
+      >
+        {isLoading ? 'Loading...' : 'Click to Load'}
+      </Button>
+    )
+  }}
+</LoadingManager>

--- a/src/buttons/docs/index.js
+++ b/src/buttons/docs/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import LoadingManager from './LoadingManager'
 import { BackButton, IconButton, Button } from '..'
 /* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
 import sourceBackButton from '!raw-loader!../src/BackButton'
@@ -10,6 +11,7 @@ import sourceButton from '!raw-loader!../src/Button'
  * Code examples
  */
 import basicExample from './examples/basic.example'
+import loadingExample from './examples/loading.example'
 import basicWithIconsExample from './examples/basic-with-icons.example'
 import backButtonExample from './examples/back-button.example'
 import triangleExample from './examples/triangle.example'
@@ -17,7 +19,7 @@ import arrowExample from './examples/arrow.example'
 import iconButtonBasicExample from './examples/icon-button-basic.example'
 
 const title = 'Buttons'
-const subTitle = 'A package exporting multiple types of buttons.'
+const subTitle = 'A set of buttons with multiple appearances.'
 
 const designGuidelines = (
   <div>
@@ -130,12 +132,18 @@ const components = [
         scope: { Button }
       },
       {
+        title: 'Loading button',
+        codeText: loadingExample,
+        scope: { Button, LoadingManager }
+      },
+      {
         title: 'Buttons with an icon',
         codeText: basicWithIconsExample,
         scope: { Button }
       }
     ]
   },
+
   {
     name: 'BackButton',
     source: sourceBackButton,

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -7,6 +7,7 @@ import {
   getTextStyleForControlHeight,
   getIconSizeForControlHeight
 } from '../../shared-styles'
+import { Spinner } from '../../spinner'
 import ButtonAppearances from './styles/ButtonAppearances'
 
 export default class Button extends PureComponent {
@@ -20,6 +21,12 @@ export default class Button extends PureComponent {
      * The appearance of the button.
      */
     appearance: PropTypes.oneOf(Object.keys(ButtonAppearances)).isRequired,
+
+    /**
+     * When true, show a loading spinner before the children.
+     * This also disables the button.
+     */
+    isLoading: PropTypes.bool,
 
     /**
      * Forcefully set the active state of a button.
@@ -46,6 +53,12 @@ export default class Button extends PureComponent {
      * The aim of the right icon. Useful to aim a triangle down.
      */
     iconAfterAim: PropTypes.oneOf(Object.keys(IconAim)),
+
+    /**
+     * When true, the button is disabled.
+     * isLoading also sets the button to disabled.
+     */
+    disabled: PropTypes.bool,
 
     /**
      * A JavaScript object to override css styling
@@ -77,7 +90,9 @@ export default class Button extends PureComponent {
       height,
       isActive,
       children,
+      disabled,
       appearance,
+      isLoading,
 
       // Paddings
       paddingRight,
@@ -145,7 +160,15 @@ export default class Button extends PureComponent {
         lineHeight={`${height}px`}
         {...(isActive ? { 'data-active': true } : {})}
         {...props}
+        disabled={disabled || isLoading}
       >
+        {isLoading && (
+          <Spinner
+            marginLeft={-Math.round(height / 8)}
+            marginRight={Math.round(height / 4)}
+            size={Math.round(height / 2)}
+          />
+        )}
         {iconBefore || null}
         <span>{children}</span>
         {iconAfter || null}

--- a/src/buttons/stories/index.stories.js
+++ b/src/buttons/stories/index.stories.js
@@ -154,6 +154,56 @@ buttonsStory.add('Button + icons', () => (
   </Box>
 ))
 
+class LoadingManager extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.func
+  }
+
+  state = {
+    isLoading: false
+  }
+
+  render() {
+    return this.props.children({
+      isLoading: this.state.isLoading,
+      setLoading: () => {
+        this.setState({
+          isLoading: true
+        })
+
+        window.setTimeout(() => {
+          this.setState({
+            isLoading: false
+          })
+        }, 2000)
+      }
+    })
+  }
+}
+
+buttonsStory.add('Button isLoading', () => (
+  <Box padding={80}>
+    {Object.keys(ButtonAppearances).map(appearance => {
+      return (
+        <LoadingManager key={appearance}>
+          {({ isLoading, setLoading }) => {
+            return (
+              <Button
+                marginRight={16}
+                appearance={appearance}
+                isLoading={isLoading}
+                onClick={setLoading}
+              >
+                {isLoading ? 'Loading...' : 'Click to Load'}
+              </Button>
+            )
+          }}
+        </LoadingManager>
+      )
+    })}
+  </Box>
+))
+
 function IconButtonIcon({ appearance, height, iconKey }) {
   const iconProps = {
     appearance,

--- a/src/buttons/stories/index.stories.js
+++ b/src/buttons/stories/index.stories.js
@@ -10,6 +10,7 @@ import {
 } from '../../buttons'
 import { Heading } from '../../typography'
 import { IconMap } from '../../icons'
+import LoadingManager from '../docs/LoadingManager'
 
 const baseStyles = {
   margin: 16
@@ -153,33 +154,6 @@ buttonsStory.add('Button + icons', () => (
     ))}
   </Box>
 ))
-
-class LoadingManager extends React.PureComponent {
-  static propTypes = {
-    children: PropTypes.func
-  }
-
-  state = {
-    isLoading: false
-  }
-
-  render() {
-    return this.props.children({
-      isLoading: this.state.isLoading,
-      setLoading: () => {
-        this.setState({
-          isLoading: true
-        })
-
-        window.setTimeout(() => {
-          this.setState({
-            isLoading: false
-          })
-        }, 2000)
-      }
-    })
-  }
-}
 
 buttonsStory.add('Button isLoading', () => (
   <Box padding={80}>

--- a/src/dialog/docs/DialogManager.js
+++ b/src/dialog/docs/DialogManager.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class DialogManager extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.func
+  }
+
+  state = {
+    isShown: false,
+    isLoading: false
+  }
+
+  render() {
+    return this.props.children({
+      isShown: this.state.isShown,
+      isLoading: this.state.isLoading,
+      confirmLoading: () => {
+        this.setState({
+          isLoading: true
+        })
+
+        window.setTimeout(() => {
+          this.setState({
+            isShown: false
+          })
+        }, 2000)
+      },
+      show: () =>
+        this.setState({
+          isShown: true
+        }),
+      hide: () =>
+        this.setState({
+          isShown: false,
+          isLoading: false
+        })
+    })
+  }
+}

--- a/src/dialog/docs/examples/hide-header.example
+++ b/src/dialog/docs/examples/hide-header.example
@@ -1,0 +1,19 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog isShown={isShown} hideHeader onExited={hide}>
+        {({ close }) => (
+          <Box>
+            <Paragraph>
+              Manage your own header, buttons and interactions.
+            </Paragraph>
+            <Button marginTop={16} onClick={close}>
+              Self Managed Close
+            </Button>
+          </Box>
+        )}
+      </Dialog>
+      <Button onClick={show}>Show Dialog without Header</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/hide-header.example
+++ b/src/dialog/docs/examples/hide-header.example
@@ -1,7 +1,12 @@
 <DialogManager>
   {({ isShown, show, hide }) => (
     <Box>
-      <Dialog isShown={isShown} hideHeader onExited={hide}>
+      <Dialog
+        isShown={isShown}
+        hasHeader={false}
+        hasFooter={false}
+        onCloseComplete={hide}
+      >
         {({ close }) => (
           <Box>
             <Paragraph>

--- a/src/dialog/docs/examples/internal-scrolling.example
+++ b/src/dialog/docs/examples/internal-scrolling.example
@@ -1,0 +1,20 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with Internal Scrolling"
+        onExited={hide}
+        primaryButton={{
+          onClick: close => {
+            close()
+          },
+          children: 'Primary Button',
+        }}
+      >
+        <Box height={1200} width="100%" backgroundColor="#ddd" />
+      </Dialog>
+      <Button onClick={show}>Show Dialog with Internal Scrolling</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/internal-scrolling.example
+++ b/src/dialog/docs/examples/internal-scrolling.example
@@ -4,13 +4,7 @@
       <Dialog
         isShown={isShown}
         title="Dialog with Internal Scrolling"
-        onExited={hide}
-        primaryButton={{
-          onClick: close => {
-            close()
-          },
-          children: 'Primary Button',
-        }}
+        onCloseComplete={hide}
       >
         <Box height={1200} width="100%" backgroundColor="#ddd" />
       </Dialog>

--- a/src/dialog/docs/examples/primary-button-confirmation.example
+++ b/src/dialog/docs/examples/primary-button-confirmation.example
@@ -1,0 +1,23 @@
+<DialogManager>
+  {({ isShown, isLoading, confirmLoading, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with Primary Confirmation"
+        onExited={hide}
+        primaryButton={{
+          children: isLoading ? 'Loading...' : 'Confirm Loading',
+          onClick: confirmLoading,
+          isLoading,
+        }}
+        hideCancelButton
+      >
+        <Paragraph>
+          This is useful when you need to process something before closing
+          the dialog.
+        </Paragraph>
+      </Dialog>
+      <Button onClick={show}>Show Dialog with Loading Confirmation</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/primary-button-confirmation.example
+++ b/src/dialog/docs/examples/primary-button-confirmation.example
@@ -3,14 +3,11 @@
     <Box>
       <Dialog
         isShown={isShown}
-        title="Dialog with Primary Confirmation"
-        onExited={hide}
-        primaryButton={{
-          children: isLoading ? 'Loading...' : 'Confirm Loading',
-          onClick: confirmLoading,
-          isLoading,
-        }}
-        hideCancelButton
+        title="Dialog with Loading Confirmation"
+        onConfirm={confirmLoading}
+        confirmLabel={isLoading ? 'Loading...' : 'Confirm Loading'}
+        isConfirmLoading={isLoading}
+        onCloseComplete={hide}
       >
         <Paragraph>
           This is useful when you need to process something before closing

--- a/src/dialog/docs/examples/primary-button-only.example
+++ b/src/dialog/docs/examples/primary-button-only.example
@@ -3,12 +3,10 @@
     <Box>
       <Dialog
         isShown={isShown}
-        title="Dialog with Primary Button Only"
-        onExited={hide}
-        primaryButton={{
-          children: 'Got It',
-        }}
-        hideCancelButton
+        title="Dialog with Confirmation Button Only"
+        onCloseComplete={hide}
+        hasCancel={false}
+        confirmLabel='Got It'
       >
         <Paragraph>
           This is useful for product updates and onboarding content.

--- a/src/dialog/docs/examples/primary-button-only.example
+++ b/src/dialog/docs/examples/primary-button-only.example
@@ -1,0 +1,20 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with Primary Button Only"
+        onExited={hide}
+        primaryButton={{
+          children: 'Got It',
+        }}
+        hideCancelButton
+      >
+        <Paragraph>
+          This is useful for product updates and onboarding content.
+        </Paragraph>
+      </Dialog>
+      <Button onClick={show}>Show Dialog with Primary Button Only</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/primary-button-red.example
+++ b/src/dialog/docs/examples/primary-button-red.example
@@ -5,7 +5,7 @@
         isShown={isShown}
         title="Dialog with Danger Intent"
         onCloseComplete={hide}
-        intent="danger"
+        type="danger"
         confirmLabel="Dangerous Action"
       >
         <Paragraph>Dialog content</Paragraph>

--- a/src/dialog/docs/examples/primary-button-red.example
+++ b/src/dialog/docs/examples/primary-button-red.example
@@ -3,19 +3,14 @@
     <Box>
       <Dialog
         isShown={isShown}
-        title="Dialog with Red Primary Button"
-        onExited={hide}
-        primaryButton={{
-          onClick: close => {
-            close()
-          },
-          appearance: 'red',
-          children: 'Primary Button',
-        }}
+        title="Dialog with Danger Intent"
+        onCloseComplete={hide}
+        intent="danger"
+        confirmLabel="Dangerous Action"
       >
         <Paragraph>Dialog content</Paragraph>
       </Dialog>
-      <Button onClick={show}>Show Dialog with Red Button</Button>
+      <Button onClick={show}>Show Dialog with Danger Intent</Button>
     </Box>
   )}
 </DialogManager>

--- a/src/dialog/docs/examples/primary-button-red.example
+++ b/src/dialog/docs/examples/primary-button-red.example
@@ -1,0 +1,21 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with Red Primary Button"
+        onExited={hide}
+        primaryButton={{
+          onClick: close => {
+            close()
+          },
+          appearance: 'red',
+          children: 'Primary Button',
+        }}
+      >
+        <Paragraph>Dialog content</Paragraph>
+      </Dialog>
+      <Button onClick={show}>Show Dialog with Red Button</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/primary-button.example
+++ b/src/dialog/docs/examples/primary-button.example
@@ -1,0 +1,20 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with Primary Button"
+        onExited={hide}
+        primaryButton={{
+          onClick: close => {
+            close()
+          },
+          children: 'Primary Button',
+        }}
+      >
+        <Paragraph>Dialog content.</Paragraph>
+      </Dialog>
+      <Button onClick={show}>Show Dialog with Primary Button</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/primary-button.example
+++ b/src/dialog/docs/examples/primary-button.example
@@ -3,18 +3,13 @@
     <Box>
       <Dialog
         isShown={isShown}
-        title="Dialog with Primary Button"
-        onExited={hide}
-        primaryButton={{
-          onClick: close => {
-            close()
-          },
-          children: 'Primary Button',
-        }}
+        title="Dialog Title"
+        onCloseComplete={hide}
+        confirmLabel="Custom Label"
       >
-        <Paragraph>Dialog content.</Paragraph>
+        <Paragraph>Dialog content</Paragraph>
       </Dialog>
-      <Button onClick={show}>Show Dialog with Primary Button</Button>
+      <Button onClick={show}>Show Dialog with Custom Button Label</Button>
     </Box>
   )}
 </DialogManager>

--- a/src/dialog/docs/examples/self-managed-close.example
+++ b/src/dialog/docs/examples/self-managed-close.example
@@ -4,7 +4,8 @@
       <Dialog
         isShown={isShown}
         title="Dialog with Self Managed Close"
-        onExited={hide}
+        onCloseComplete={hide}
+        hasFooter={false}
       >
         {({ close }) => (
           <Box>

--- a/src/dialog/docs/examples/self-managed-close.example
+++ b/src/dialog/docs/examples/self-managed-close.example
@@ -1,0 +1,21 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with Self Managed Close"
+        onExited={hide}
+      >
+        {({ close }) => (
+          <Box>
+            <Paragraph>Manage Your Own Buttons and Interactions.</Paragraph>
+            <Button marginTop={16} onClick={close}>
+              Self Managed Close
+            </Button>
+          </Box>
+        )}
+      </Dialog>
+      <Button onClick={show}>Show Dialog with Self Managed Close</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/examples/without-buttons.example
+++ b/src/dialog/docs/examples/without-buttons.example
@@ -4,7 +4,8 @@
       <Dialog
         isShown={isShown}
         title="Dialog without Buttons"
-        onExited={hide}
+        onCloseComplete={hide}
+        hasFooter={false}
       >
         <Box>
           <Paragraph>Manage your own buttons and interactions.</Paragraph>

--- a/src/dialog/docs/examples/without-buttons.example
+++ b/src/dialog/docs/examples/without-buttons.example
@@ -1,0 +1,16 @@
+<DialogManager>
+  {({ isShown, show, hide }) => (
+    <Box>
+      <Dialog
+        isShown={isShown}
+        title="Dialog without Buttons"
+        onExited={hide}
+      >
+        <Box>
+          <Paragraph>Manage your own buttons and interactions.</Paragraph>
+        </Box>
+      </Dialog>
+      <Button onClick={show}>Show Dialog without Buttons</Button>
+    </Box>
+  )}
+</DialogManager>

--- a/src/dialog/docs/index.js
+++ b/src/dialog/docs/index.js
@@ -1,0 +1,183 @@
+import React from 'react'
+import Box from 'ui-box'
+import Dialog from '../src/Dialog'
+import { Button } from '../../buttons'
+import { Paragraph } from '../../typography'
+import DialogManager from './DialogManager'
+
+/* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
+import sourceDialog from '!raw-loader!../src/Dialog'
+/* eslint-enable import/no-unresolved, import/no-webpack-loader-syntax */
+
+/**
+ * Code examples
+ */
+import examplePrimaryButton from './examples/primary-button.example'
+import examplePrimaryButtonRed from './examples/primary-button-red.example'
+import examplePrimaryButtonOnly from './examples/primary-button-only.example'
+import examplePrimaryButtonConfirmation from './examples/primary-button-confirmation.example'
+import exampleWithoutButtons from './examples/without-buttons.example'
+import exampleSelfManagedClose from './examples/self-managed-close.example'
+import exampleHideHeader from './examples/hide-header.example'
+import exampleInternalScrolling from './examples/internal-scrolling.example'
+
+const title = 'Dialog'
+const subTitle = 'A component that displays content on top of an overlay.'
+
+const designGuidelines = (
+  <div>
+    <p>
+      The <code>Dialog</code> component is used to show content on top of an
+      overlay. It blocks any interaction with the page &mdash; until the overlay
+      is clicked, or a close action is triggered.
+    </p>
+    <h3>When To Use</h3>
+    <p>
+      When you require your user to interact with you app, but don&rsquo;t want
+      your users to jump to a different page and break their workflow.
+    </p>
+    <p>
+      You should also use a dialog in cases where you need to ask for
+      confirmation from the user before doing a lengthy or dangerous action.
+      This could be a deletion of some sorts or initiating a lengthy download.
+    </p>
+    <h3>Terminology</h3>
+    <p>
+      <a href="http://blueprintjs.com/docs/v2/#core/components/dialog">
+        BlueprintJS
+      </a>{' '}
+      pointed out in their documentation that &ldquo;modal&rdquo; is a misnomer
+      for &ldquo;dialog&rdquo;.
+    </p>
+    <blockquote cite="http://blueprintjs.com/docs/v2/#core/components/dialog">
+      The term &ldquo;modal&rdquo; is sometimes used to mean
+      &ldquo;dialog&rdquo;, but this is a misnomer. Modal is an adjective that
+      describes parts of a UI. An element is considered modal if it{' '}
+      <a href="https://en.wikipedia.org/wiki/Modal_window">
+        blocks interaction with the rest of the application
+      </a>. We use the term &ldquo;dialog&rdquo; to avoid confusion with the
+      adjective.
+    </blockquote>
+  </div>
+)
+
+const appearanceOptions = null
+
+const scope = {
+  Box,
+  Dialog,
+  DialogManager,
+  Paragraph,
+  Button
+}
+
+const components = [
+  {
+    name: 'Dialog',
+    source: sourceDialog,
+    description: (
+      <p>
+        This is the component responsible for all interactions and properties.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Primary button and cancel button',
+        description: (
+          <p>
+            By passing in the primary button, the cancel button also shows.
+            Primary button is an object which is passed through to the{' '}
+            <code>Button</code> component.
+          </p>
+        ),
+        codeText: examplePrimaryButton,
+        scope
+      },
+      {
+        title: 'Primary button with a custom appearance',
+        description: (
+          <p>
+            You can pass all properties through to the primary button. In this
+            example the red appearance is passed.
+          </p>
+        ),
+        codeText: examplePrimaryButtonRed,
+        scope
+      },
+      {
+        title: 'Primary button with loading confirmation',
+        description: (
+          <p>
+            You can pass all properties through to the primary button. Including
+            the <code>isLoading</code> prop.
+          </p>
+        ),
+        codeText: examplePrimaryButtonConfirmation,
+        scope
+      },
+      {
+        title: 'Primary button only',
+        description: (
+          <p>Hide the cancel button, useful in onboarding dialogs.</p>
+        ),
+        codeText: examplePrimaryButtonOnly,
+        scope
+      },
+      {
+        title: 'Internal scrolling',
+        description: (
+          <p>
+            When you pass in content that is greater than the available space,
+            the content area will become scrollable. It will add a symmetric
+            offset on the top and bottom — based on the <code>topOffset</code>{' '}
+            prop.
+          </p>
+        ),
+        codeText: exampleInternalScrolling,
+        scope
+      },
+      {
+        title: 'Without buttons',
+        description: (
+          <p>
+            If you don&rsquo;t pass the <code>primaryButton</code> prop — you
+            wont&rsquo;t see any footer at all. Clicks on the overlay will still
+            close your dialog.
+          </p>
+        ),
+        codeText: exampleWithoutButtons,
+        scope
+      },
+      {
+        title: 'Self managed close',
+        description: (
+          <p>
+            Pass in a function as children to accept a <code>close</code>{' '}
+            function you can use to manually close your dialog.
+          </p>
+        ),
+        codeText: exampleSelfManagedClose,
+        scope
+      },
+      {
+        title: 'Hidden header',
+        description: (
+          <p>
+            Hide the header by passing the <code>hideHeader</code> prop. This
+            will hide both the close icon button as the title.
+          </p>
+        ),
+        codeText: exampleHideHeader,
+        scope
+      }
+    ]
+  }
+]
+
+export default {
+  title,
+  subTitle,
+  designGuidelines,
+  appearanceOptions,
+  components
+}

--- a/src/dialog/docs/index.js
+++ b/src/dialog/docs/index.js
@@ -81,74 +81,65 @@ const components = [
     ),
     examples: [
       {
-        title: 'Primary button and cancel button',
+        title: 'Default Behavior',
         description: (
           <p>
-            By passing in the primary button, the cancel button also shows.
-            Primary button is an object which is passed through to the{' '}
-            <code>Button</code> component.
+            The default behavior of the dialog is to show a header with a title
+            and close button —  and a footer with a confirm and cancel button.
           </p>
         ),
         codeText: examplePrimaryButton,
         scope
       },
       {
-        title: 'Primary button with a custom appearance',
+        title: 'Dialog with a Danger Intent',
         description: (
           <p>
-            You can pass all properties through to the primary button. In this
-            example the red appearance is passed.
+            The intent prop determines the appearance of the confirm button.
+            <code>danger</code> is red. In the future, more intent types might
+            be added.
           </p>
         ),
         codeText: examplePrimaryButtonRed,
         scope
       },
       {
-        title: 'Primary button with loading confirmation',
+        title: 'Confirm Button with Loading Confirmation',
         description: (
           <p>
-            You can pass all properties through to the primary button. Including
-            the <code>isLoading</code> prop.
+            Pass the <code>isConfirmLoading</code> to set the loading state on
+            the confirm button.
           </p>
         ),
         codeText: examplePrimaryButtonConfirmation,
         scope
       },
       {
-        title: 'Primary button only',
+        title: 'Confirm Button Only',
         description: (
-          <p>Hide the cancel button, useful in onboarding dialogs.</p>
+          <p>
+            Sometimes you only need a confirm button and not a cancel button.
+            For example in onboarding use cases.
+          </p>
         ),
         codeText: examplePrimaryButtonOnly,
         scope
       },
       {
-        title: 'Internal scrolling',
+        title: 'Internal Scrolling',
         description: (
           <p>
-            When you pass in content that is greater than the available space,
-            the content area will become scrollable. It will add a symmetric
-            offset on the top and bottom — based on the <code>topOffset</code>{' '}
-            prop.
+            When content makes the dialog height greater than the available
+            space in the viewport, the content area will become scrollable. It
+            will add a symmetric offset on the top and bottom — based on the{' '}
+            <code>topOffset</code> prop.
           </p>
         ),
         codeText: exampleInternalScrolling,
         scope
       },
       {
-        title: 'Without buttons',
-        description: (
-          <p>
-            If you don’t pass the <code>primaryButton</code> prop — you wont’t
-            see any footer at all. Clicks on the overlay will still close your
-            dialog.
-          </p>
-        ),
-        codeText: exampleWithoutButtons,
-        scope
-      },
-      {
-        title: 'Self managed close',
+        title: 'Self Managed Close',
         description: (
           <p>
             Pass in a function as children to accept a <code>close</code>{' '}
@@ -159,10 +150,21 @@ const components = [
         scope
       },
       {
-        title: 'Hidden header',
+        title: 'Without Footer',
         description: (
           <p>
-            Hide the header by passing the <code>hideHeader</code> prop. This
+            Use the <code>hasFooter</code> props to show or hide the footer.
+            This will hide the confirm and cancel buttons.
+          </p>
+        ),
+        codeText: exampleWithoutButtons,
+        scope
+      },
+      {
+        title: 'Without Header',
+        description: (
+          <p>
+            Use the <code>hasHeader</code> props to show or hide the heaer. This
             will hide both the close icon button as the title.
           </p>
         ),

--- a/src/dialog/docs/index.js
+++ b/src/dialog/docs/index.js
@@ -33,8 +33,8 @@ const designGuidelines = (
     </p>
     <h3>When To Use</h3>
     <p>
-      When you require your user to interact with you app, but don&rsquo;t want
-      your users to jump to a different page and break their workflow.
+      When you require your user to interact with you app, but don’t want your
+      users to jump to a different page and break their workflow.
     </p>
     <p>
       You should also use a dialog in cases where you need to ask for
@@ -46,17 +46,16 @@ const designGuidelines = (
       <a href="http://blueprintjs.com/docs/v2/#core/components/dialog">
         BlueprintJS
       </a>{' '}
-      pointed out in their documentation that &ldquo;modal&rdquo; is a misnomer
-      for &ldquo;dialog&rdquo;.
+      pointed out in their documentation that “modal” is a misnomer for
+      “dialog”.
     </p>
     <blockquote cite="http://blueprintjs.com/docs/v2/#core/components/dialog">
-      The term &ldquo;modal&rdquo; is sometimes used to mean
-      &ldquo;dialog&rdquo;, but this is a misnomer. Modal is an adjective that
-      describes parts of a UI. An element is considered modal if it{' '}
+      The term “modal” is sometimes used to mean “dialog”, but this is a
+      misnomer. Modal is an adjective that describes parts of a UI. An element
+      is considered modal if it{' '}
       <a href="https://en.wikipedia.org/wiki/Modal_window">
         blocks interaction with the rest of the application
-      </a>. We use the term &ldquo;dialog&rdquo; to avoid confusion with the
-      adjective.
+      </a>. We use the term “dialog” to avoid confusion with the adjective.
     </blockquote>
   </div>
 )
@@ -140,9 +139,9 @@ const components = [
         title: 'Without buttons',
         description: (
           <p>
-            If you don&rsquo;t pass the <code>primaryButton</code> prop — you
-            wont&rsquo;t see any footer at all. Clicks on the overlay will still
-            close your dialog.
+            If you don’t pass the <code>primaryButton</code> prop — you wont’t
+            see any footer at all. Clicks on the overlay will still close your
+            dialog.
           </p>
         ),
         codeText: exampleWithoutButtons,

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -106,9 +106,9 @@ class Dialog extends React.Component {
     confirmLabel: PropTypes.string,
 
     /**
-     * The intent of the message.
+     * The type of the message.
      */
-    intent: PropTypes.oneOf(['neutral', 'danger']),
+    type: PropTypes.oneOf(['default', 'danger']),
 
     /**
      * When true, the confirm button is set to loading.
@@ -168,7 +168,7 @@ class Dialog extends React.Component {
     hasHeader: true,
     hasFooter: true,
     hasCancel: true,
-    intent: 'neutral',
+    type: 'default',
     width: 560,
     topOffset: '12vh',
     minHeightContent: 80,
@@ -184,7 +184,7 @@ class Dialog extends React.Component {
     const {
       title,
       width,
-      intent,
+      type,
       isShown,
       children,
       topOffset,
@@ -212,9 +212,9 @@ class Dialog extends React.Component {
     }
 
     let buttonAppearance
-    if (intent === 'neutral') {
+    if (type === 'default') {
       buttonAppearance = 'green'
-    } else if (intent === 'danger') {
+    } else if (type === 'danger') {
       buttonAppearance = 'red'
     }
 

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -101,7 +101,7 @@ class Dialog extends React.Component {
     onConfirm: PropTypes.func,
 
     /**
-     * Label that is used inside of the confirm button.
+     * Label of the confirm button.
      */
     confirmLabel: PropTypes.string,
 
@@ -129,10 +129,9 @@ class Dialog extends React.Component {
     onCancel: PropTypes.func,
 
     /**
-     * Label of the cancel button, shown when primaryButton is passed.
-     * You should not have to change this in most cases.
+     * Label of the cancel button.
      */
-    cancelLabel: PropTypes.node,
+    cancelLabel: PropTypes.string,
 
     /**
      * Width of the Dialog.
@@ -140,9 +139,9 @@ class Dialog extends React.Component {
     width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
-     * The space above the Dialog.
+     * The space above the dialog.
      * This offset is also used at the bottom when there is not enough space
-     * available on screen — and the Dialog scrolls internally.
+     * available on screen — and the dialog scrolls internally.
      */
     topOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
@@ -153,7 +152,7 @@ class Dialog extends React.Component {
     minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
-     * Props that are passed to the Dialog container.
+     * Props that are passed to the dialog container.
      */
     containerProps: PropTypes.object
   }

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -59,7 +59,7 @@ class Dialog extends React.Component {
      * Children can be a node or a function accepting `({ close })`.
      * See an example to understand how this works.
      */
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
 
     /**
      * Title of the Dialog. Titles should use Title Case.
@@ -135,6 +135,13 @@ class Dialog extends React.Component {
       ...props
     } = this.props
 
+    let maxHeight
+    if (Number.isInteger(topOffset)) {
+      maxHeight = `calc(100% - ${topOffset}px - ${topOffset}px)`
+    } else {
+      maxHeight = `calc(100% - ${topOffset} - ${topOffset})`
+    }
+
     return (
       <Overlay {...props}>
         {({ state, close }) => (
@@ -142,7 +149,7 @@ class Dialog extends React.Component {
             display="flex"
             justifyContent="center"
             paddingTop={topOffset}
-            maxHeight={`calc(100% - ${topOffset} - ${topOffset})`}
+            maxHeight={maxHeight}
           >
             <Pane
               role="dialog"
@@ -207,7 +214,7 @@ class Dialog extends React.Component {
                           : close()
                       }
                     />
-                    {hideCancelButton ? null : (
+                    {!hideCancelButton && (
                       <Button onClick={close}>{cancelLabel}</Button>
                     )}
                   </Pane>

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -4,7 +4,7 @@ import { css } from 'ui-box'
 import { Pane } from '../../layers'
 import { Heading } from '../../typography'
 import { Overlay } from '../../overlay'
-import { IconButton } from '../../buttons'
+import { Button, IconButton } from '../../buttons'
 
 const animationEasing = {
   deceleration: `cubic-bezier(0.0, 0.0, 0.2, 1)`,
@@ -50,28 +50,88 @@ const animationStyles = {
 
 class Dialog extends React.Component {
   static propTypes = {
+    /**
+     * Composes the Overlay component as the base.
+     */
     ...Overlay.propTypes,
+
+    /**
+     * Children can be a node or a function accepting `({ close })`.
+     * See an example to understand how this works.
+     */
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+
+    /**
+     * Title of the Dialog. Titles should use Title Case.
+     */
     title: PropTypes.node,
+
+    /**
+     * Props passed through to the primary button.
+     * Passing this object will show the button and cancel button.
+     * You should pass `children` and `onClick`.
+     */
+    primaryButton: PropTypes.object,
+
+    /**
+     * Label of the cancel button, shown when primaryButton is passed.
+     * You should not have to change this in most cases.
+     */
+    cancelLabel: PropTypes.node,
+
+    /**
+     * Only effective when when passing primaryButton.
+     */
+    hideCancelButton: PropTypes.bool,
+
+    /**
+     * Width of the Dialog.
+     */
     width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    hasCloseIcon: PropTypes.bool,
+
+    /**
+     * The space above the Dialog.
+     * This offset is also used at the bottom when there is not enough space
+     * available on screen — and the Dialog scrolls internally.
+     */
+    topOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * The min height of the body content.
+     * Makes it less weird when only showing little content.
+     */
+    minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * When true, hide the header containing the title and close button.
+     */
+    hideHeader: PropTypes.bool,
+
+    /**
+     * Props that are passed to the Dialog container.
+     */
     containerProps: PropTypes.object
   }
 
   static defaultProps = {
-    width: 567,
-    height: 240,
-    hasCloseIcon: true
+    width: 560,
+    topOffset: '12vh',
+    minHeightContent: 80,
+    cancelLabel: 'Cancel'
   }
 
   render() {
     const {
-      children,
-      width,
-      height,
-      hasCloseIcon,
-      containerProps,
       title,
+      width,
+      children,
+      topOffset,
+      hideHeader,
+      cancelLabel,
+      primaryButton,
+      minHeightContent,
+      hideCancelButton,
+      containerProps,
       ...props
     } = this.props
 
@@ -81,8 +141,8 @@ class Dialog extends React.Component {
           <Pane
             display="flex"
             justifyContent="center"
-            height="100vh"
-            paddingTop={120}
+            paddingTop={topOffset}
+            maxHeight={`calc(100% - ${topOffset} - ${topOffset})`}
           >
             <Pane
               role="dialog"
@@ -90,31 +150,68 @@ class Dialog extends React.Component {
               elevation={4}
               borderRadius={8}
               width={width}
-              height={height}
+              display="flex"
+              flexDirection="column"
               css={animationStyles}
               data-state={state}
               {...containerProps}
             >
-              <Pane
-                padding={16}
-                borderBottom="extraMuted"
-                display="flex"
-                alignItems="center"
-              >
-                <Heading is="h4" size={600} flex="1">
-                  {title}
-                </Heading>
-                {hasCloseIcon && (
+              {!hideHeader && (
+                <Pane
+                  padding={16}
+                  flexShrink={0}
+                  borderBottom="extraMuted"
+                  display="flex"
+                  alignItems="center"
+                >
+                  <Heading is="h4" size={600} flex="1">
+                    {title}
+                  </Heading>
                   <IconButton appearance="ghost" icon="close" onClick={close} />
-                )}
-              </Pane>
+                </Pane>
+              )}
 
-              <Pane overflowY="auto" data-state={state} padding={16}>
-                {typeof children === 'function'
-                  ? children({
-                      close
-                    })
-                  : children}
+              <Pane
+                data-state={state}
+                flex={1}
+                display="flex"
+                flexDirection="column"
+              >
+                <Pane
+                  overflowY="auto"
+                  padding={16}
+                  minHeight={minHeightContent}
+                >
+                  {typeof children === 'function'
+                    ? children({
+                        close
+                      })
+                    : children}
+                </Pane>
+
+                {primaryButton && (
+                  <Pane
+                    flexShrink={0}
+                    padding={16}
+                    borderTop="extraMuted"
+                    display="flex"
+                    flexDirection="row-reverse"
+                  >
+                    <Button
+                      marginLeft={8}
+                      appearance="green"
+                      {...primaryButton}
+                      onClick={() =>
+                        typeof primaryButton.onClick === 'function'
+                          ? primaryButton.onClick(close)
+                          : close()
+                      }
+                    />
+                    {hideCancelButton ? null : (
+                      <Button onClick={close}>{cancelLabel}</Button>
+                    )}
+                  </Pane>
+                )}
               </Pane>
             </Pane>
           </Pane>

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -121,11 +121,6 @@ class Dialog extends React.Component {
     isConfirmDisabled: PropTypes.bool,
 
     /**
-     * When true, the cancel button is shown.
-     */
-    showCancel: PropTypes.bool,
-
-    /**
      * Function that will be called when the cancel button is clicked.
      * This closes the Dialog by default.
      *

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -18,17 +18,12 @@ storiesOf('dialog', module).add('Dialog', () => (
           <Dialog
             isShown={isShown}
             title="Dialog Title"
-            onExited={hide}
-            primaryButton={{
-              onClick: close => {
-                close()
-              },
-              children: 'Primary Button'
-            }}
+            onCloseComplete={hide}
+            confirmLabel="Custom Label"
           >
             <Paragraph>Dialog content</Paragraph>
           </Dialog>
-          <Button onClick={show}>Show Dialog with Primary Button</Button>
+          <Button onClick={show}>Show Dialog with Custom Button Label</Button>
         </Box>
       )}
     </DialogManager>
@@ -37,19 +32,14 @@ storiesOf('dialog', module).add('Dialog', () => (
         <Box marginBottom={16}>
           <Dialog
             isShown={isShown}
-            title="Dialog with Red Primary Button"
-            onExited={hide}
-            primaryButton={{
-              onClick: close => {
-                close()
-              },
-              appearance: 'red',
-              children: 'Primary Button'
-            }}
+            title="Dialog with Danger Intent"
+            onCloseComplete={hide}
+            intent="danger"
+            confirmLabel="Dangerous Action"
           >
             <Paragraph>Dialog content</Paragraph>
           </Dialog>
-          <Button onClick={show}>Show Dialog with Red Button</Button>
+          <Button onClick={show}>Show Dialog with Danger Intent</Button>
         </Box>
       )}
     </DialogManager>
@@ -58,14 +48,11 @@ storiesOf('dialog', module).add('Dialog', () => (
         <Box marginBottom={16}>
           <Dialog
             isShown={isShown}
-            title="Dialog with Primary Confirmation"
-            onExited={hide}
-            primaryButton={{
-              children: isLoading ? 'Loading...' : 'Confirm Loading',
-              onClick: confirmLoading,
-              isLoading
-            }}
-            hideCancelButton
+            title="Dialog with Loading Confirmation"
+            onConfirm={confirmLoading}
+            confirmLabel={isLoading ? 'Loading...' : 'Confirm Loading'}
+            isConfirmLoading={isLoading}
+            onCloseComplete={hide}
           >
             <Paragraph>
               This is useful when you need to process something before closing
@@ -81,12 +68,10 @@ storiesOf('dialog', module).add('Dialog', () => (
         <Box marginBottom={16}>
           <Dialog
             isShown={isShown}
-            title="Dialog with Primary Button Only"
-            onExited={hide}
-            primaryButton={{
-              children: 'Got It'
-            }}
-            hideCancelButton
+            title="Dialog with Confirmation Button Only"
+            onCloseComplete={hide}
+            hasCancel={false}
+            confirmLabel="Got It"
           >
             <Paragraph>
               This is useful for product updates and onboarding content.
@@ -102,7 +87,8 @@ storiesOf('dialog', module).add('Dialog', () => (
           <Dialog
             isShown={isShown}
             title="Dialog without Buttons"
-            onExited={hide}
+            onCloseComplete={hide}
+            hasFooter={false}
           >
             <Box>
               <Paragraph>Manage your own buttons and interactions.</Paragraph>
@@ -118,7 +104,8 @@ storiesOf('dialog', module).add('Dialog', () => (
           <Dialog
             isShown={isShown}
             title="Dialog with Self Managed Close"
-            onExited={hide}
+            onCloseComplete={hide}
+            hasFooter={false}
           >
             {({ close }) => (
               <Box>
@@ -136,7 +123,12 @@ storiesOf('dialog', module).add('Dialog', () => (
     <DialogManager>
       {({ isShown, show, hide }) => (
         <Box marginBottom={16}>
-          <Dialog isShown={isShown} hideHeader onExited={hide}>
+          <Dialog
+            isShown={isShown}
+            hasHeader={false}
+            hasFooter={false}
+            onCloseComplete={hide}
+          >
             {({ close }) => (
               <Box>
                 <Paragraph>
@@ -158,13 +150,7 @@ storiesOf('dialog', module).add('Dialog', () => (
           <Dialog
             isShown={isShown}
             title="Dialog with Internal Scrolling"
-            onExited={hide}
-            primaryButton={{
-              onClick: close => {
-                close()
-              },
-              children: 'Primary Button'
-            }}
+            onCloseComplete={hide}
           >
             <Box height={1200} width="100%" backgroundColor="#ddd" />
           </Dialog>

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -1,33 +1,10 @@
 import { storiesOf } from '@storybook/react'
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 import Box from 'ui-box'
+import DialogManager from '../docs/DialogManager'
+import { Paragraph } from '../../typography'
 import { Dialog } from '../../dialog'
 import { Button } from '../../buttons'
-
-class DialogManager extends PureComponent {
-  static propTypes = {
-    children: PropTypes.func
-  }
-
-  state = {
-    isShown: true
-  }
-
-  render() {
-    return this.props.children({
-      isShown: this.state.isShown,
-      show: () =>
-        this.setState({
-          isShown: true
-        }),
-      hide: () =>
-        this.setState({
-          isShown: false
-        })
-    })
-  }
-}
 
 storiesOf('dialog', module).add('Dialog', () => (
   <Box padding={40}>
@@ -37,11 +14,161 @@ storiesOf('dialog', module).add('Dialog', () => (
     })()}
     <DialogManager>
       {({ isShown, show, hide }) => (
-        <Box>
-          <Dialog isShown={isShown} title="Dialog title" onHide={hide}>
-            Dialog content
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog Title"
+            onExited={hide}
+            primaryButton={{
+              onClick: close => {
+                close()
+              },
+              children: 'Primary Button'
+            }}
+          >
+            <Paragraph>Dialog content</Paragraph>
           </Dialog>
-          <Button onClick={show}>Show Dialog</Button>
+          <Button onClick={show}>Show Dialog with Primary Button</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog with Red Primary Button"
+            onExited={hide}
+            primaryButton={{
+              onClick: close => {
+                close()
+              },
+              appearance: 'red',
+              children: 'Primary Button'
+            }}
+          >
+            <Paragraph>Dialog content</Paragraph>
+          </Dialog>
+          <Button onClick={show}>Show Dialog with Red Button</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, isLoading, confirmLoading, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog with Primary Confirmation"
+            onExited={hide}
+            primaryButton={{
+              children: isLoading ? 'Loading...' : 'Confirm Loading',
+              onClick: confirmLoading,
+              isLoading
+            }}
+            hideCancelButton
+          >
+            <Paragraph>
+              This is useful when you need to process something before closing
+              the dialog.
+            </Paragraph>
+          </Dialog>
+          <Button onClick={show}>Show Dialog with Loading Confirmation</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog with Primary Button Only"
+            onExited={hide}
+            primaryButton={{
+              children: 'Got It'
+            }}
+            hideCancelButton
+          >
+            <Paragraph>
+              This is useful for product updates and onboarding content.
+            </Paragraph>
+          </Dialog>
+          <Button onClick={show}>Show Dialog with Primary Button Only</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog without Buttons"
+            onExited={hide}
+          >
+            <Box>
+              <Paragraph>Manage your own buttons and interactions.</Paragraph>
+            </Box>
+          </Dialog>
+          <Button onClick={show}>Show Dialog without Buttons</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog with Self Managed Close"
+            onExited={hide}
+          >
+            {({ close }) => (
+              <Box>
+                <Paragraph>Manage Your Own Buttons and Interactions.</Paragraph>
+                <Button marginTop={16} onClick={close}>
+                  Self Managed Close
+                </Button>
+              </Box>
+            )}
+          </Dialog>
+          <Button onClick={show}>Show Dialog with Self Managed Close</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog isShown={isShown} hideHeader onExited={hide}>
+            {({ close }) => (
+              <Box>
+                <Paragraph>
+                  Manage your own header, buttons and interactions.
+                </Paragraph>
+                <Button marginTop={16} onClick={close}>
+                  Self Managed Close
+                </Button>
+              </Box>
+            )}
+          </Dialog>
+          <Button onClick={show}>Show Dialog without Header</Button>
+        </Box>
+      )}
+    </DialogManager>
+    <DialogManager>
+      {({ isShown, show, hide }) => (
+        <Box marginBottom={16}>
+          <Dialog
+            isShown={isShown}
+            title="Dialog with Internal Scrolling"
+            onExited={hide}
+            primaryButton={{
+              onClick: close => {
+                close()
+              },
+              children: 'Primary Button'
+            }}
+          >
+            <Box height={1200} width="100%" backgroundColor="#ddd" />
+          </Dialog>
+          <Button onClick={show}>Show Dialog with Internal Scrolling</Button>
         </Box>
       )}
     </DialogManager>

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -34,7 +34,7 @@ storiesOf('dialog', module).add('Dialog', () => (
             isShown={isShown}
             title="Dialog with Danger Intent"
             onCloseComplete={hide}
-            intent="danger"
+            type="danger"
             confirmLabel="Dangerous Action"
           >
             <Paragraph>Dialog content</Paragraph>

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -22,7 +22,7 @@ const loadingCircleKeyframes = css.keyframes('loading-circle', {
 })
 
 const outer = {
-  animation: `${loadingKeyframes} 3s linear infinite`
+  animation: `${loadingKeyframes} 2s linear infinite`
 }
 
 const inner = {
@@ -31,14 +31,21 @@ const inner = {
   strokeWidth: 12,
   strokeMiterlimit: 10,
   strokeLinecap: 'round',
-  animation: `${loadingCircleKeyframes} 2s cubic-bezier(0.4, 0.15, 0.6, 0.85) infinite`,
+  animation: `${loadingCircleKeyframes} 1.6s cubic-bezier(0.4, 0.15, 0.6, 0.85) infinite`,
   stroke: colors.neutral['500'],
   fill: 'transparent'
 }
 
 export default class Spinner extends PureComponent {
   static propTypes = {
+    /**
+     * Composes the Box component as the base.
+     */
     ...Box.propTypes,
+
+    /**
+     * The size of the spinner.
+     */
     size: PropTypes.number
   }
 
@@ -49,7 +56,7 @@ export default class Spinner extends PureComponent {
   render() {
     const { size, ...props } = this.props
     return (
-      <Box width={size} height={size} {...props}>
+      <Box width={size} height={size} lineHeight={0} {...props}>
         <Box is="svg" css={outer} x="0px" y="0px" viewBox="0 0 150 150">
           <Box is="circle" css={inner} cx="75" cy="75" r="60" />
         </Box>

--- a/src/table/docs/index.js
+++ b/src/table/docs/index.js
@@ -37,33 +37,29 @@ import exampleTableBody from './examples/TableBody.example'
 import exampleTableHead from './examples/TableHead.example'
 
 const title = 'Table'
-const subTitle = 'A package exporting the building blocks of a table.'
+const subTitle = 'A set of components for building a table.'
 
 const designGuidelines = (
   <div>
     <p>
-      This package exports the building blocks for tables. This package is also
-      used in places such as the options list in the <code>SelectMenu</code>{' '}
-      component. Currently this package does not use real tables under the hood.
-      There is a{' '}
-      <a href="https://github.com/segmentio/evergreen/issues/105">
-        discussion on GitHub
-      </a>{' '}
-      going on to potentially change this in the future.
+      Evergreen exports a set of building blocks for building tables. This
+      package is also used in places such as the options list in the{' '}
+      <code>SelectMenu</code> component. Currently this package does not use
+      real tables under the hood.
     </p>
     <h3>Implementation details</h3>
     <ul>
       <li>
         None of these components implement HTML table elements such as:
         {` `}
-        <code>table</code>, <code>th</code> or <code>tr</code>
+        <code>table</code>, <code>th</code> or <code>tr</code>.
       </li>
       <li>
         Most components are basic <code>Pane</code> components combined with
         {` `}
-        <code>Text</code>
+        <code>Text</code>.
       </li>
-      <li>All components are presentational, no sorting build in</li>
+      <li>All components are presentational, no sorting build in.</li>
     </ul>
   </div>
 )


### PR DESCRIPTION
This PR is based on top of #127, #128. The other PR was still based on the old mono-repo, so I redid most what was in that PR and made some additional changes and tweaks. 

**This is a breaking change**

## This PR contains

* Dialog API improvements
* More Dialog stories
* Dialog documentation
* Button now has a `isLoading` prop
* Minor changes in content for Table and Buttons docs.

## Props and default props

```javascript
static propTypes = {
  /**
   * Children can be a node or a function accepting `({ close })`.
   * See an example to understand how this works.
   */
  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,

  /**
   * When true, the dialog is shown.
   */
  isShown: PropTypes.bool,

  /**
   * Title of the Dialog. Titles should use Title Case.
   */
  title: PropTypes.node,

  /**
   * When true, the header with the title and close icon button is shown.
   */
  hasHeader: PropTypes.bool,

  /**
   * When true, the footer with the cancel and confirm button is shown.
   */
  hasFooter: PropTypes.bool,

  /**
   * When true, the cancel button is shown.
   */
  hasCancel: PropTypes.bool,

  /**
   * Function that will be called when the exit transition is complete.
   */
  onCloseComplete: PropTypes.func,

  /**
   * Function that will be called when the enter transition is complete.
   */
  onOpenComplete: PropTypes.func,

  /**
   * Function that will be called when the confirm button is clicked.
   * This does not close the Dialog. A close function will be passed
   * as a paramater you can use to close the dialog.
   *
   * `onConfirm={(close) => close()}`
   */
  onConfirm: PropTypes.func,

  /**
   * Label of the confirm button.
   */
  confirmLabel: PropTypes.string,

  /**
   * The type of the message.
   */
  type: PropTypes.oneOf(['default', 'danger']),

  /**
   * When true, the confirm button is set to loading.
   */
  isConfirmLoading: PropTypes.bool,

  /**
   * When true, the confirm button is set to disabled.
   */
  isConfirmDisabled: PropTypes.bool,

  /**
   * Function that will be called when the cancel button is clicked.
   * This closes the Dialog by default.
   *
   * `onCancel={(close) => close()}`
   */
  onCancel: PropTypes.func,

  /**
   * Label of the cancel button.
   */
  cancelLabel: PropTypes.string,

  /**
   * Width of the Dialog.
   */
  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

  /**
   * The space above the dialog.
   * This offset is also used at the bottom when there is not enough space
   * available on screen — and the dialog scrolls internally.
   */
  topOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

  /**
   * The min height of the body content.
   * Makes it less weird when only showing little content.
   */
  minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

  /**
   * Props that are passed to the dialog container.
   */
  containerProps: PropTypes.object
}

static defaultProps = {
  isShown: false,
  hasHeader: true,
  hasFooter: true,
  hasCancel: true,
  type: 'default',
  width: 560,
  topOffset: '12vh',
  minHeightContent: 80,
  confirmLabel: 'Confirm',
  isConfirmLoading: false,
  isConfirmDisabled: false,
  cancelLabel: 'Cancel',
  onCancel: close => close(),
  onConfirm: close => close()
}
```

## Design Examples

These examples don‘t reflect the latest state of the component.

![dialog](https://user-images.githubusercontent.com/564463/36235625-a97bd824-11a6-11e8-9158-acc6718b9ccb.gif)
![confirm loading](https://user-images.githubusercontent.com/564463/36235629-ac259ee8-11a6-11e8-967c-d0541ff6f902.gif)
![button isloading](https://user-images.githubusercontent.com/564463/36235631-aebffc16-11a6-11e8-85fb-e76340373245.gif)
![dialog docs](https://user-images.githubusercontent.com/564463/36235707-0f9f7c78-11a7-11e8-9f03-82d0a86d3827.gif)
