### PR TITLE
Update selectors for Combobox

### DIFF
--- a/src/shared-styles/src/styles/selectableRowStyle.js
+++ b/src/shared-styles/src/styles/selectableRowStyle.js
@@ -17,7 +17,7 @@ const selectableRowStyle = {
     color: colors.blue['500']
   },
 
-  '&[aria-current="true"], &[aria-selected="true"]': {
+  '&[aria-current="true"]': {
     cursor: 'default'
   }
 }

--- a/src/shared-styles/src/styles/selectableTabStyle.js
+++ b/src/shared-styles/src/styles/selectableTabStyle.js
@@ -8,12 +8,12 @@ const selectableTabStyle = {
     backgroundColor: colors.neutral['5A']
   },
 
-  '&[aria-current], &[aria-selected="true"], &:active': {
+  '&[aria-current="page"], &[aria-selected="true"], &:active': {
     backgroundColor: colors.blue['10A'],
     color: colors.blue['500']
   },
 
-  '&[aria-current], &[aria-selected="true"]': {
+  '&[aria-current="page"], &[aria-selected="true"]': {
     cursor: 'default'
   },
 


### PR DESCRIPTION
WAI ARIA attributes are somewhat of a pain to understand in different contexts. `aria-current` and `aria-selected` is used differently in different contexts. Downshift uses `aria-selected` on the current item that is selected (aka hovered, or selected by tab). This resulted in a janky cursor change. This is fixed with this PR.