### PR TITLE
Making SearchInput width-aware

### DIFF
--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -20,9 +20,8 @@ export default class SearchInput extends PureComponent {
   render() {
     const { appearance, iconProps, disabled, height, ...props } = this.props
     const { matchedProps, remainingProps } = splitBoxProps(props)
-    const { width } = matchedProps
+    const { width = TextInput.defaultProps.width } = matchedProps
     const iconSize = getIconSizeForControlHeight({ height })
-
     return (
       <Box
         position="relative"
@@ -46,8 +45,8 @@ export default class SearchInput extends PureComponent {
           paddingLeft={height}
           appearance={appearance}
           disable={disabled}
+          width={width}
           {...remainingProps}
-          {...{ width }}
         />
       </Box>
     )

--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -20,6 +20,7 @@ export default class SearchInput extends PureComponent {
   render() {
     const { appearance, iconProps, disabled, height, ...props } = this.props
     const { matchedProps, remainingProps } = splitBoxProps(props)
+    const { width } = matchedProps
     const iconSize = getIconSizeForControlHeight({ height })
 
     return (
@@ -46,6 +47,7 @@ export default class SearchInput extends PureComponent {
           appearance={appearance}
           disable={disabled}
           {...remainingProps}
+          {...{ width }}
         />
       </Box>
     )

--- a/src/search-input/stories/index.stories.js
+++ b/src/search-input/stories/index.stories.js
@@ -37,6 +37,12 @@ storiesOf('search-input', module).add('SearchInput', () => (
     </StorySection>
     <StorySection>
       <StoryHeader>
+        <StoryHeading>Height 32 and Width 100%</StoryHeading>
+      </StoryHeader>
+      <SearchInput height={32} width="100%" placeholder="Long Input" />
+    </StorySection>
+    <StorySection>
+      <StoryHeader>
         <StoryHeading>Appearance: neutral</StoryHeading>
         <StoryDescription>
           Use this on top of a white background

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -42,12 +42,18 @@ export default class TextInput extends PureComponent {
     /**
      * The appearance of the TextInput.
      */
-    appearance: PropTypes.oneOf(Object.keys(InputAppearances))
+    appearance: PropTypes.oneOf(Object.keys(InputAppearances)),
+
+    /**
+     * The width of the TextInput.
+     */
+    width: PropTypes.oneOf([PropTypes.string, PropTypes.number])
   }
 
   static defaultProps = {
     appearance: 'default',
     height: 32,
+    width: 280,
     disabled: false,
     isInvalid: false,
     spellCheck: true
@@ -56,6 +62,7 @@ export default class TextInput extends PureComponent {
   render() {
     const {
       css,
+      width,
       height,
       disabled,
       required,
@@ -73,7 +80,7 @@ export default class TextInput extends PureComponent {
       <Text
         is="input"
         type="text"
-        width={280}
+        width={width}
         height={height}
         required={required}
         disabled={disabled}


### PR DESCRIPTION
Hallo @Rowno @jeroenransijn 
I came across a case where I needed to customize the width of the searchInput box. 

Passing a 'width' prop to `SearchInput` only set the container's width and not the input, so hopefully this pr fixes that.

> While It could've been done with CSS classes, I wanted to add the fix to evergreen.
> My other idea was to modify `splitBoxProps` to pass another parameter of whitelisted keys that should not be removed.


### Screenshot of storybook 
![image](https://user-images.githubusercontent.com/952992/36636731-3dfef03a-1981-11e8-97a9-ffe414d85c75.png)
