### PR TITLE
Docs typography

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,8 @@
     "react-docgen": "next",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",
-    "react-live": "^1.7.1"
+    "react-live": "^1.7.1",
+    "react-syntax-highlighter": "^7.0.2"
   },
   "devDependencies": {
     "prettier": "^1.10.2"

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,17 +7,17 @@
     "build": "gatsby build"
   },
   "dependencies": {
-    "gatsby": "^1.9.127",
+    "gatsby": "1.9.166",
     "gatsby-link": "^1.6.30",
     "gatsby-plugin-react-helmet": "^2.0.2",
     "gatsby-plugin-react-next": "^1.0.6",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
-    "react-docgen": "next",
+    "react-docgen": "^3.0.0-beta11",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",
-    "react-live": "^1.7.1",
+    "react-live": "v1.10.1",
     "react-syntax-highlighter": "^7.0.2"
   },
   "devDependencies": {

--- a/docs/src/componentRoutes.js
+++ b/docs/src/componentRoutes.js
@@ -23,9 +23,13 @@ module.exports = [
     name: 'Layers',
     sidebarOverride: 'Pane & Card',
     path: '/components/layers'
+  },
+  {
+    name: 'Typography',
+    path: '/components/typography'
   }
 ].sort((a, b) => {
   // Lazy way to sort this list so I don't have
   // to sing the alphabet everytime.
-  return (b.sidebarOverride || b.name) - (a.sidebarOverride || a.name)
+  return (b.sidebarOverride || b.name) > (a.sidebarOverride || a.name) ? -1 : 1
 })

