### PR TITLE
Side Sheet docs and breaking improvements

### DIFF
--- a/docs/src/componentRoutes.js
+++ b/docs/src/componentRoutes.js
@@ -41,6 +41,10 @@ module.exports = [
     path: '/components/select-menu'
   },
   {
+    name: 'Side Sheet',
+    path: '/components/side-sheet'
+  },
+  {
     name: 'Text Input',
     path: '/components/text-input'
   },

--- a/docs/src/utils/getComponent.js
+++ b/docs/src/utils/getComponent.js
@@ -22,7 +22,7 @@ import textInputDocs from '../../../src/text-input/docs/'
 // import spinnerDocs from '../../src/spinner/docs/'
 import searchInputDocs from '../../../src/search-input/docs/'
 import tableDocs from '../../../src/table/docs/'
-// import sideSheetDocs from '../../src/side-sheet/docs/'
+import sideSheetDocs from '../../../src/side-sheet/docs/'
 // import radioDocs from '../../src/radio/docs/'
 import dialogDocs from '../../../src/dialog/docs/'
 import cornerDialogDocs from '../../../src/corner-dialog/docs/'
@@ -43,6 +43,7 @@ const map = {
   'text input': textInputDocs,
   'search input': searchInputDocs,
   'corner dialog': cornerDialogDocs,
+  'side sheet': sideSheetDocs,
   icons: iconsDocs
 }
 

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -191,7 +191,6 @@ class Dialog extends React.Component {
       width,
       type,
       isShown,
-      children,
       topOffset,
       hasHeader,
       hasFooter,
@@ -202,11 +201,9 @@ class Dialog extends React.Component {
       confirmLabel,
       isConfirmLoading,
       isConfirmDisabled,
-      onCancel,
       cancelLabel,
       containerProps,
-      minHeightContent,
-      ...props
+      minHeightContent
     } = this.props
 
     let maxHeight
@@ -228,7 +225,6 @@ class Dialog extends React.Component {
         isShown={isShown}
         onExited={onCloseComplete}
         onEntered={onOpenComplete}
-        {...props}
       >
         {({ state, close }) => (
           <Pane

--- a/src/side-sheet/docs/examples/SideSheet-basic.example
+++ b/src/side-sheet/docs/examples/SideSheet-basic.example
@@ -1,0 +1,15 @@
+<Manager isShown={false}>
+  {({ state, setState }) => (
+    <Box>
+      <SideSheet
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+      >
+        <Paragraph margin={40}>Basic Example</Paragraph>
+      </SideSheet>
+      <Button onClick={() => setState({ isShown: true })}>
+        Show Basic Side Sheet
+      </Button>
+    </Box>
+  )}
+</Manager>

--- a/src/side-sheet/docs/examples/SideSheet-full-featured.example
+++ b/src/side-sheet/docs/examples/SideSheet-full-featured.example
@@ -1,0 +1,56 @@
+<Manager isShown={false}>
+  {({ state, setState }) => (
+    <Box>
+      <SideSheet
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+        containerProps={{
+          display: 'flex',
+          flex: '1',
+          flexDirection: 'column',
+        }}
+      >
+        <Pane flexShrink={0} elevation={0} backgroundColor="white">
+          <Pane padding={16} borderBottom="extraMuted">
+            <Heading size={600}>Title</Heading>
+            <Paragraph size={400} color="extraMuted">
+              Optional description or sub title
+            </Paragraph>
+          </Pane>
+          <Pane display="flex" padding={8}>
+            <Manager selectedIndex={0}>
+              {({ setState, state }) =>
+                ['Traits', 'Event History', 'Identities'].map(
+                  (tab, index) => (
+                    <Tab
+                      key={tab}
+                      isSelected={state.selectedIndex === index}
+                      onSelect={() => setState({ selectedIndex: index })}
+                    >
+                      {tab}
+                    </Tab>
+                  )
+                )
+              }
+            </Manager>
+          </Pane>
+        </Pane>
+        <Pane flex="1" overflowY="scroll" appearance="tint1" padding={16}>
+          <Card
+            backgroundColor="white"
+            elevation={0}
+            height={240}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Heading>Some content</Heading>
+          </Card>
+        </Pane>
+      </SideSheet>
+      <Button onClick={() => setState({ isShown: true })}>
+        Show Full Featured Side Sheet
+      </Button>
+    </Box>
+  )}
+</Manager>

--- a/src/side-sheet/docs/examples/SideSheet-title-subtitle.example
+++ b/src/side-sheet/docs/examples/SideSheet-title-subtitle.example
@@ -1,0 +1,39 @@
+<Manager isShown={false}>
+  {({ state, setState }) => (
+    <Box>
+      <SideSheet
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+        containerProps={{
+          display: 'flex',
+          flex: '1',
+          flexDirection: 'column',
+        }}
+      >
+        <Pane flexShrink={0} elevation={0} backgroundColor="white">
+          <Pane padding={16}>
+            <Heading size={600}>Title</Heading>
+            <Paragraph size={400} color="extraMuted">
+              Optional description or sub title
+            </Paragraph>
+          </Pane>
+        </Pane>
+        <Pane flex="1" overflowY="scroll" appearance="tint1" padding={16}>
+          <Card
+            backgroundColor="white"
+            elevation={0}
+            height={240}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Heading>Some content</Heading>
+          </Card>
+        </Pane>
+      </SideSheet>
+      <Button onClick={() => setState({ isShown: true })}>
+        Show Side Sheet with Title and Subtitle
+      </Button>
+    </Box>
+  )}
+</Manager>

--- a/src/side-sheet/docs/examples/SideSheet-title.example
+++ b/src/side-sheet/docs/examples/SideSheet-title.example
@@ -1,0 +1,36 @@
+<Manager isShown={false}>
+  {({ state, setState }) => (
+    <Box>
+      <SideSheet
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+        containerProps={{
+          display: 'flex',
+          flex: '1',
+          flexDirection: 'column',
+        }}
+      >
+        <Pane flexShrink={0} elevation={0} backgroundColor="white">
+          <Pane padding={16}>
+            <Heading size={600}>Title</Heading>
+          </Pane>
+        </Pane>
+        <Pane flex="1" overflowY="scroll" appearance="tint1" padding={16}>
+          <Card
+            backgroundColor="white"
+            elevation={0}
+            height={240}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Heading>Some content</Heading>
+          </Card>
+        </Pane>
+      </SideSheet>
+      <Button onClick={() => setState({ isShown: true })}>
+        Show Side Sheet with Title
+      </Button>
+    </Box>
+  )}
+</Manager>

--- a/src/side-sheet/docs/index.js
+++ b/src/side-sheet/docs/index.js
@@ -1,0 +1,130 @@
+import React from 'react'
+import Box from 'ui-box'
+import SideSheet from '../src/SideSheet'
+import { Heading, Paragraph } from '../../typography'
+import { Card, Pane } from '../../layers'
+import { Button } from '../../buttons'
+import { Tab } from '../../tabs'
+import { Manager } from '../../manager'
+
+/* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
+import sourceSideSheet from '!raw-loader!../src/SideSheet'
+/* eslint-enable import/no-unresolved, import/no-webpack-loader-syntax */
+
+/**
+ * Code examples
+ */
+import exampleSideSheetBasic from './examples/SideSheet-basic.example'
+import exampleSideSheetFullFeatured from './examples/SideSheet-full-featured.example'
+import exampleSideSheetTitleSubtitle from './examples/SideSheet-title-subtitle.example'
+import exampleSideSheetTitle from './examples/SideSheet-title.example'
+
+const title = 'Side Sheet'
+const subTitle = 'A side panel overlaying the screen.'
+
+const introduction = (
+  <div>
+    <p>
+      The Side Sheet component is a panel overlaying the screen on the right
+      side. It is used to show more details about a certain object or person. A
+      Side Sheet is often triggered by clicking a row in a table.
+    </p>
+    <h3>Use Cases</h3>
+    <ul>
+      <li>Showing a profile view of a user</li>
+      <li>
+        Showing detailed information about a transaction (such as a sync or run)
+      </li>
+      <li>
+        Showing configuration settings that don‘t need to be accessible by a URL
+      </li>
+    </ul>
+    <h3>When Not to Use a Side Sheet</h3>
+    <p>
+      Side Sheets are a great way to cheat creating a new page. As a general
+      rule of thumb, a Side Sheet should not be used as a replacement of a new
+      page when the page needs to be accessible by a URL. Avoid showing a Side
+      Sheet based on a URL.
+    </p>
+  </div>
+)
+
+const implementationDetails = (
+  <div>
+    <p>
+      The Side Sheet component does not have any opinion about the contents of
+      the Side Sheet. In the examples below are some recipes to make sure usage
+      of the Side Sheet is consistent. It is recommended to compose more
+      opinionated Side Sheets in the consuming application.
+    </p>
+  </div>
+)
+
+const scope = {
+  Heading,
+  Paragraph,
+  Card,
+  Pane,
+  Button,
+  Tab,
+  Manager,
+  Box,
+  SideSheet
+}
+
+const components = [
+  {
+    name: 'SideSheet',
+    source: sourceSideSheet,
+    description: (
+      <p>
+        The <code>SideSheet</code> component is .
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Example',
+        codeText: exampleSideSheetBasic,
+        scope
+      },
+      {
+        title: 'Full Featured Example',
+        description: (
+          <p>
+            Full featured example with a header with a title, subtitle and a tab
+            bar. Content is a simple card.
+          </p>
+        ),
+        codeText: exampleSideSheetFullFeatured,
+        scope
+      },
+      {
+        title: 'Title',
+        codeText: exampleSideSheetTitle,
+        description: (
+          <p>Example with a header with a title. Content is a simple card.</p>
+        ),
+        scope
+      },
+      {
+        title: 'Title and Subtitle',
+        codeText: exampleSideSheetTitleSubtitle,
+        description: (
+          <p>
+            Example with a header with a title and subtitle. Content is a simple
+            card.
+          </p>
+        ),
+        scope
+      }
+    ]
+  }
+]
+
+export default {
+  title,
+  subTitle,
+  introduction,
+  implementationDetails,
+  components
+}

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -53,14 +53,29 @@ const animationStyles = {
 class SideSheet extends React.Component {
   static propTypes = {
     /**
-     * Composes the Overlay components as the base.
+     * Children can be a string, node or a function accepting `({ close })`.
      */
-    ...Overlay.propTypes,
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+    /**
+     * When true, the Side Sheet is shown.
+     */
+    isShown: PropTypes.bool,
+
+    /**
+     * Function that will be called when the exit transition is complete.
+     */
+    onCloseComplete: PropTypes.func,
+
+    /**
+     * Function that will be called when the enter transition is complete.
+     */
+    onOpenComplete: PropTypes.func,
 
     /**
      * Width of the SideSheet.
      */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 
     /**
      * Properties to pass through the SideSheet container Pane.
@@ -69,14 +84,27 @@ class SideSheet extends React.Component {
   }
 
   static defaultProps = {
-    width: 620
+    width: 620,
+    onCloseComplete: () => {},
+    onOpenComplete: () => {}
   }
 
   render() {
-    const { children, width, containerProps, ...props } = this.props
+    const {
+      width,
+      isShown,
+      children,
+      containerProps,
+      onOpenComplete,
+      onCloseComplete
+    } = this.props
 
     return (
-      <Overlay {...props}>
+      <Overlay
+        isShown={isShown}
+        onExited={onCloseComplete}
+        onEntered={onOpenComplete}
+      >
         {({ state, close }) => (
           <Pane
             width={width}
@@ -94,9 +122,7 @@ class SideSheet extends React.Component {
               {...paneProps}
               {...containerProps}
             >
-              {typeof children === 'function'
-                ? children({ state, close })
-                : children}
+              {typeof children === 'function' ? children({ close }) : children}
             </Pane>
           </Pane>
         )}

--- a/src/side-sheet/stories/index.stories.js
+++ b/src/side-sheet/stories/index.stories.js
@@ -1,59 +1,12 @@
 import { storiesOf } from '@storybook/react'
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 import Box from 'ui-box'
 import { SideSheet } from '../../side-sheet'
 import { Heading, Paragraph } from '../../typography'
 import { Card, Pane } from '../../layers'
 import { Button } from '../../buttons'
 import { Tab } from '../../tabs'
-
-class SideSheetManager extends PureComponent {
-  static propTypes = {
-    children: PropTypes.func
-  }
-
-  state = {
-    isShown: true
-  }
-
-  render() {
-    return this.props.children({
-      isShown: this.state.isShown,
-      show: () =>
-        this.setState({
-          isShown: true
-        }),
-      hide: () => {
-        this.setState({
-          isShown: false
-        })
-      }
-    })
-  }
-}
-
-class Manager extends React.Component {
-  static propTypes = {
-    children: PropTypes.func
-  }
-
-  constructor(props) {
-    super(props)
-    this.state = {
-      ...props
-    }
-  }
-
-  render() {
-    return this.props.children({
-      setState: (...args) => {
-        this.setState(...args)
-      },
-      state: this.state
-    })
-  }
-}
+import { Manager } from '../../manager'
 
 storiesOf('side-sheet', module)
   .add('title + sub title + tabs', () => (
@@ -62,12 +15,12 @@ storiesOf('side-sheet', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <SideSheetManager>
-        {({ hide, show, isShown }) => (
+      <Manager isShown>
+        {({ state, setState }) => (
           <Box>
             <SideSheet
-              isShown={isShown}
-              onExited={hide}
+              isShown={state.isShown}
+              onCloseComplete={() => setState({ isShown: false })}
               containerProps={{
                 display: 'flex',
                 flex: '1',
@@ -112,10 +65,12 @@ storiesOf('side-sheet', module)
                 </Card>
               </Pane>
             </SideSheet>
-            <Button onClick={show}>Show Side Sheet</Button>
+            <Button onClick={() => setState({ isShown: true })}>
+              Show Side Sheet
+            </Button>
           </Box>
         )}
-      </SideSheetManager>
+      </Manager>
     </Box>
   ))
   .add('title + sub title', () => (
@@ -124,12 +79,12 @@ storiesOf('side-sheet', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <SideSheetManager>
-        {({ hide, show, isShown }) => (
+      <Manager isShown>
+        {({ state, setState }) => (
           <Box>
             <SideSheet
-              isShown={isShown}
-              onExited={hide}
+              isShown={state.isShown}
+              onCloseComplete={() => setState({ isShown: false })}
               containerProps={{
                 display: 'flex',
                 flex: '1',
@@ -157,10 +112,12 @@ storiesOf('side-sheet', module)
                 </Card>
               </Pane>
             </SideSheet>
-            <Button onClick={show}>Show Side Sheet</Button>
+            <Button onClick={() => setState({ isShown: true })}>
+              Show Side Sheet
+            </Button>
           </Box>
         )}
-      </SideSheetManager>
+      </Manager>
     </Box>
   ))
   .add('title', () => (
@@ -169,12 +126,12 @@ storiesOf('side-sheet', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <SideSheetManager>
-        {({ hide, show, isShown }) => (
+      <Manager isShown>
+        {({ state, setState }) => (
           <Box>
             <SideSheet
-              isShown={isShown}
-              onExited={hide}
+              isShown={state.isShown}
+              onCloseComplete={() => setState({ isShown: false })}
               containerProps={{
                 display: 'flex',
                 flex: '1',
@@ -199,10 +156,12 @@ storiesOf('side-sheet', module)
                 </Card>
               </Pane>
             </SideSheet>
-            <Button onClick={show}>Show Side Sheet</Button>
+            <Button onClick={() => setState({ isShown: true })}>
+              Show Side Sheet
+            </Button>
           </Box>
         )}
-      </SideSheetManager>
+      </Manager>
     </Box>
   ))
   .add('close from within', () => (
@@ -211,10 +170,13 @@ storiesOf('side-sheet', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <SideSheetManager>
-        {({ hide, show, isShown }) => (
+      <Manager isShown>
+        {({ state, setState }) => (
           <Box>
-            <SideSheet isShown={isShown} onExited={hide}>
+            <SideSheet
+              isShown={state.isShown}
+              onCloseComplete={() => setState({ isShown: false })}
+            >
               {({ close }) => {
                 return (
                   <Box padding={40}>
@@ -223,9 +185,11 @@ storiesOf('side-sheet', module)
                 )
               }}
             </SideSheet>
-            <Button onClick={show}>Show Side Sheet</Button>
+            <Button onClick={() => setState({ isShown: true })}>
+              Show Side Sheet
+            </Button>
           </Box>
         )}
-      </SideSheetManager>
+      </Manager>
     </Box>
   ))


### PR DESCRIPTION
```
class SideSheet extends React.Component {
  static propTypes = {
    /**
     * Children can be a string, node or a function accepting `({ close })`.
     */
    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,

    /**
     * When true, the Side Sheet is shown.
     */
    isShown: PropTypes.bool,

    /**
     * Function that will be called when the exit transition is complete.
     */
    onCloseComplete: PropTypes.func,

    /**
     * Function that will be called when the enter transition is complete.
     */
    onOpenComplete: PropTypes.func,

    /**
     * Width of the SideSheet.
     */
    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

    /**
     * Properties to pass through the SideSheet container Pane.
     */
    containerProps: PropTypes.object
  }
```
![image](https://user-images.githubusercontent.com/564463/37690340-89de78a6-2c67-11e8-84e0-b4e1ed7b07a9.png)
![image](https://user-images.githubusercontent.com/564463/37690344-8f808db2-2c67-11e8-884f-244cbc528e44.png)
![image](https://user-images.githubusercontent.com/564463/37690345-923e02f0-2c67-11e8-953b-fcd00e616074.png)
![image](https://user-images.githubusercontent.com/564463/37690348-95ee9c48-2c67-11e8-853c-d918aff8d723.png)
