### PR TITLE
Fixing some warnings

### DIFF
--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -26,7 +26,8 @@ export default class Combobox extends PureComponent {
 
   static defaultProps = {
     openOnFocus: false,
-    width: 224
+    width: 224,
+    appearance: 'default'
   }
 
   constructor(props, context) {

--- a/src/layers/src/Pane.js
+++ b/src/layers/src/Pane.js
@@ -26,6 +26,7 @@ export default class Pane extends PureComponent {
 
     // Enable to set a boolean for a default border
     border: StringAndBoolPropType,
+    borderTop: StringAndBoolPropType,
     borderRight: StringAndBoolPropType,
     borderBottom: StringAndBoolPropType,
     borderLeft: StringAndBoolPropType

--- a/src/layers/src/Pane.js
+++ b/src/layers/src/Pane.js
@@ -25,7 +25,7 @@ export default class Pane extends PureComponent {
     activeElevation: ElevationPropType,
 
     // Enable to set a boolean for a default border
-    borderTop: StringAndBoolPropType,
+    border: StringAndBoolPropType,
     borderRight: StringAndBoolPropType,
     borderBottom: StringAndBoolPropType,
     borderLeft: StringAndBoolPropType


### PR DESCRIPTION
I was receiving some warning on a couple of components we where using.
So this really small PR adds a default appearance for `ComboBox` & a default border PropType for `Pane`