### PR TITLE
Improved focus handling

### DIFF
--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -257,12 +257,7 @@ class Dialog extends React.Component {
                   <Heading is="h4" size={600} flex="1">
                     {title}
                   </Heading>
-                  <IconButton
-                    tabindex={3}
-                    appearance="ghost"
-                    icon="close"
-                    onClick={close}
-                  />
+                  <IconButton appearance="ghost" icon="close" onClick={close} />
                 </Pane>
               )}
 
@@ -281,28 +276,26 @@ class Dialog extends React.Component {
                 </Pane>
 
                 {hasFooter && (
-                  <Pane
-                    flexShrink={0}
-                    padding={16}
-                    borderTop="extraMuted"
-                    display="flex"
-                    flexDirection="row-reverse"
-                  >
-                    <Button
-                      tabIndex={2}
-                      marginLeft={8}
-                      appearance={buttonAppearance}
-                      isLoading={isConfirmLoading}
-                      disabled={isConfirmDisabled}
-                      onClick={() => onConfirm(close)}
-                    >
-                      {confirmLabel}
-                    </Button>
-                    {hasCancel && (
-                      <Button tabIndex={1} onClick={close}>
-                        {cancelLabel}
+                  <Pane borderTop="extraMuted" clearfix>
+                    <Pane padding={16} float="right">
+                      {/* Cancel should be first to make sure focus gets on it first. */}
+                      {hasCancel && (
+                        <Button tabIndex={0} onClick={close}>
+                          {cancelLabel}
+                        </Button>
+                      )}
+
+                      <Button
+                        tabIndex={0}
+                        marginLeft={8}
+                        appearance={buttonAppearance}
+                        isLoading={isConfirmLoading}
+                        disabled={isConfirmDisabled}
+                        onClick={() => onConfirm(close)}
+                      >
+                        {confirmLabel}
                       </Button>
-                    )}
+                    </Pane>
                   </Pane>
                 )}
               </Pane>

--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -181,29 +181,18 @@ class Overlay extends React.Component {
         const autofocusElement = this.containerElement.querySelector(
           '[autofocus]'
         )
+        const wrapperElement = this.containerElement.querySelector('[tabindex]')
+        const buttonElement = this.containerElement.querySelector('button')
 
-        // eslint-disable-next-line eqeqeq, no-eq-null, no-negated-condition
+        // eslint-disable-next-line eqeqeq, no-eq-null
         if (autofocusElement != null) {
           autofocusElement.focus()
-        } else {
-          const tabIndexElements = this.containerElement.querySelectorAll(
-            '[tabindex]'
-          )
-
           // eslint-disable-next-line eqeqeq, no-eq-null
-          if (tabIndexElements == null) return
-
-          // Make sure to honor tab index specificity.
-          const sortedList = Array.from(tabIndexElements).sort((a, b) => {
-            return (
-              Number(a.getAttribute('tabindex')) -
-              Number(b.getAttribute('tabindex'))
-            )
-          })
-
-          if (sortedList.length > 0) {
-            sortedList[0].focus()
-          }
+        } else if (wrapperElement != null) {
+          wrapperElement.focus()
+          // eslint-disable-next-line eqeqeq, no-eq-null
+        } else if (buttonElement != null) {
+          buttonElement.focus()
         }
       }
     })

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -137,6 +137,7 @@ export default class Popover extends Component {
         // Element marked autofocus has higher priority than the other clowns
         const autofocusElement = this.popoverNode.querySelector('[autofocus]')
         const wrapperElement = this.popoverNode.querySelector('[tabindex]')
+        const buttonElement = this.popoverNode.querySelector('button')
 
         // eslint-disable-next-line eqeqeq, no-eq-null
         if (autofocusElement != null) {
@@ -144,6 +145,9 @@ export default class Popover extends Component {
           // eslint-disable-next-line eqeqeq, no-eq-null
         } else if (wrapperElement != null) {
           wrapperElement.focus()
+          // eslint-disable-next-line eqeqeq, no-eq-null
+        } else if (buttonElement != null) {
+          buttonElement.focus()
         }
       }
     })


### PR DESCRIPTION
This is based on the feedback from @Rowno. I removed the hardcoded tabindex order in the Dialog in favor of using DOM order. Bringing the focus inside the Overlay (or Popover) now looks for:

1. `[autofocus]`
2. `[tabindex]`
3. `button`