### PR TITLE
Pane & Card (layers) documentation

### DIFF
--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -1,27 +1,25 @@
 const path = require('path')
 const webpack = require('webpack') // eslint-disable-line import/no-extraneous-dependencies
+const componentRoutes = require('./src/componentRoutes')
 
 const componentTemplate = path.resolve(`src/templates/component.js`)
-const componentNames = ['alert', 'buttons', 'dialog', 'table', 'toaster']
 
 // Implement the Gatsby API “createPages”. This is called once the
 // data layer is bootstrapped to let plugins create pages from data.
 exports.createPages = ({ boundActionCreators }) => {
   const { createPage } = boundActionCreators
 
-  componentNames.forEach(componentName => {
-    const componentPath = `/components/${componentName}`
-
+  componentRoutes.forEach(({ name, path }) => {
     createPage({
-      path: componentPath,
+      path,
       component: componentTemplate,
       // If you have a layout component at src/layouts/blog-layout.js
       // layout: `blog-layout`,
       // In your blog post template's graphql query, you can use path
       // as a GraphQL variable to query for data from the markdown file.
       context: {
-        path: componentPath,
-        name: componentName
+        path,
+        name
       }
     })
   })

--- a/docs/src/componentRoutes.js
+++ b/docs/src/componentRoutes.js
@@ -21,10 +21,11 @@ module.exports = [
   },
   {
     name: 'Layers',
+    sidebarOverride: 'Pane & Card',
     path: '/components/layers'
   }
 ].sort((a, b) => {
   // Lazy way to sort this list so I don't have
   // to sing the alphabet everytime.
-  return b.name - a.name
+  return (b.sidebarOverride || b.name) - (a.sidebarOverride || a.name)
 })

--- a/docs/src/componentRoutes.js
+++ b/docs/src/componentRoutes.js
@@ -1,0 +1,30 @@
+module.exports = [
+  {
+    name: 'Alert',
+    path: '/components/alert'
+  },
+  {
+    name: 'Buttons',
+    path: '/components/buttons'
+  },
+  {
+    name: 'Dialog',
+    path: '/components/dialog'
+  },
+  {
+    name: 'Table',
+    path: '/components/table'
+  },
+  {
+    name: 'Toaster',
+    path: '/components/toaster'
+  },
+  {
+    name: 'Layers',
+    path: '/components/layers'
+  }
+].sort((a, b) => {
+  // Lazy way to sort this list so I don't have
+  // to sing the alphabet everytime.
+  return b.name - a.name
+})

--- a/docs/src/components/ComponentReadme.js
+++ b/docs/src/components/ComponentReadme.js
@@ -8,6 +8,7 @@ import PlaygroundExample from './PlaygroundExample'
 export default class ComponentReadme extends PureComponent {
   static propTypes = {
     name: PropTypes.string,
+    introduction: PropTypes.node,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     designGuidelines: PropTypes.node,
@@ -23,6 +24,7 @@ export default class ComponentReadme extends PureComponent {
       subTitle,
       designGuidelines,
       examples,
+      introduction,
       appearanceOptions,
       components,
       ...props
@@ -45,6 +47,12 @@ export default class ComponentReadme extends PureComponent {
             </p>
           </header>
           <div>
+            {introduction && (
+              <div className="Content">
+                <h2 id="introduction">Introduction</h2>
+                {introduction}
+              </div>
+            )}
             {designGuidelines && (
               <div className="Content">
                 <h2 id="design-guidelines">Design Guidelines</h2>

--- a/docs/src/components/ComponentsSidebar.js
+++ b/docs/src/components/ComponentsSidebar.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import componentRoutes from '../componentRoutes'
 import Sidebar from './Sidebar'
 
 export default class ComponentsSidebar extends PureComponent {
@@ -13,28 +14,12 @@ export default class ComponentsSidebar extends PureComponent {
     groups: [
       {
         title: 'Components',
-        links: [
-          {
-            label: 'Alert',
-            to: '/components/alert'
-          },
-          {
-            label: 'Buttons',
-            to: '/components/buttons'
-          },
-          {
-            label: 'Dialog',
-            to: '/components/dialog'
-          },
-          {
-            label: 'Table',
-            to: '/components/table'
-          },
-          {
-            label: 'Toaster',
-            to: '/components/toaster'
+        links: componentRoutes.map(route => {
+          return {
+            label: route.name,
+            to: route.path
           }
-        ]
+        })
       }
     ]
   }

--- a/docs/src/components/ComponentsSidebar.js
+++ b/docs/src/components/ComponentsSidebar.js
@@ -16,7 +16,7 @@ export default class ComponentsSidebar extends PureComponent {
         title: 'Components',
         links: componentRoutes.map(route => {
           return {
-            label: route.name,
+            label: route.sidebarOverride || route.name,
             to: route.path
           }
         })

--- a/docs/src/templates/component.js
+++ b/docs/src/templates/component.js
@@ -12,6 +12,7 @@ export default class ComponentTemplate extends React.PureComponent {
 
   render() {
     const {
+      introduction,
       designGuidelines,
       appearanceOptions,
       components,
@@ -29,6 +30,7 @@ export default class ComponentTemplate extends React.PureComponent {
               title={title}
               subTitle={subTitle}
               name={this.props.pathContext.name}
+              introduction={introduction}
               designGuidelines={designGuidelines}
               appearanceOptions={appearanceOptions}
               components={components}

--- a/docs/src/templates/component.js
+++ b/docs/src/templates/component.js
@@ -18,7 +18,7 @@ export default class ComponentTemplate extends React.PureComponent {
       title,
       subTitle,
       examples
-    } = getComponent(this.props.pathContext.name)
+    } = getComponent(this.props.pathContext.name.toLowerCase())
 
     return (
       <div className="MainLayout">

--- a/docs/src/utils/getComponent.js
+++ b/docs/src/utils/getComponent.js
@@ -2,7 +2,7 @@
 // Import colorsDocs from '../../src/colors/docs/'
 // import sharedStylesDocs from '../../src/shared-styles/docs/'
 // import typographyDocs from '../../src/typography/docs/'
-// import layersDocs from '../../src/layers/docs/'
+import layersDocs from '../../../src/layers/docs/'
 import buttonsDocs from '../../../src/buttons/docs'
 // Import iconsDocs from '../../src/icons/docs/'
 // import autocompleteDocs from '../../src/autocomplete/docs/'
@@ -34,7 +34,8 @@ const map = {
   table: tableDocs,
   dialog: dialogDocs,
   alert: alertDocs,
-  toaster: toasterDocs
+  toaster: toasterDocs,
+  layers: layersDocs
 }
 
 export default function getComponent(name) {

--- a/src/layers/docs/examples/Card-basic.example
+++ b/src/layers/docs/examples/Card-basic.example
@@ -1,0 +1,13 @@
+<Card
+  innerRef={(ref) => console.log(ref)}
+  elevation={2}
+  border='muted'
+  marginLeft={12}
+  marginY={24}
+  paddingTop={12}
+  paddingX={40}
+  width={120}
+  height={120}
+  cursor='pointer'
+  onClick={() => alert('Works just like expected')}
+/>

--- a/src/layers/docs/examples/Card-elevation-styles.example
+++ b/src/layers/docs/examples/Card-elevation-styles.example
@@ -1,0 +1,73 @@
+<Card clearfix>
+  <Card
+    elevation={0}
+    float="left"
+    backgroundColor="white"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 0</Text>
+    <Text size={300}>Flat Cards</Text>
+  </Card>
+  <Card
+    elevation={1}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 1</Text>
+    <Text size={300}>Floating Cards</Text>
+  </Card>
+  <Card
+    elevation={2}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 2</Text>
+    <Text size={300}>Popovers and Dropdowns</Text>
+  </Card>
+  <Card
+    elevation={3}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 3</Text>
+    <Text size={300}>Toasts</Text>
+  </Card>
+  <Card
+    elevation={4}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 4</Text>
+    <Text size={300}>Dialog</Text>
+  </Card>
+</Card>

--- a/src/layers/docs/examples/Pane-appearances.example
+++ b/src/layers/docs/examples/Pane-appearances.example
@@ -1,0 +1,63 @@
+<Pane clearfix>
+  <Pane
+    appearance="tint1"
+    float="left"
+    width={120}
+    height={120}
+    margin={24}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+  >
+    <Text color="inherit">tint1</Text>
+  </Pane>
+  <Pane
+    appearance="tint2"
+    float="left"
+    width={120}
+    height={120}
+    margin={24}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+  >
+    <Text color="inherit">tint1</Text>
+  </Pane>
+  <Pane
+    appearance="tint3"
+    float="left"
+    width={120}
+    height={120}
+    margin={24}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+  >
+    <Text color="inherit">tint1</Text>
+  </Pane>
+  <Pane
+    appearance="dark"
+    color="white"
+    float="left"
+    width={120}
+    height={120}
+    margin={24}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+  >
+    <Text color="inherit">dark</Text>
+  </Pane>
+  <Pane
+    appearance="selected"
+    float="left"
+    width={120}
+    height={120}
+    margin={24}
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+  >
+    <Text color="inherit">selected</Text>
+  </Pane>
+</Pane>

--- a/src/layers/docs/examples/Pane-basic.example
+++ b/src/layers/docs/examples/Pane-basic.example
@@ -1,0 +1,14 @@
+<Pane
+  is="section"
+  innerRef={(ref) => console.log(ref)}
+  appearance="tint2"
+  border="muted"
+  marginLeft={12}
+  marginY={24}
+  paddingTop={12}
+  paddingX={40}
+  width={120}
+  height={120}
+  cursor="help"
+  onClick={() => alert('Works just like expected')}
+/>

--- a/src/layers/docs/examples/Pane-borders.example
+++ b/src/layers/docs/examples/Pane-borders.example
@@ -1,0 +1,14 @@
+<div>
+  <Pane borderTop width={120} height={120} display='flex' justifyContent='center' alignItems='center'>
+    <Text>borderTop</Text>
+  </Pane>
+  <Pane borderRight width={120} height={120} display='flex' justifyContent='center' alignItems='center'>
+    <Text>borderRight</Text>
+  </Pane>
+  <Pane borderBottom width={120} height={120} display='flex' justifyContent='center' alignItems='center'>
+    <Text>borderBottom</Text>
+  </Pane>
+  <Pane borderLeft width={120} height={120} display='flex' justifyContent='center' alignItems='center'>
+    <Text>borderLeft</Text>
+  </Pane>
+</div>

--- a/src/layers/docs/examples/Pane-elevation-styles.example
+++ b/src/layers/docs/examples/Pane-elevation-styles.example
@@ -1,0 +1,73 @@
+<Pane clearfix>
+  <Pane
+    elevation={0}
+    float="left"
+    backgroundColor="white"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 0</Text>
+    <Text size={300}>Flat Panes</Text>
+  </Pane>
+  <Pane
+    elevation={1}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 1</Text>
+    <Text size={300}>Floating Panes</Text>
+  </Pane>
+  <Pane
+    elevation={2}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 2</Text>
+    <Text size={300}>Popovers and Dropdowns</Text>
+  </Pane>
+  <Pane
+    elevation={3}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 3</Text>
+    <Text size={300}>Toasts</Text>
+  </Pane>
+  <Pane
+    elevation={4}
+    float="left"
+    width={200}
+    height={120}
+    margin={24}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    flexDirection="column"
+  >
+    <Text>Elevation 4</Text>
+    <Text size={300}>Dialog</Text>
+  </Pane>
+</Pane>

--- a/src/layers/docs/index.js
+++ b/src/layers/docs/index.js
@@ -1,0 +1,240 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+import { Text } from '../../typography/'
+import Pane from '../src/Pane'
+import Card from '../src/Card'
+
+/* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
+import sourcePane from '!raw-loader!../src/Pane'
+import sourceCard from '!raw-loader!../src/Card'
+/* eslint-enable import/no-unresolved, import/no-webpack-loader-syntax */
+
+/**
+ * Code examples
+ */
+import examplePaneBasic from './examples/Pane-basic.example'
+import examplePaneElevationStyles from './examples/Pane-elevation-styles.example'
+import examplePaneAppearances from './examples/Pane-appearances.example'
+import exampleCardBasic from './examples/Card-basic.example'
+import exampleCardElevationStyles from './examples/Card-elevation-styles.example'
+
+const title = 'Pane & Card'
+const subTitle = 'Foundational atoms to build layout and components.'
+
+const introduction = (
+  <div>
+    <p>
+      The <code>Pane</code> and <code>Card</code> components are one of the most
+      important components in Evergreen. They are essentially a replacement of
+      the <code>div</code> element. They are used as primitives to construct
+      layouts and compose components.
+    </p>
+
+    <h3>
+      The Relationship to <code>ui-box</code>
+    </h3>
+    <p>
+      The <code>Pane</code> component maps almost directly to the{' '}
+      <code>Box</code> from{' '}
+      <a href="https://github.com/segmentio/ui-box">ui-box</a>. This means you
+      can pass everything to <code>Pane</code> that you can pass to{' '}
+      <code>Box</code>. The <code>Card</code> component simply maps to the{' '}
+      <code>Pane</code> component with a default border-radius.
+    </p>
+
+    <h4>Pass Styles Directly to Pane & Card</h4>
+    <p>
+      Because the <code>Pane</code> component directly maps to a{' '}
+      <code>Box</code> you can pass almost any CSS property directly to the
+      React component. Simply pass a property such as <code>marginTop</code> to
+      the <code>Pane</code> component: <code>{`<Pane marginTop={12} />`}</code>.
+    </p>
+
+    <h4>
+      Other Components Implement the <code>Pane</code> or <code>Box</code>{' '}
+      Component
+    </h4>
+    <p>
+      One of the biggest powers of Evergreen is that a lot of components
+      implement either <code>Box</code> or <code>Pane</code>. Or at least some
+      of the APIs of <code>Box</code> such as <code>dimensions</code> and{' '}
+      <code>spacing</code>.
+    </p>
+
+    <p>
+      In the real world that means you can pass properties such as{' '}
+      <code>marginTop</code>, <code>height</code>, <code>width</code>,{' '}
+      <code>position</code> to almost any smaller component such as{' '}
+      <code>TextInput</code>, <code>Button</code>, <code>SegmentedControl</code>{' '}
+      and many others.
+    </p>
+
+    <h3>Responsive Layouts</h3>
+    <p>
+      Currently there is no opinionated way to construct responsive layouts in
+      Evergreen. In the case of responsive layouts you might want to simply use
+      a <code>div</code> with a class name and use breakpoints in CSS — or
+      potentially a CSS-in-JS solution.
+    </p>
+    <p>
+      In the case when you need to pass properties to a Evergreen component
+      based on the viewport, you can try something like{' '}
+      <a href="https://github.com/ctrlplusb/react-component-queries/issues">
+        react-component-queries
+      </a>.{' '}
+    </p>
+
+    <h3>Never Pass a String of Text as Direct Children</h3>
+    <p>
+      Pane & Card don’t have text styles applied to them. Always pass a{' '}
+      <code>Text</code>, <code>Heading</code> or other typograpghy component as
+      children to Panes & Cards.
+    </p>
+  </div>
+)
+
+const PaneExample = ({ children, ...props }) => {
+  return (
+    <Pane
+      width={120}
+      height={120}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      {...props}
+    >
+      <Text color="inherit">{children}</Text>
+    </Pane>
+  )
+}
+
+PaneExample.propTypes = {
+  children: PropTypes.node
+}
+
+const appearanceOptions = [
+  {
+    title: 'Tint 1',
+    component: <PaneExample appearance="tint1">tint1</PaneExample>,
+    description: (
+      <p>
+        This is the lightest tint and should be used before moving up to{' '}
+        <code>tint2</code>. Evergreen promotes a light user experience as much
+        as possible. When background colors are lighter it increase the dynamic
+        range of the whole experience.
+      </p>
+    )
+  },
+  {
+    title: 'Tint 2',
+    component: <PaneExample appearance="tint2">tint2</PaneExample>,
+    description: <p>Often useful for backgrounds.</p>
+  },
+  {
+    title: 'Tint 3',
+    component: <PaneExample appearance="tint3">tint3</PaneExample>,
+    description: (
+      <p>
+        Useful when you are have a Pane or Card layered on top that is using{' '}
+        <code>tint2</code>. Use sparingly.
+      </p>
+    )
+  },
+  {
+    title: 'Dark',
+    component: (
+      <PaneExample appearance="dark" color="white">
+        dark
+      </PaneExample>
+    ),
+    description: (
+      <p>This is rarely used. Might become depracted in the future.</p>
+    )
+  },
+  {
+    title: 'Selected',
+    component: <PaneExample appearance="selected">selected</PaneExample>,
+    description: <p>This is to create a big selected Card. Rarely used.</p>
+  }
+]
+
+const scope = {
+  Box,
+  Pane,
+  Text,
+  Card
+}
+
+const components = [
+  {
+    name: 'Pane',
+    source: sourcePane,
+    description: (
+      <div>
+        <p>
+          The <code>Pane</code> component maps almost directly to the{' '}
+          <code>Box</code> from{' '}
+          <a href="https://github.com/segmentio/ui-box">ui-box</a>. This means
+          you can pass everything to <code>Pane</code> that you can pass to{' '}
+          <code>Box</code>.
+        </p>
+        <p>
+          Because the <code>Pane</code> component directly maps to a{' '}
+          <code>Box</code> you can pass almost any CSS property directly to the
+          React component. Simply pass a property such as <code>marginTop</code>{' '}
+          to the <code>Pane</code> component:{' '}
+          <code>{`<Pane marginTop={12} />`}</code>.
+        </p>
+      </div>
+    ),
+    examples: [
+      {
+        title: 'Basic Pane Example',
+        codeText: examplePaneBasic,
+        scope
+      },
+      {
+        title: 'Pane Elevation Styles',
+        codeText: examplePaneElevationStyles,
+        scope
+      },
+      {
+        title: 'Pane Appearances',
+        codeText: examplePaneAppearances,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Card',
+    source: sourceCard,
+    description: (
+      <p>
+        The <code>Card</code> component maps directly to a <code>Pane</code>{' '}
+        component. The only difference is that it sets a border-radius of 5px by
+        default.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Card Example',
+        codeText: exampleCardBasic,
+        scope
+      },
+      {
+        title: 'Card Elevation Styles',
+        codeText: exampleCardElevationStyles,
+        scope
+      }
+    ]
+  }
+]
+
+export default {
+  title,
+  subTitle,
+  introduction,
+  appearanceOptions,
+  components
+}

--- a/src/layers/src/Pane.js
+++ b/src/layers/src/Pane.js
@@ -16,19 +16,63 @@ const StringAndBoolPropType = PropTypes.oneOfType([
 
 export default class Pane extends PureComponent {
   static propTypes = {
+    /**
+     * Composes the Box component as the base.
+     */
     ...Box.propTypes,
 
+    /**
+     * The appearance of the Pane.
+     * Values: tint1, tint2, tint3, selected, dark.
+     */
     appearance: PropTypes.oneOf(Object.keys(LayerAppearances)),
 
+    /**
+     * Elevation of the Pane.
+     * Values: 0, 1, 2, 3, 4.
+     */
     elevation: ElevationPropType,
+
+    /**
+     * Elevation of the Pane on hover. Might get deprecated.
+     * Values: 0, 1, 2, 3, 4.
+     */
     hoverElevation: ElevationPropType,
+
+    /**
+     * Elevation of the Pane on click. Might get deprecated.
+     * Values: 0, 1, 2, 3, 4.
+     */
     activeElevation: ElevationPropType,
 
-    // Enable to set a boolean for a default border
+    /**
+     * Can be a explicit border value or a boolean.
+     * Values: true, extraMuted, muted, default.
+     */
     border: StringAndBoolPropType,
+
+    /**
+     * Can be a explicit border value or a boolean.
+     * Values: true, extraMuted, muted, default.
+     */
     borderTop: StringAndBoolPropType,
+
+    /**
+     * Can be a explicit border value or a boolean.
+     * Values: true, extraMuted, muted, default.
+     */
     borderRight: StringAndBoolPropType,
+
+    /**
+     * Can be a explicit border value or a boolean.
+     * Values: true, extraMuted, muted, default.
+     */
     borderBottom: StringAndBoolPropType,
+
+    /**
+     * Can be a explicit border value or a boolean.
+     * Values: true, extraMuted, muted, default.
+     */
     borderLeft: StringAndBoolPropType
   }
 

--- a/tools/docs-index-template.js
+++ b/tools/docs-index-template.js
@@ -42,7 +42,7 @@ function getComponents(componentNames) {
         scope,
       },
     ],
-  },
+  }
   `
   )
 }


### PR DESCRIPTION
This PR implements documentation for Panes and Cards. See it live here: http://evergreen.surge.sh/components/layers

I am doing somewhat of a hack to make `Pane & Card` appear in the docs instead of `Layers`. I don't think it should be a blocker.

![layer docs](https://user-images.githubusercontent.com/564463/37176541-840abb8c-22d1-11e8-830b-72fee17f615d.gif)