--- a/docs/src/components/ComponentReadme.js
+++ b/docs/src/components/ComponentReadme.js
@@ -12,6 +12,7 @@ export default class ComponentReadme extends PureComponent {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     designGuidelines: PropTypes.node,
+    implementationDetails: PropTypes.node,
     appearanceOptions: PropTypes.array,
     examples: PropTypes.array,
     components: PropTypes.array
@@ -25,6 +26,7 @@ export default class ComponentReadme extends PureComponent {
       designGuidelines,
       examples,
       introduction,
+      implementationDetails,
       appearanceOptions,
       components,
       ...props
@@ -57,6 +59,12 @@ export default class ComponentReadme extends PureComponent {
               <div className="Content">
                 <h2 id="design-guidelines">Design Guidelines</h2>
                 {designGuidelines}
+              </div>
+            )}
+            {implementationDetails && (
+              <div className="Content">
+                <h2 id="implementation-details">Implementation Details</h2>
+                {implementationDetails}
               </div>
             )}
             {appearanceOptions && (

--- a/docs/src/components/SyntaxHighlighter.js
+++ b/docs/src/components/SyntaxHighlighter.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import SyntaxHighlighter, {
+  registerLanguage
+} from 'react-syntax-highlighter/prism-light'
+import jsx from 'react-syntax-highlighter/languages/prism/jsx'
+import prism from 'react-syntax-highlighter/styles/prism/prism'
+
+registerLanguage('jsx', jsx)
+
+export default class SyntaxHighlighterComponent extends React.Component {
+  static propTypes = {
+    children: PropTypes.string
+  }
+
+  render() {
+    const { children, ...props } = this.props
+    return (
+      <SyntaxHighlighter language="javascript" style={prism} {...props}>
+        {children}
+      </SyntaxHighlighter>
+    )
+  }
+}

--- a/docs/src/components/prop-types-table/index.js
+++ b/docs/src/components/prop-types-table/index.js
@@ -17,7 +17,13 @@ export default class PropTypesTable extends PureComponent {
     // Parsing the componentSrc is expensive, so we cache it in state rather than
     // computing it every time the component is rendered. Note the
     // componentWillReceiveProps method below where it is re-parsed as required.
-    const componentDocs = reactDocs.parse(props.componentSource)
+    let componentDocs
+    try {
+      componentDocs = reactDocs.parse(props.componentSource)
+    } catch (err) {
+      // Gatsby build is having some issues atm.
+      console.log('Error in react-docgen parse', err)
+    }
     this.state = { componentDocs }
   }
 
@@ -31,7 +37,7 @@ export default class PropTypesTable extends PureComponent {
   render() {
     const { componentDocs } = this.state
     let propTypes
-    if (Object.hasOwnProperty.call(componentDocs, 'props')) {
+    if (Object.hasOwnProperty.call(componentDocs || {}, 'props')) {
       propTypes = Object.keys(componentDocs.props)
     }
 
@@ -39,7 +45,8 @@ export default class PropTypesTable extends PureComponent {
       <div>
         <div className="Content">
           <h3>Props</h3>
-          {componentDocs.composes &&
+          {componentDocs &&
+            componentDocs.composes &&
             componentDocs.composes.length > 0 && (
               <div className="PropTypesTable-composes">
                 <p>

--- a/docs/src/components/prop-types-table/index.js
+++ b/docs/src/components/prop-types-table/index.js
@@ -58,7 +58,6 @@ export default class PropTypesTable extends PureComponent {
           propTypes.map(propName => {
             const prop = componentDocs.props[propName]
             // Figure out what makes sense here.
-            // const value = (prop.type || {}).value
             return (
               <PropTypeWrapper key={propName}>
                 <PropTypeHeading
@@ -67,6 +66,12 @@ export default class PropTypesTable extends PureComponent {
                   defaultValue={prop.defaultValue}
                   type={prop.type || {}}
                 />
+                {prop.type &&
+                  typeof prop.type.value === 'string' && (
+                    <div className="PropTypeTypeValue Content">
+                      Value type: <code>{prop.type.value}</code>
+                    </div>
+                  )}
                 {prop.description ? (
                   <PropTypeDescription>{prop.description}</PropTypeDescription>
                 ) : null}

--- a/docs/src/css/content.css
+++ b/docs/src/css/content.css
@@ -114,7 +114,7 @@
   }
 
   & pre:not(.prism-code) {
-    background-color: var(--turquoise-15A);
+    background-color: var(--neutral-10A);
     padding: 16px;
     overflow-x: auto;
 

--- a/docs/src/css/prop-type-table.css
+++ b/docs/src/css/prop-type-table.css
@@ -55,3 +55,9 @@
 .PropTypeDescription {
   margin-bottom: 8px;
 }
+
+.PropTypeTypeValue {
+  padding-bottom: 4px;
+  border-bottom: 2px solid var(--neutral-5A);
+  margin-bottom: 4px;
+}

--- a/docs/src/pages/get-started/introduction.js
+++ b/docs/src/pages/get-started/introduction.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import TopBar from '../../components/TopBar'
 import GetStartedSidebar from '../../components/GetStartedSidebar'
+import SyntaxHighlighter from '../../components/SyntaxHighlighter'
 
 const NativeLink = ({ ...props }) => {
   return <a target="_blank" rel="noopener noreferrer" {...props} />
@@ -78,9 +79,8 @@ $ npm install --save evergreen-ui
                 </NativeLink>, might look like this:
               </p>
 
-              <pre>
-                <code>
-                  {`
+              <SyntaxHighlighter>
+                {`
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Button } from 'evergreen-ui'
@@ -90,8 +90,7 @@ ReactDOM.render(
   document.getElementById('root')
 )
                 `.trim()}
-                </code>
-              </pre>
+              </SyntaxHighlighter>
             </div>
           </section>
         </div>

--- a/docs/src/templates/component.js
+++ b/docs/src/templates/component.js
@@ -14,6 +14,7 @@ export default class ComponentTemplate extends React.PureComponent {
     const {
       introduction,
       designGuidelines,
+      implementationDetails,
       appearanceOptions,
       components,
       title,
@@ -31,6 +32,7 @@ export default class ComponentTemplate extends React.PureComponent {
               subTitle={subTitle}
               name={this.props.pathContext.name}
               introduction={introduction}
+              implementationDetails={implementationDetails}
               designGuidelines={designGuidelines}
               appearanceOptions={appearanceOptions}
               components={components}

--- a/docs/src/utils/getComponent.js
+++ b/docs/src/utils/getComponent.js
@@ -1,7 +1,7 @@
 /* eslint-disable capitalized-comments */
 // Import colorsDocs from '../../src/colors/docs/'
 // import sharedStylesDocs from '../../src/shared-styles/docs/'
-// import typographyDocs from '../../src/typography/docs/'
+import typographyDocs from '../../../src/typography/docs/'
 import layersDocs from '../../../src/layers/docs/'
 import buttonsDocs from '../../../src/buttons/docs'
 // Import iconsDocs from '../../src/icons/docs/'
@@ -35,7 +35,8 @@ const map = {
   dialog: dialogDocs,
   alert: alertDocs,
   toaster: toasterDocs,
-  layers: layersDocs
+  layers: layersDocs,
+  typography: typographyDocs
 }
 
 export default function getComponent(name) {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
 "@types/history@*", "@types/history@^4.6.2":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
@@ -22,47 +29,47 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "16.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.38.tgz#76617433ea10274505f60bb86eddfdd0476ffdc2"
+  version "16.0.40"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.40.tgz#caabc2296886f40b67f6fc80f0f3464476461df9"
 
-"@zeit/check-updates@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@zeit/check-updates/-/check-updates-1.0.5.tgz#3ac40afe270a0cc646a279b629698a77ad4543c6"
+"@zeit/check-updates@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@zeit/check-updates/-/check-updates-1.1.0.tgz#d0f65026a36f27cd1fd54c647d8294447c1d2d8b"
   dependencies:
-    chalk "^2.3.0"
-    ms "^2.1.1"
-    update-notifier "^2.3.0"
+    chalk "2.3.0"
+    ms "2.1.1"
+    update-notifier "2.3.0"
 
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 accepts@^1.3.0, accepts@~1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
-    mime-types "~2.1.16"
+    mime-types "~2.1.18"
     negotiator "0.6.1"
 
-acorn-jsx@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
   dependencies:
-    acorn "^3.0.4"
+    acorn "^5.0.0"
 
-acorn5-object-spread@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz#d5758081eed97121ab0be47e31caaef2aa399697"
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   dependencies:
-    acorn "^5.1.2"
+    acorn "^5.0.3"
 
-acorn@^3.0.0, acorn@^3.0.4:
+acorn@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.1.2:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+acorn@^5.0.0, acorn@^5.0.3, acorn@^5.4.1:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -130,9 +137,9 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0, ansi-styles@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+ansi-styles@^3.1.0, ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -288,7 +295,7 @@ ast-types@0.10.2:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.2.tgz#aef76a04fde54634976fc94defaad1a67e2eadb0"
 
-async-each@^1.0.0, async-each@^1.0.1:
+async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
@@ -377,7 +384,7 @@ babel-core@^6.24.1, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-generator@^6.24.1, babel-generator@^6.26.0:
+babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
@@ -1141,7 +1148,7 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.40:
+babylon@7.0.0-beta.40, babylon@^7.0.0-beta:
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
 
@@ -1200,25 +1207,6 @@ base@^0.11.1:
 basename@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/basename/-/basename-0.1.2.tgz#d6039bef939863160c78048cced3c5e7f88cb261"
-
-bash-glob@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bash-glob/-/bash-glob-1.0.2.tgz#95ac5631fdd7a8fc569f267167a84eb831979a1b"
-  dependencies:
-    async-each "^1.0.1"
-    bash-path "^1.0.1"
-    component-emitter "^1.2.1"
-    cross-spawn "^5.1.0"
-    extend-shallow "^2.0.1"
-    is-extglob "^2.1.1"
-    is-glob "^4.0.0"
-
-bash-path@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/bash-path/-/bash-path-1.0.3.tgz#dbc9efbdf18b1c11413dcb59b960e6aa56c84258"
-  dependencies:
-    arr-union "^3.1.0"
-    is-windows "^1.0.1"
 
 basic-auth@2.0.0:
   version "2.0.0"
@@ -1455,18 +1443,18 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buble@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/buble/-/buble-0.18.0.tgz#63b338b8248c474b46fd3e3546560ae08d8abe91"
+buble@^0.19.3:
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/buble/-/buble-0.19.3.tgz#01e9412062cff1da6f20342b6ecd72e7bf699d02"
   dependencies:
-    acorn "^5.1.2"
-    acorn-jsx "^3.0.1"
-    acorn5-object-spread "^4.0.0"
-    chalk "^2.1.0"
+    acorn "^5.4.1"
+    acorn-dynamic-import "^3.0.0"
+    acorn-jsx "^4.1.1"
+    chalk "^2.3.1"
     magic-string "^0.22.4"
     minimist "^1.2.0"
     os-homedir "^1.0.1"
-    vlq "^0.2.2"
+    vlq "^1.0.0"
 
 buffer-alloc-unsafe@^0.1.0:
   version "0.1.1"
@@ -1555,12 +1543,12 @@ caniuse-api@^1.5.2, caniuse-api@^1.5.3:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000810"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000810.tgz#bd25830c41efab64339a2e381f49677343c84509"
+  version "1.0.30000813"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000813.tgz#e0a1c603f8880ad787b2a35652b2733f32a5e29a"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000810"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz#47585fffce0e9f3593a6feea4673b945424351d9"
+  version "1.0.30000813"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz#7b25e27fdfb8d133f3c932b01f77452140fcc6c9"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1603,13 +1591,13 @@ chalk@2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+chalk@2.3.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
-    ansi-styles "^3.2.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^5.2.0"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -1721,9 +1709,9 @@ clipboard@^2.0.0:
     select "^1.1.2"
     tiny-emitter "^2.0.0"
 
-clipboardy@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.2.tgz#2ce320b9ed9be1514f79878b53ff9765420903e2"
+clipboardy@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.3.tgz#0526361bf78724c1f20be248d428e365433c07ef"
   dependencies:
     arch "^2.1.0"
     execa "^0.8.0"
@@ -1839,8 +1827,8 @@ commander@2.9.0, commander@2.9.x:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.9.0:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
 
 common-tags@0.1.1:
   version "0.1.1"
@@ -2296,7 +2284,7 @@ depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
-depd@~1.1.1:
+depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -2468,8 +2456,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
-  version "1.3.33"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz#bf00703d62a7c65238136578c352d6c5c042a545"
+  version "1.3.37"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.37.tgz#4a92734e0044c8cf0b1553be57eae21a4c6e5fab"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2487,7 +2475,7 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-encodeurl@~1.0.1:
+encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
@@ -2504,8 +2492,8 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
     once "^1.4.0"
 
 engine.io-client@~3.1.0:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.5.tgz#85de17666560327ef1817978f6e3f8101ded2c47"
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.6.tgz#5bdeb130f8b94a50ac5cbeb72583e7a4a063ddfd"
   dependencies:
     component-emitter "1.2.1"
     component-inherit "0.0.3"
@@ -2583,8 +2571,8 @@ error-stack-parser@^2.0.0:
     stackframe "^1.0.3"
 
 es5-ext@^0.10.12, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.39"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.39.tgz#fca21b67559277ca4ac1a1ed7048b107b6f76d87"
+  version "0.10.40"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.40.tgz#ab3d2179b943008c5e9ef241beb25ef41424c774"
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
@@ -2596,10 +2584,6 @@ es6-iterator@~2.0.3:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
-
-es6-promise@^4.1.0:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
@@ -2848,25 +2832,22 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
-fast-glob@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-1.0.1.tgz#30f9b1120fd57a7f172364a6458fbdbd98187b3c"
+fast-glob@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.0.tgz#e9d032a69b86bef46fc03d935408f02fb211d9fc"
   dependencies:
-    bash-glob "^1.0.1"
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
     glob-parent "^3.1.0"
-    micromatch "^3.0.3"
-    readdir-enhanced "^1.5.2"
+    is-glob "^4.0.0"
+    merge2 "^1.2.1"
+    micromatch "^3.1.8"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-
-fast-levenshtein@~2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
 fastparse@^1.1.1:
   version "1.1.1"
@@ -2921,6 +2902,10 @@ filename-regex@^2.0.0:
 filesize@3.5.11:
   version "3.5.11"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
+
+filesize@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.0.tgz#22d079615624bb6fd3c04026120628a41b3f4efa"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -3139,15 +3124,15 @@ function-bind@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
-gatsby-1-config-css-modules@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/gatsby-1-config-css-modules/-/gatsby-1-config-css-modules-1.0.9.tgz#ae7ebffcaea4b1cc821951b71c123107d697bfaa"
+gatsby-1-config-css-modules@^1.0.8:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/gatsby-1-config-css-modules/-/gatsby-1-config-css-modules-1.0.10.tgz#56967add247213d56167715539229afe39d4ccf6"
   dependencies:
     babel-runtime "^6.26.0"
 
-gatsby-cli@^1.1.40:
-  version "1.1.40"
-  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-1.1.40.tgz#6d81d245092f1eb983a2c3015875c3750c7d7db8"
+gatsby-cli@^1.1.29:
+  version "1.1.45"
+  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-1.1.45.tgz#d68f780bc861130c9afe7dae7cd5bdb665b0f05a"
   dependencies:
     babel-code-frame "^6.26.0"
     babel-runtime "^6.26.0"
@@ -3167,9 +3152,9 @@ gatsby-cli@^1.1.40:
     yargs "^8.0.2"
     yurnalist "^0.2.1"
 
-gatsby-link@^1.6.30, gatsby-link@^1.6.37:
-  version "1.6.37"
-  resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-1.6.37.tgz#d132290c0239dc2e11a9106353c586f969194673"
+gatsby-link@^1.6.30, gatsby-link@^1.6.34:
+  version "1.6.39"
+  resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-1.6.39.tgz#4189d26a66476b61fb524c2c8dd97b74aee728d4"
   dependencies:
     "@types/history" "^4.6.2"
     "@types/react-router-dom" "^4.2.2"
@@ -3177,39 +3162,39 @@ gatsby-link@^1.6.30, gatsby-link@^1.6.37:
     prop-types "^15.5.8"
     ric "^1.3.0"
 
-gatsby-module-loader@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/gatsby-module-loader/-/gatsby-module-loader-1.0.10.tgz#32560de487ea5523097917bc1dc76b9a1247bbe9"
+gatsby-module-loader@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/gatsby-module-loader/-/gatsby-module-loader-1.0.11.tgz#35f269456f6a6d85c693bdc2b3b3b3432987f55b"
   dependencies:
     babel-runtime "^6.26.0"
     loader-utils "^0.2.16"
 
 gatsby-plugin-react-helmet@^2.0.2:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-2.0.5.tgz#cb63ca1c9b6004a1214190cfbe1d241727b1b7d5"
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-2.0.7.tgz#f2d7836147f28cd3d3a7eae82b5ac6978c4c5e34"
   dependencies:
     babel-runtime "^6.26.0"
 
 gatsby-plugin-react-next@^1.0.6:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-next/-/gatsby-plugin-react-next-1.0.9.tgz#c5963eb10cfcc3225c66f82432eb4413b71a2729"
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-next/-/gatsby-plugin-react-next-1.0.11.tgz#715cab5ea86f64664f96af3e7f3640eecd9de5e3"
   dependencies:
     babel-runtime "^6.26.0"
     core-js "^2.5.1"
     react "^16.0.0"
     react-dom "^16.0.0"
 
-gatsby-react-router-scroll@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.11.tgz#1ad3bdfc7f0a897abf24e4d89111ee49de516691"
+gatsby-react-router-scroll@^1.0.8:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.13.tgz#d1cfd43c334497ad174ae9409c24bb5d4dcda3aa"
   dependencies:
     babel-runtime "^6.26.0"
     scroll-behavior "^0.9.9"
     warning "^3.0.0"
 
-gatsby@^1.9.127:
-  version "1.9.203"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.203.tgz#de632e1faace1a9a0d1d99f0430739784c4260a0"
+gatsby@1.9.166:
+  version "1.9.166"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.166.tgz#556e7c3450b7cbb674ca03c776eda598d073d493"
   dependencies:
     async "^2.1.2"
     babel-code-frame "^6.22.0"
@@ -3243,21 +3228,20 @@ gatsby@^1.9.127:
     express "^4.14.0"
     express-graphql "^0.6.6"
     extract-text-webpack-plugin "^1.0.1"
-    fast-levenshtein "~2.0.4"
     file-loader "^0.9.0"
     flat "^2.0.1"
     friendly-errors-webpack-plugin "^1.6.1"
     front-matter "^2.1.0"
     fs-extra "^4.0.1"
-    gatsby-1-config-css-modules "^1.0.9"
-    gatsby-cli "^1.1.40"
-    gatsby-link "^1.6.37"
-    gatsby-module-loader "^1.0.10"
-    gatsby-react-router-scroll "^1.0.11"
+    gatsby-1-config-css-modules "^1.0.8"
+    gatsby-cli "^1.1.29"
+    gatsby-link "^1.6.34"
+    gatsby-module-loader "^1.0.9"
+    gatsby-react-router-scroll "^1.0.8"
     glob "^7.1.1"
     graphql "^0.11.7"
     graphql-relay "^0.5.1"
-    graphql-skip-limit "^1.0.10"
+    graphql-skip-limit "^1.0.9"
     history "^4.6.2"
     invariant "^2.2.2"
     is-relative "^0.2.1"
@@ -3298,7 +3282,6 @@ gatsby@^1.9.127:
     relay-compiler "^1.4.1"
     remote-redux-devtools "^0.5.7"
     serve "^6.4.0"
-    shallow-compare "^1.2.2"
     sift "^3.2.6"
     signal-exit "^3.0.2"
     slash "^1.0.0"
@@ -3308,7 +3291,6 @@ gatsby@^1.9.127:
     style-loader "^0.13.0"
     type-of "^2.0.1"
     url-loader "^0.5.7"
-    uuid "^3.1.0"
     v8-compile-cache "^1.1.0"
     webpack "^1.13.3"
     webpack-configurator "^0.3.0"
@@ -3515,18 +3497,24 @@ graphql-relay@^0.5.1:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
 
-graphql-skip-limit@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/graphql-skip-limit/-/graphql-skip-limit-1.0.10.tgz#0923b8b2e333cfc5d47283fa3e376657a1378452"
+graphql-skip-limit@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/graphql-skip-limit/-/graphql-skip-limit-1.0.11.tgz#c6970d11bdfe7aa001f96c8ba41b9a93a6dc805c"
   dependencies:
     babel-runtime "^6.26.0"
     graphql "^0.11.7"
 
-graphql@^0.11.3, graphql@^0.11.7:
+graphql@^0.11.7:
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
   dependencies:
     iterall "1.1.3"
+
+graphql@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.1.tgz#9b3db3d8e40d1827e4172404bfdd2e4e17a58b55"
+  dependencies:
+    iterall "^1.2.0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -3731,8 +3719,8 @@ homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
 
 html-comment-regex@^1.1.0:
   version "1.1.1"
@@ -3772,8 +3760,8 @@ http-errors@1.6.2, http-errors@^1.3.0, http-errors@~1.6.2:
     statuses ">= 1.3.1 < 2"
 
 http-parser-js@>=0.4.0:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.11.tgz#5b720849c650903c27e521633d94696ee95f3529"
 
 http-proxy-middleware@~0.17.1:
   version "0.17.4"
@@ -4256,6 +4244,10 @@ iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
+iterall@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+
 joi@12.x.x:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
@@ -4283,8 +4275,8 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.10.0, js-yaml@^3.5.2:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4296,7 +4288,7 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-jsan@^3.1.0, jsan@^3.1.5:
+jsan@^3.1.5, jsan@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.9.tgz#2705676c1058f0a7d9ac266ad036a5769cfa7c96"
 
@@ -4533,8 +4525,8 @@ locate-path@^2.0.0:
     path-exists "^3.0.0"
 
 lodash-es@^4.2.1:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.5.tgz#9fc6e737b1c4d151d8f9cae2247305d552ce748f"
+  version "4.17.7"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.7.tgz#db240a3252c3dd8360201ac9feef91ac977ea856"
 
 lodash-id@^0.14.0:
   version "0.14.0"
@@ -4692,8 +4684,8 @@ lowlight@~1.9.1:
     highlight.js "~9.12.0"
 
 lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -4797,6 +4789,10 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge2@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.1.tgz#271d2516ff52d4af7f7b710b8bf3e16e183fef66"
+
 merge@^1.1.3, merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -4838,9 +4834,9 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.3, micromatch@^3.0.4:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.6.tgz#8d7c043b48156f408ca07a4715182b79b99420bf"
+micromatch@^3.0.4, micromatch@^3.1.8:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -4867,7 +4863,7 @@ miller-rabin@^4.0.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@2.1.18, mime-types@^2.1.12, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
+mime-types@2.1.18, mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
@@ -4945,8 +4941,8 @@ mixin-deep@^1.2.0:
     minimist "0.0.8"
 
 moment@2.x.x, moment@^2.16.0:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 mri@1.1.0:
   version "1.1.0"
@@ -4956,7 +4952,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.1.1:
+ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -4965,8 +4961,8 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -5282,7 +5278,7 @@ opn@5.1.0:
   dependencies:
     is-wsl "^1.1.0"
 
-opn@^5.1.0:
+opn@5.2.0, opn@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.2.0.tgz#71fdf934d6827d676cecbea1531f95d354641225"
   dependencies:
@@ -6106,8 +6102,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
 pretty-error@^2.1.1:
   version "2.1.1"
@@ -6116,13 +6112,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-prismjs@^1.6.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.11.0.tgz#297aef33eb79421bfdb19273a5092ca515970d29"
-  optionalDependencies:
-    clipboard "^1.7.1"
-
-prismjs@^1.8.4:
+prismjs@^1.6.0, prismjs@^1.8.4:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.12.2.tgz#a40a6cd5bf36716e316cb75df91976a7d5d694e6"
   optionalDependencies:
@@ -6163,8 +6153,8 @@ promise@^7.1.1:
     asap "~2.0.3"
 
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
@@ -6335,7 +6325,7 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-docgen@next:
+react-docgen@^3.0.0-beta11:
   version "3.0.0-beta11"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-3.0.0-beta11.tgz#a4e51b87d93bab73cded48f1336b2bcccab4f23d"
   dependencies:
@@ -6388,11 +6378,11 @@ react-hot-loader@^3.0.0-beta.6:
     redbox-react "^1.3.6"
     source-map "^0.6.1"
 
-react-live@^1.7.1:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.9.2.tgz#40b2762c980d63bed909deeb0c0aa00c6298d9e6"
+react-live@v1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.10.1.tgz#3736be3e8281e455b3cca781506813c55abed011"
   dependencies:
-    buble "^0.18.0"
+    buble "^0.19.3"
     core-js "^2.4.1"
     dom-iterator "^1.0.0"
     prismjs "^1.6.0"
@@ -6429,8 +6419,8 @@ react-router@^4.1.1, react-router@^4.2.0:
     warning "^3.0.0"
 
 react-side-effect@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.3.tgz#512c25abe0dec172834c4001ec5c51e04d41bc5c"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
@@ -6516,8 +6506,8 @@ readable-stream@1.0, readable-stream@~1.0.31:
     string_decoder "~0.10.x"
 
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -6526,14 +6516,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
-
-readdir-enhanced@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz#61463048690ac6a455b75b62fa78a88f8dc85e53"
-  dependencies:
-    call-me-maybe "^1.0.1"
-    es6-promise "^4.1.0"
-    glob-to-regexp "^0.3.0"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -6589,8 +6571,8 @@ reduce-function-call@^1.0.1:
     balanced-match "^0.4.2"
 
 redux-devtools-instrument@^1.3.3:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.2.tgz#5e91cfe402e790dae3fd2f0d235f7b7d84b09ffe"
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.3.tgz#c510d67ab4e5e4525acd6e410c25ab46b85aca7c"
   dependencies:
     lodash "^4.2.0"
     symbol-observable "^1.0.2"
@@ -6637,7 +6619,7 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
-regex-not@^1.0.0:
+regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
   dependencies:
@@ -6684,37 +6666,32 @@ regjsparser@^0.1.4:
     jsesc "~0.5.0"
 
 relay-compiler@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-1.4.1.tgz#10e83f0f5de8db3d000851a4c0e435e7dd1deb95"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-1.5.0.tgz#564f1582c549fa6b4af9d9f09dadb5e239c11055"
   dependencies:
-    babel-generator "^6.24.1"
+    babel-generator "^6.26.0"
     babel-polyfill "^6.20.0"
     babel-preset-fbjs "^2.1.4"
     babel-runtime "^6.23.0"
     babel-traverse "^6.26.0"
     babel-types "^6.24.1"
-    babylon "^6.18.0"
+    babylon "^7.0.0-beta"
     chalk "^1.1.1"
-    fast-glob "^1.0.1"
+    fast-glob "^2.0.0"
     fb-watchman "^2.0.0"
     fbjs "^0.8.14"
-    graphql "^0.11.3"
+    graphql "^0.13.0"
     immutable "~3.7.6"
-    relay-runtime "1.4.1"
+    relay-runtime "1.5.0"
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-relay-debugger-react-native-runtime@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/relay-debugger-react-native-runtime/-/relay-debugger-react-native-runtime-0.0.10.tgz#0ef36012a1fba928962205514b46f635c652f235"
-
-relay-runtime@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-1.4.1.tgz#f88dcd0a422700a04563f291f570e4ce368e36d0"
+relay-runtime@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-1.5.0.tgz#95e7c26f95f216370f7d699290238a4d966a915c"
   dependencies:
     babel-runtime "^6.23.0"
     fbjs "^0.8.14"
-    relay-debugger-react-native-runtime "0.0.10"
 
 remote-redux-devtools@^0.5.7:
   version "0.5.12"
@@ -6728,10 +6705,10 @@ remote-redux-devtools@^0.5.7:
     socketcluster-client "^5.3.1"
 
 remotedev-serialize@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.0.tgz#074768e98cb7aa806f45994eeb0c8af95120ee32"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.1.tgz#0f598000b7dd7515d67f9b51a61d211e18ce9554"
   dependencies:
-    jsan "^3.1.0"
+    jsan "^3.1.9"
 
 remotedev-utils@^0.1.1:
   version "0.1.4"
@@ -7052,6 +7029,24 @@ send@0.16.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+send@0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.6.2"
+    mime "1.4.1"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.4.0"
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -7074,19 +7069,19 @@ serve-static@1.13.1:
     send "0.16.1"
 
 serve@^6.4.0:
-  version "6.4.11"
-  resolved "https://registry.yarnpkg.com/serve/-/serve-6.4.11.tgz#53ad2cae2cdd164dba5602616dc82f5c9abab211"
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/serve/-/serve-6.5.2.tgz#b6030a82c3f5597813f231f75abc29536bb098f9"
   dependencies:
-    "@zeit/check-updates" "1.0.5"
+    "@zeit/check-updates" "1.1.0"
     args "3.0.8"
     basic-auth "2.0.0"
     bluebird "3.5.1"
     boxen "1.3.0"
-    chalk "2.3.0"
-    clipboardy "1.2.2"
+    chalk "2.3.2"
+    clipboardy "1.2.3"
     dargs "5.1.0"
     detect-port "1.2.2"
-    filesize "3.5.11"
+    filesize "3.6.0"
     fs-extra "5.0.0"
     handlebars "4.0.11"
     ip "1.1.5"
@@ -7095,10 +7090,10 @@ serve@^6.4.0:
     mime-types "2.1.18"
     node-version "1.1.0"
     openssl-self-signed-certificate "1.1.6"
-    opn "5.1.0"
+    opn "5.2.0"
     path-is-inside "1.0.2"
     path-type "3.0.0"
-    send "0.16.1"
+    send "0.16.2"
 
 set-blocking@^1.0.0:
   version "1.0.0"
@@ -7158,10 +7153,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-shallow-compare@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/shallow-compare/-/shallow-compare-1.2.2.tgz#fa4794627bf455a47c4f56881d8a6132d581ffdb"
 
 shallowequal@^1.0.1:
   version "1.0.2"
@@ -7276,11 +7267,11 @@ socket.io-client@2.0.4:
     to-array "0.1.4"
 
 socket.io-parser@~3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.1.2.tgz#dbc2282151fc4faebbe40aeedc0772eba619f7f2"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.1.3.tgz#ed2da5ee79f10955036e3da413bfd7f1e4d86c8e"
   dependencies:
     component-emitter "1.2.1"
-    debug "~2.6.4"
+    debug "~3.1.0"
     has-binary2 "~1.0.2"
     isarray "2.0.1"
 
@@ -7408,19 +7399,27 @@ space-separated-tokens@^1.0.0:
   dependencies:
     trim "0.0.1"
 
-spdx-correct@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
   dependencies:
-    spdx-license-ids "^1.0.2"
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
 
-spdx-expression-parse@~1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
 
-spdx-license-ids@^1.0.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -7475,7 +7474,7 @@ static-site-generator-webpack-plugin@^3.4.1:
     url "^0.11.0"
     webpack-sources "^0.2.0"
 
-"statuses@>= 1.3.1 < 2":
+"statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
@@ -7545,7 +7544,13 @@ string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@^1.0.0, string_decoder@~1.0.3:
+string_decoder@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.0.tgz#384f322ee8a848e500effde99901bba849c5d403"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
@@ -7607,9 +7612,9 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+supports-color@^5.2.0, supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:
     has-flag "^3.0.0"
 
@@ -7783,12 +7788,13 @@ to-regex-range@^2.1.0:
     repeat-string "^1.6.1"
 
 to-regex@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.1.tgz#15358bee4a2c83bd76377ba1dc049d0f18837aae"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
   dependencies:
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    regex-not "^1.0.0"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
 
 topo@2.x.x:
   version "2.0.2"
@@ -7797,8 +7803,8 @@ topo@2.x.x:
     hoek "4.x.x"
 
 tough-cookie@~2.3.0, tough-cookie@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
@@ -7942,7 +7948,7 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-update-notifier@^2.3.0:
+update-notifier@2.3.0, update-notifier@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.3.0.tgz#4e8827a6bb915140ab093559d7014e3ebb837451"
   dependencies:
@@ -8037,11 +8043,11 @@ v8-compile-cache@^1.1.0:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:
-    spdx-correct "~1.0.0"
-    spdx-expression-parse "~1.0.0"
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 value-equal@^0.4.0:
   version "0.4.0"
@@ -8067,9 +8073,13 @@ viewport-dimensions@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz#de740747db5387fd1725f5175e91bac76afdf36c"
 
-vlq@^0.2.1, vlq@^0.2.2:
+vlq@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+
+vlq@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.0.tgz#8101be90843422954c2b13eb27f2f3122bdcc806"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -8149,8 +8159,8 @@ webpack-dev-server@^1.16.1:
     webpack-dev-middleware "^1.10.2"
 
 webpack-hot-middleware@^2.13.2:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz#7b3c113a7a4b301c91e0749573c7aab28b414b52"
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.2.tgz#2e2aa65563b8b32546b67e53b5a9667dcd80f327"
   dependencies:
     ansi-html "0.0.7"
     html-entities "^1.2.0"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1713,6 +1713,14 @@ clipboard@^1.7.1:
     select "^1.1.2"
     tiny-emitter "^2.0.0"
 
+clipboard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.0.tgz#4661dc972fb72a4c4770b8db78aa9b1caef52b50"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 clipboardy@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.2.tgz#2ce320b9ed9be1514f79878b53ff9765420903e2"
@@ -1817,6 +1825,12 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.4.tgz#72083e58d4a462f01866f6617f4d98a3cd3b8a46"
+  dependencies:
+    trim "0.0.1"
 
 commander@2.9.0, commander@2.9.x:
   version "2.9.0"
@@ -3637,6 +3651,20 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.1.0.tgz#b55c0f4bb7bb2040c889c325ef87ab29c38102b4"
+
+hastscript@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-3.1.0.tgz#66628ba6d7f1ad07d9277dd09028aba7f4934599"
+  dependencies:
+    camelcase "^3.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^3.0.0"
+    space-separated-tokens "^1.0.0"
+
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -3654,6 +3682,10 @@ hawk@~6.0.2:
     cryptiles "3.x.x"
     hoek "4.x.x"
     sntp "2.x.x"
+
+highlight.js@~9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
 
 history@^4.6.2, history@^4.7.2:
   version "4.7.2"
@@ -4652,6 +4684,12 @@ lowdb@^0.16.2:
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lowlight@~1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.9.1.tgz#ed7c3dffc36f8c1f263735c0fe0c907847c11250"
+  dependencies:
+    highlight.js "~9.12.0"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -6084,6 +6122,18 @@ prismjs@^1.6.0:
   optionalDependencies:
     clipboard "^1.7.1"
 
+prismjs@^1.8.4:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.12.2.tgz#a40a6cd5bf36716e316cb75df91976a7d5d694e6"
+  optionalDependencies:
+    clipboard "^2.0.0"
+
+prismjs@~1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.10.0.tgz#77e5187c2ae6b3253fcc313029cf25fe53778721"
+  optionalDependencies:
+    clipboard "^1.7.1"
+
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6128,6 +6178,10 @@ proper-lockfile@^1.1.2:
     extend "^3.0.0"
     graceful-fs "^4.1.2"
     retry "^0.10.0"
+
+property-information@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
 
 proxy-addr@~2.0.2:
   version "2.0.3"
@@ -6381,6 +6435,16 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
+react-syntax-highlighter@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-7.0.2.tgz#674036d4803183f3a33202defc35e5ba83d992f5"
+  dependencies:
+    babel-runtime "^6.18.0"
+    highlight.js "~9.12.0"
+    lowlight "~1.9.1"
+    prismjs "^1.8.4"
+    refractor "^2.0.0"
+
 react@^15.6.0:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
@@ -6539,6 +6603,13 @@ redux@^3.6.0:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+refractor@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.3.0.tgz#b8cade8f88020f8836ca3622c6ef87fd2444d76a"
+  dependencies:
+    hastscript "^3.1.0"
+    prismjs "~1.10.0"
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -7331,6 +7402,12 @@ sourcemapped-stacktrace@^1.1.6:
   dependencies:
     source-map "0.5.6"
 
+space-separated-tokens@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.1.tgz#9695b9df9e65aec1811d4c3f9ce52520bc2f7e4d"
+  dependencies:
+    trim "0.0.1"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -7738,6 +7815,10 @@ traceur@0.0.105:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/src/layers/docs/examples/Card-basic.example
+++ b/src/layers/docs/examples/Card-basic.example
@@ -1,7 +1,6 @@
 <Card
   innerRef={(ref) => console.log(ref)}
   elevation={2}
-  border='muted'
   marginLeft={12}
   marginY={24}
   paddingTop={12}

--- a/src/layers/docs/index.js
+++ b/src/layers/docs/index.js
@@ -30,10 +30,11 @@ const introduction = (
       the <code>div</code> element. They are used as primitives to construct
       layouts and compose components.
     </p>
+  </div>
+)
 
-    <h3>
-      The Relationship to <code>ui-box</code>
-    </h3>
+const implementationDetails = (
+  <div>
     <p>
       The <code>Pane</code> component maps almost directly to the{' '}
       <code>Box</code> from{' '}
@@ -149,7 +150,7 @@ const appearanceOptions = [
       </PaneExample>
     ),
     description: (
-      <p>This is rarely used. Might become depracted in the future.</p>
+      <p>This is rarely used. Might become deprecated in the future.</p>
     )
   },
   {
@@ -235,6 +236,7 @@ export default {
   title,
   subTitle,
   introduction,
+  implementationDetails,
   appearanceOptions,
   components
 }

--- a/src/table/docs/index.js
+++ b/src/table/docs/index.js
@@ -229,6 +229,7 @@ const components = [
         title: 'Basic TableHeaderCell example',
         codeText: exampleTableHeaderCell,
         scope: {
+          TableHead,
           TableHeaderCell,
           TableRow
         }
@@ -250,6 +251,7 @@ const components = [
         title: 'Basic TextTableHeaderCell example',
         codeText: exampleTextTableHeaderCell,
         scope: {
+          TableHead,
           TextTableHeaderCell,
           TableRow
         }

--- a/src/table/docs/index.js
+++ b/src/table/docs/index.js
@@ -47,21 +47,23 @@ const designGuidelines = (
       <code>SelectMenu</code> component. Currently this package does not use
       real tables under the hood.
     </p>
-    <h3>Implementation details</h3>
-    <ul>
-      <li>
-        None of these components implement HTML table elements such as:
-        {` `}
-        <code>table</code>, <code>th</code> or <code>tr</code>.
-      </li>
-      <li>
-        Most components are basic <code>Pane</code> components combined with
-        {` `}
-        <code>Text</code>.
-      </li>
-      <li>All components are presentational, no sorting build in.</li>
-    </ul>
   </div>
+)
+
+const implementationDetails = (
+  <ul>
+    <li>
+      None of these components implement HTML table elements such as:
+      {` `}
+      <code>table</code>, <code>th</code> or <code>tr</code>.
+    </li>
+    <li>
+      Most components are basic <code>Pane</code> components combined with
+      {` `}
+      <code>Text</code>.
+    </li>
+    <li>All components are presentational, no sorting build in.</li>
+  </ul>
 )
 
 const appearanceOptions = null
@@ -280,6 +282,7 @@ export default {
   title,
   subTitle,
   designGuidelines,
+  implementationDetails,
   appearanceOptions,
   components
 }

--- a/src/toaster/docs/index.js
+++ b/src/toaster/docs/index.js
@@ -25,12 +25,15 @@ const designGuidelines = (
       When you want to give feedback to your users about a action they take.
       Often this is in the form of creation or deletion.
     </p>
-    <h3>Types of Toasts</h3>
+  </div>
+)
+const implementationDetails = (
+  <div>
     <p>
       A toast is simply a wrapper around the <code>Alert</code> component and
-      has the same kind of types as an alert. The following methods are
-      available:
+      has the same kind of types as an alert. The following types are available:
     </p>
+    <h3>Types of Toasts</h3>
     <ul>
       <li>
         <code>toaster.notify()</code> &mdash; uses the default type
@@ -114,6 +117,7 @@ export default {
   title,
   subTitle,
   designGuidelines,
+  implementationDetails,
   appearanceOptions,
   examples
 }

--- a/src/typography/docs/examples/Code-basic.example
+++ b/src/typography/docs/examples/Code-basic.example
@@ -1,0 +1,9 @@
+<Box>
+  <Code size={300}>The quick brown fox jumps over the lazy dog</Code>
+  <Code size={400}>The quick brown fox jumps over the lazy dog</Code>
+  <Code size={500}>The quick brown fox jumps over the lazy dog</Code>
+  <Code size={600}>The quick brown fox jumps over the lazy dog</Code>
+  <Code size={700}>The quick brown fox jumps over the lazy dog</Code>
+  <Code size={800}>The quick brown fox jumps over the lazy dog</Code>
+  <Code size={900}>The quick brown fox jumps over the lazy dog</Code>
+</Box>

--- a/src/typography/docs/examples/Heading-basic.example
+++ b/src/typography/docs/examples/Heading-basic.example
@@ -1,0 +1,11 @@
+<Box>
+  <Heading size={100} isUppercase>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={200} isUppercase>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={300}>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={400}>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={500}>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={600}>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={700}>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={800}>The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={900}>The quick brown fox jumps over the lazy dog</Heading>
+</Box>

--- a/src/typography/docs/examples/Label-basic.example
+++ b/src/typography/docs/examples/Label-basic.example
@@ -1,0 +1,11 @@
+<Box>
+  <Label size={100} isUppercase>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={200} isUppercase>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={300}>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={400}>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={500}>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={600}>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={700}>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={800}>The quick brown fox jumps over the lazy dog</Label>
+  <Label size={900}>The quick brown fox jumps over the lazy dog</Label>
+</Box>

--- a/src/typography/docs/examples/Link-basic.example
+++ b/src/typography/docs/examples/Link-basic.example
@@ -1,0 +1,5 @@
+<Box>
+  <Link href="#" marginRight={12} appearance="green">Green</Link>
+  <Link href="#" marginRight={12} appearance="blue">Blue</Link>
+  <Link href="#" marginRight={12} appearance="neutral">Neutral</Link>
+</Box>

--- a/src/typography/docs/examples/ListItem-basic.example
+++ b/src/typography/docs/examples/ListItem-basic.example
@@ -1,0 +1,1 @@
+<ListItem>List item. Use inside of a UnorderedList or OrderedList.</ListItem>

--- a/src/typography/docs/examples/OrderedList-basic.example
+++ b/src/typography/docs/examples/OrderedList-basic.example
@@ -1,0 +1,6 @@
+<OrderedList>
+  <ListItem>Lorem ipsum dolor sit amet</ListItem>
+  <ListItem>Consectetur adipiscing elit</ListItem>
+  <ListItem>Integer molestie lorem at massa</ListItem>
+  <ListItem>Facilisis in pretium nisl aliquet</ListItem>
+</OrderedList>

--- a/src/typography/docs/examples/Paragraph-basic.example
+++ b/src/typography/docs/examples/Paragraph-basic.example
@@ -1,0 +1,11 @@
+<Box>
+  <Paragraph size={300} marginBottom={32}>
+    Size 300. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </Paragraph>
+  <Paragraph size={400} marginBottom={32}>
+    Size 400. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </Paragraph>
+  <Paragraph>
+    Size 500. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </Paragraph>
+</Box>

--- a/src/typography/docs/examples/Pre-basic.example
+++ b/src/typography/docs/examples/Pre-basic.example
@@ -1,0 +1,3 @@
+<Pre>
+  Preformatted text.
+</Pre>

--- a/src/typography/docs/examples/Small-basic.example
+++ b/src/typography/docs/examples/Small-basic.example
@@ -1,0 +1,9 @@
+<Box>
+  <Small size={300}>The quick brown fox jumps over the lazy dog</Small>
+  <Small size={400}>The quick brown fox jumps over the lazy dog</Small>
+  <Small size={500}>The quick brown fox jumps over the lazy dog</Small>
+  <Small size={600}>The quick brown fox jumps over the lazy dog</Small>
+  <Small size={700}>The quick brown fox jumps over the lazy dog</Small>
+  <Small size={800}>The quick brown fox jumps over the lazy dog</Small>
+  <Small size={900}>The quick brown fox jumps over the lazy dog</Small>
+</Box>

--- a/src/typography/docs/examples/Strong-basic.example
+++ b/src/typography/docs/examples/Strong-basic.example
@@ -1,0 +1,11 @@
+<Box>
+  <Strong size={100} isUppercase>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={200} isUppercase>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={300}>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={400}>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={500}>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={600}>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={700}>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={800}>The quick brown fox jumps over the lazy dog</Strong>
+  <Strong size={900}>The quick brown fox jumps over the lazy dog</Strong>
+</Box>

--- a/src/typography/docs/examples/SubHeading-basic.example
+++ b/src/typography/docs/examples/SubHeading-basic.example
@@ -1,0 +1,11 @@
+<Box>
+  <SubHeading size={100} isUppercase>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={200} isUppercase>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={300}>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={400}>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={500}>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={600}>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={700}>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={800}>The quick brown fox jumps over the lazy dog</SubHeading>
+  <SubHeading size={900}>The quick brown fox jumps over the lazy dog</SubHeading>
+</Box>

--- a/src/typography/docs/examples/Text-basic.example
+++ b/src/typography/docs/examples/Text-basic.example
@@ -1,0 +1,11 @@
+<Box>
+  <Text size={100} isUppercase>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={200} isUppercase>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={300}>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={400}>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={500}>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={600}>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={700}>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={800}>The quick brown fox jumps over the lazy dog</Text>
+  <Text size={900}>The quick brown fox jumps over the lazy dog</Text>
+</Box>

--- a/src/typography/docs/examples/UnorderedList-basic.example
+++ b/src/typography/docs/examples/UnorderedList-basic.example
@@ -1,0 +1,6 @@
+<UnorderedList>
+  <ListItem>Lorem ipsum dolor sit amet</ListItem>
+  <ListItem>Consectetur adipiscing elit</ListItem>
+  <ListItem>Integer molestie lorem at massa</ListItem>
+  <ListItem>IFacilisis in pretium nisl aliquet</ListItem>
+</UnorderedList>

--- a/src/typography/docs/index.js
+++ b/src/typography/docs/index.js
@@ -1,0 +1,365 @@
+import React from 'react'
+import Box from 'ui-box'
+import Text from '../src/Text'
+import Paragraph from '../src/Paragraph'
+import Heading from '../src/Heading'
+import SubHeading from '../src/SubHeading'
+import Link from '../src/Link'
+import Strong from '../src/Strong'
+import Small from '../src/Small'
+import Label from '../src/Label'
+import Code from '../src/Code'
+import Pre from '../src/Pre'
+import UnorderedList from '../src/UnorderedList'
+import OrderedList from '../src/OrderedList'
+import ListItem from '../src/ListItem'
+
+import FontFamilies from '../src/styles/FontFamilies'
+
+/* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
+import sourceText from '!raw-loader!../src/Text'
+import sourceParagraph from '!raw-loader!../src/Paragraph'
+import sourceHeading from '!raw-loader!../src/Heading'
+import sourceSubHeading from '!raw-loader!../src/SubHeading'
+import sourceLink from '!raw-loader!../src/Link'
+import sourceStrong from '!raw-loader!../src/Strong'
+import sourceSmall from '!raw-loader!../src/Small'
+import sourceLabel from '!raw-loader!../src/Label'
+import sourceCode from '!raw-loader!../src/Code'
+import sourcePre from '!raw-loader!../src/Pre'
+import sourceUnorderedList from '!raw-loader!../src/UnorderedList'
+import sourceOrderedList from '!raw-loader!../src/OrderedList'
+import sourceListItem from '!raw-loader!../src/ListItem'
+/* eslint-enable import/no-unresolved, import/no-webpack-loader-syntax */
+
+/**
+ * Code examples
+ */
+import exampleTextBasic from './examples/Text-basic.example'
+import exampleParagraphBasic from './examples/Paragraph-basic.example'
+import exampleHeadingBasic from './examples/Heading-basic.example'
+import exampleSubHeadingBasic from './examples/SubHeading-basic.example'
+import exampleLinkBasic from './examples/Link-basic.example'
+import exampleStrongBasic from './examples/Strong-basic.example'
+import exampleSmallBasic from './examples/Small-basic.example'
+import exampleLabelBasic from './examples/Label-basic.example'
+import exampleCodeBasic from './examples/Code-basic.example'
+import examplePreBasic from './examples/Pre-basic.example'
+import exampleUnorderedListBasic from './examples/UnorderedList-basic.example'
+import exampleOrderedListBasic from './examples/OrderedList-basic.example'
+import exampleListItemBasic from './examples/ListItem-basic.example'
+
+const title = 'Typography'
+const subTitle = 'A set of components for typography.'
+
+const designGuidelines = (
+  <div>
+    <p>
+      Typography in Evergreen uses the system font stack, that means that it is
+      using different fonts on Windows, Mac and Linux. This makes the experience
+      feel native to the OS and font rendering is fast.
+    </p>
+    <h3>Font Families</h3>
+    <p>
+      Evergreen uses three font family stacks, ui, display and mono. Text
+      components willy set the font family accordingly to their use case. For
+      example, <code>Heading</code> components will use display and{' '}
+      <code>Code</code> components will use mono.
+    </p>
+    <br />
+    {Object.keys(FontFamilies).map(key => {
+      return (
+        <div key={key}>
+          <code>{key}</code>
+          <br /> <br /> <pre>{FontFamilies[key]}</pre>
+          <br /> <br />
+        </div>
+      )
+    })}
+  </div>
+)
+
+const implementationDetails = (
+  <div>
+    <p>
+      Typography in Evergreen is currently a very flexible system. In the future
+      some of the APIs might slightly change and be more locked down.
+    </p>
+    <p>
+      The idea behind the type system in Evergreen is that each typography
+      component composes the base <code>Text</code> component. For example, the{' '}
+      <code>Strong</code> component composes the <code>Text</code> component and
+      sets the font weight property.
+    </p>
+    <h3>Available Text Sizes</h3>
+    <p>
+      Because all the typography components compose the <code>Text</code>{' '}
+      component, the <code>size</code> property is available on all of those
+      components. The <code>size</code> property supports the following values.
+    </p>
+    <ul>
+      <li>100</li>
+      <li>200</li>
+      <li>300</li>
+      <li>400</li>
+      <li>500</li>
+      <li>600</li>
+      <li>700</li>
+      <li>800</li>
+      <li>900</li>
+    </ul>
+  </div>
+)
+
+const appearanceOptions = null
+
+const scope = {
+  Box,
+  Text,
+  Paragraph,
+  Heading,
+  SubHeading,
+  Link,
+  Strong,
+  Small,
+  Label,
+  Code,
+  Pre,
+  UnorderedList,
+  OrderedList,
+  ListItem
+}
+
+const components = [
+  {
+    name: 'Text',
+    source: sourceText,
+    description: (
+      <p>
+        The <code>Text</code> component is a <code>span</code> by default. This
+        component is generally used as the base of other components. If you need{' '}
+        <code>Text</code> to be a block use <code>{`<Text is="p" />`}</code> or
+        a <code>Paragraph</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Text Example',
+        codeText: exampleTextBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Paragraph',
+    source: sourceParagraph,
+    description: (
+      <p>
+        The <code>Paragraph</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Paragraph Example',
+        codeText: exampleParagraphBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Heading',
+    source: sourceHeading,
+    description: (
+      <p>
+        The <code>Heading</code> component is used for titles and headings. Make
+        sure to use <code>isUppercase</code> when using sizes 100 and 200.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Heading Example',
+        codeText: exampleHeadingBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'SubHeading',
+    source: sourceSubHeading,
+    description: (
+      <p>
+        The <code>SubHeading</code> component is currently rarely used and might
+        get deprecated in the future. Make sure to use <code>isUppercase</code>{' '}
+        when using sizes 100 and 200.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic SubHeading Example',
+        codeText: exampleSubHeadingBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Link',
+    source: sourceLink,
+    description: (
+      <p>
+        The <code>Link</code> component is a anchor element by default.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Link Example',
+        codeText: exampleLinkBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Strong',
+    source: sourceStrong,
+    description: (
+      <p>
+        The <code>Strong</code> component. Make sure to set the{' '}
+        <code>size</code> property if you are using this within a other text
+        component such as a <code>Paragraph</code>.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Strong Example',
+        codeText: exampleStrongBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Small',
+    source: sourceSmall,
+    description: (
+      <p>
+        The <code>Small</code> component. Make sure to set the <code>size</code>{' '}
+        property if you are using this within a other text component such as a{' '}
+        <code>Paragraph</code>.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Small Example',
+        codeText: exampleSmallBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Label',
+    source: sourceLabel,
+    description: (
+      <p>
+        The <code>Label</code> component is the same as the <code>Text</code>{' '}
+        component but is a <code>label</code> element by default. Make sure to
+        use the <code>for</code> attribute when using this component in forms.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Label Example',
+        codeText: exampleLabelBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Code',
+    source: sourceCode,
+    description: (
+      <p>
+        The <code>Code</code> component is the same as the <code>Text</code>{' '}
+        component but is a <code>code</code> element by default. This component
+        sets the the font family to <code>mono</code>.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Code Example',
+        codeText: exampleCodeBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'Pre',
+    source: sourcePre,
+    description: (
+      <p>
+        The <code>Pre</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Pre Example',
+        codeText: examplePreBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'UnorderedList',
+    source: sourceUnorderedList,
+    description: (
+      <p>
+        The <code>UnorderedList</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic UnorderedList Example',
+        codeText: exampleUnorderedListBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'OrderedList',
+    source: sourceOrderedList,
+    description: (
+      <p>
+        The <code>OrderedList</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic OrderedList Example',
+        codeText: exampleOrderedListBasic,
+        scope
+      }
+    ]
+  },
+  {
+    name: 'ListItem',
+    source: sourceListItem,
+    description: (
+      <p>
+        The <code>ListItem</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic ListItem Example',
+        codeText: exampleListItemBasic,
+        scope
+      }
+    ]
+  }
+]
+
+export default {
+  title,
+  subTitle,
+  designGuidelines,
+  implementationDetails,
+  appearanceOptions,
+  components
+}

--- a/src/typography/src/Link.js
+++ b/src/typography/src/Link.js
@@ -6,9 +6,26 @@ import Text from './Text'
 export default class Link extends PureComponent {
   static propTypes = {
     ...Text.propTypes,
+
+    /**
+     * This attribute names a relationship of the linked document to the current document.
+     * Common use case is: rel="noopener noreferrer".
+     */
     rel: PropTypes.string,
+
+    /**
+     * Specifies the URL of the linked resource. A URL might be absolute or relative.
+     */
     href: PropTypes.string,
+
+    /**
+     * Target atrribute, common use case is target="_blank."
+     */
     target: PropTypes.string,
+
+    /**
+     * The appearance of the Link. Can be blue, green or neutral.
+     */
     appearance: PropTypes.oneOf(Object.keys(LinkAppearances))
   }
 

--- a/src/typography/src/OrderedList.js
+++ b/src/typography/src/OrderedList.js
@@ -12,7 +12,7 @@ export default class OrderedList extends PureComponent {
     marginLeft: '1.1em',
     padding: 0,
     listStylePosition: 'inside',
-    listStyle: 'number'
+    listStyle: 'decimal'
   }
 
   render() {

--- a/src/typography/src/Pre.js
+++ b/src/typography/src/Pre.js
@@ -7,14 +7,6 @@ export default class Pre extends PureComponent {
   }
 
   render() {
-    return (
-      <Text
-        is="pre"
-        fontFamily="mono"
-        marginTop={0}
-        marginBottom={0}
-        {...this.props}
-      />
-    )
+    return <Text is="pre" marginTop={0} marginBottom={0} {...this.props} />
   }
 }

--- a/src/typography/src/Strong.js
+++ b/src/typography/src/Strong.js
@@ -6,12 +6,7 @@ export default class Strong extends PureComponent {
     ...Text.propTypes
   }
 
-  static defaultProps = {
-    is: 'strong',
-    fontWeight: 600
-  }
-
   render() {
-    return <Text {...this.props} />
+    return <Text is="strong" fontWeight={600} {...this.props} />
   }
 }

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -10,12 +10,41 @@ const isDev = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV
 
 export default class Text extends PureComponent {
   static propTypes = {
+    /**
+     * Composes the Box component as the base.
+     */
     ...Box.propTypes,
+
+    /**
+     * Size of the text style.
+     * Can be: 100, 200, 300, 400, 500, 600, 700, 800, 900.
+     */
     size: PropTypes.oneOf(Object.keys(TextStyles).map(Number)),
+
+    /**
+     * Font family.
+     * Can be: ui, display or mono
+     */
     fontFamily: PropTypes.oneOf(Object.keys(FontFamilies)),
+
+    /**
+     * Sets the text to uppercase.
+     * Only sizes 100 and 200 support uppercase styles at the moment.
+     */
+    isUppercase: PropTypes.bool,
+
+    /**
+     * The text styles available.
+     * This is overridden by other text components that implement Text as the base.
+     * You should avoid setting this manually.
+     */
     textStyles: PropTypes.object,
-    textUppercaseStyles: PropTypes.object,
-    isUppercase: PropTypes.bool
+
+    /**
+     * The uppercase text styles.
+     * You should avoid setting this manually.
+     */
+    textUppercaseStyles: PropTypes.object
   }
 
   static defaultProps = {


### PR DESCRIPTION
See the documentation live here: http://evergreen.surge.sh/components/typography/

This PR also explicitly set Gatsby to version `1.9.166` to prevent an issue with the build.

![image](https://user-images.githubusercontent.com/564463/37263600-1e2c74b2-2566-11e8-81a1-b1ab3983eb3f.png)
