### PR TITLE
Fforres/fix warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "build-esm":
       "BABEL_ENV=esm babel src --out-dir esm --ignore stories,test,docs --source-maps inline",
     "build": "yarn run build-commonjs && yarn run build-esm",
-    "build-watch":
-      "yarn run build-commonjs --watch && yarn run build-esm --watch",
     "clean": "git clean -Xdf",
     "release": "np --no-publish"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "build-esm":
       "BABEL_ENV=esm babel src --out-dir esm --ignore stories,test,docs --source-maps inline",
     "build": "yarn run build-commonjs && yarn run build-esm",
+    "build-watch":
+      "yarn run build-commonjs --watch && yarn run build-esm --watch",
     "clean": "git clean -Xdf",
     "release": "np --no-publish"
   },

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -23,6 +23,7 @@ export default class IconButton extends PureComponent {
   }
 
   static defaultProps = {
+    appearance: 'default',
     height: 32,
     iconAim: 'none'
   }

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -23,7 +23,7 @@ export default class IconButton extends PureComponent {
   }
 
   static defaultProps = {
-    appearance: 'default',
+    appearance: 'neutral',
     height: 32,
     iconAim: 'none'
   }

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -51,6 +51,7 @@ export default class Combobox extends PureComponent {
       defaultSelectedItem,
       itemToString,
       width,
+      appearance,
       height,
       onChange,
       inputProps,
@@ -117,6 +118,7 @@ export default class Combobox extends PureComponent {
               iconAim={isOpen ? 'up' : 'down'}
               color="muted"
               icon="triangle"
+              appearance={appearance}
               height={height}
               marginLeft={-1}
               paddingLeft={0}

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -47,7 +47,7 @@ export default class TextInput extends PureComponent {
     /**
      * The width of the TextInput.
      */
-    width: PropTypes.oneOf([PropTypes.string, PropTypes.number])
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   }
 
   static defaultProps = {


### PR DESCRIPTION
On #143 I added the wrong proptype validations so this PR fixes it

Also, while using comboBox on our app, I'm getting a warning for
![image](https://user-images.githubusercontent.com/952992/36813257-d1dc1ff8-1c88-11e8-906c-e829cbec54cd.png)
```
Warning: Failed prop type: The prop `appearance` is marked as required in `IconButton`, but its value is `undefined`.
    in IconButton
```

So this PR defines a defaultProp for `<IconButton/>` to be passed onto the `<Button/>` and allows overwriting it on `<ComboBox/>`