### PR TITLE
Add guard for fix isSelected

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -158,6 +158,7 @@ export default class Autocomplete extends PureComponent {
             renderItem={({ index, style }) => {
               const item = items[index]
               const itemString = itemToString(item)
+
               return renderItem(
                 getItemProps({
                   item,
@@ -168,7 +169,8 @@ export default class Autocomplete extends PureComponent {
                   onMouseUp: () => {
                     selectItemAtIndex(index)
                   },
-                  isSelected: itemToString(selectedItem) === itemString,
+                  isSelected:
+                    selectedItem && itemToString(selectedItem) === itemString,
                   isHighlighted: highlightedIndex === index
                 })
               )


### PR DESCRIPTION
I was using the Combobox component with an `Array<{ label: string, value: string }>`. If I wasn't provided a default value the Combobox onClick make my app crash. The problem was with the isSelected. Because of no value pass for default the label was null. Now with this check someone can provide a custom list object, without default value without a crash.

<img width="863" alt="screen shot 2018-04-14 at 12 37 53 am" src="https://user-images.githubusercontent.com/15819498/38764427-c2dcb8e8-3f7c-11e8-9d00-71df48d9e388.png">
