### PR TITLE
Enabling Dialog on Firefox 

### DIFF
--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -273,7 +273,8 @@ class Dialog extends React.Component {
                 data-state={state}
                 display="flex"
                 overflowY="auto"
-                margin={16}
+                marginY={16}
+                paddingX={16}
                 flexDirection="column"
                 minHeight={minHeightContent}
               >

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -171,7 +171,7 @@ class Dialog extends React.Component {
     width: 560,
     topOffset: '12vh',
     minHeightContent: 114,
-    minHeight: 300,
+    minHeight: 320,
     confirmLabel: 'Confirm',
     isConfirmLoading: false,
     isConfirmDisabled: false,
@@ -257,6 +257,7 @@ class Dialog extends React.Component {
               {hasHeader && (
                 <Pane
                   padding={16}
+                  flexShrink={0}
                   borderBottom="extraMuted"
                   display="flex"
                   alignItems="center"
@@ -280,26 +281,30 @@ class Dialog extends React.Component {
               </Pane>
 
               {hasFooter && (
-                <Pane borderTop="extraMuted" clearfix>
-                  <Pane padding={16} float="right">
-                    {/* Cancel should be first to make sure focus gets on it first. */}
-                    {hasCancel && (
-                      <Button tabIndex={0} onClick={close}>
-                        {cancelLabel}
-                      </Button>
-                    )}
-
-                    <Button
-                      tabIndex={0}
-                      marginLeft={8}
-                      appearance={buttonAppearance}
-                      isLoading={isConfirmLoading}
-                      disabled={isConfirmDisabled}
-                      onClick={() => onConfirm(close)}
-                    >
-                      {confirmLabel}
+                <Pane
+                  borderTop="extraMuted"
+                  flexShrink={0}
+                  padding={16}
+                  display="flex"
+                  justifyContent="flex-end"
+                >
+                  {/* Cancel should be first to make sure focus gets on it first. */}
+                  {hasCancel && (
+                    <Button tabIndex={0} onClick={close}>
+                      {cancelLabel}
                     </Button>
-                  </Pane>
+                  )}
+
+                  <Button
+                    tabIndex={0}
+                    marginLeft={8}
+                    appearance={buttonAppearance}
+                    isLoading={isConfirmLoading}
+                    disabled={isConfirmDisabled}
+                    onClick={() => onConfirm(close)}
+                  >
+                    {confirmLabel}
+                  </Button>
                 </Pane>
               )}
             </Pane>

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -241,7 +241,6 @@ class Dialog extends React.Component {
               borderRadius={8}
               width={width}
               display="flex"
-              justifyContent="space-between"
               flexDirection="column"
               css={animationStyles}
               data-state={state}

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -241,6 +241,7 @@ class Dialog extends React.Component {
               borderRadius={8}
               width={width}
               display="flex"
+              justifyContent="space-between"
               flexDirection="column"
               css={animationStyles}
               data-state={state}
@@ -249,7 +250,6 @@ class Dialog extends React.Component {
               {hasHeader && (
                 <Pane
                   padding={16}
-                  flexShrink={0}
                   borderBottom="extraMuted"
                   display="flex"
                   alignItems="center"
@@ -263,42 +263,38 @@ class Dialog extends React.Component {
 
               <Pane
                 data-state={state}
-                flex={1}
                 display="flex"
+                overflowY="auto"
+                margin={16}
                 flexDirection="column"
+                minHeight={minHeightContent}
               >
-                <Pane
-                  overflowY="auto"
-                  padding={16}
-                  minHeight={minHeightContent}
-                >
-                  {this.renderChildren(close)}
-                </Pane>
-
-                {hasFooter && (
-                  <Pane borderTop="extraMuted" clearfix>
-                    <Pane padding={16} float="right">
-                      {/* Cancel should be first to make sure focus gets on it first. */}
-                      {hasCancel && (
-                        <Button tabIndex={0} onClick={close}>
-                          {cancelLabel}
-                        </Button>
-                      )}
-
-                      <Button
-                        tabIndex={0}
-                        marginLeft={8}
-                        appearance={buttonAppearance}
-                        isLoading={isConfirmLoading}
-                        disabled={isConfirmDisabled}
-                        onClick={() => onConfirm(close)}
-                      >
-                        {confirmLabel}
-                      </Button>
-                    </Pane>
-                  </Pane>
-                )}
+                <Pane>{this.renderChildren(close)}</Pane>
               </Pane>
+
+              {hasFooter && (
+                <Pane borderTop="extraMuted" clearfix>
+                  <Pane padding={16} float="right">
+                    {/* Cancel should be first to make sure focus gets on it first. */}
+                    {hasCancel && (
+                      <Button tabIndex={0} onClick={close}>
+                        {cancelLabel}
+                      </Button>
+                    )}
+
+                    <Button
+                      tabIndex={0}
+                      marginLeft={8}
+                      appearance={buttonAppearance}
+                      isLoading={isConfirmLoading}
+                      disabled={isConfirmDisabled}
+                      onClick={() => onConfirm(close)}
+                    >
+                      {confirmLabel}
+                    </Button>
+                  </Pane>
+                </Pane>
+              )}
             </Pane>
           </Pane>
         )}

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -152,6 +152,11 @@ class Dialog extends React.Component {
     minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
+     * The min height of the dialog container.
+     */
+    minHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
      * Props that are passed to the dialog container.
      */
     containerProps: PropTypes.object
@@ -166,6 +171,7 @@ class Dialog extends React.Component {
     width: 560,
     topOffset: '12vh',
     minHeightContent: 114,
+    minHeight: 300,
     confirmLabel: 'Confirm',
     isConfirmLoading: false,
     isConfirmDisabled: false,
@@ -203,7 +209,8 @@ class Dialog extends React.Component {
       isConfirmDisabled,
       cancelLabel,
       containerProps,
-      minHeightContent
+      minHeightContent,
+      minHeight
     } = this.props
 
     let maxHeight
@@ -233,6 +240,7 @@ class Dialog extends React.Component {
             justifyContent="center"
             paddingTop={topOffset}
             maxHeight={maxHeight}
+            minHeight={minHeight}
           >
             <Pane
               role="dialog"


### PR DESCRIPTION
Currently evergreen Dialog behavior on FF is extending over the boundaries of the container.

I did extract footer from the scrollable component and put it at the same level as header/body of the dialog

Behavior for chrome stays the same :) 

### Current behavior on Firefox
![image](https://user-images.githubusercontent.com/952992/39454681-9abe0cfa-4c91-11e8-9cd7-4ed8603fad77.png)

### PR behavior on FF
![2018-04-30 16 15 25](https://user-images.githubusercontent.com/952992/39454714-c56db2d4-4c91-11e8-973b-d8000a248bea.gif)

### Chrome Behavior
![2018-04-30 16 16 28](https://user-images.githubusercontent.com/952992/39454739-e75ada34-4c91-11e8-99f0-15fa8ca019d7.gif)

## Min-Height Behavior
![2018-04-30 17 24 58](https://user-images.githubusercontent.com/952992/39456469-7773a76e-4c9b-11e8-8621-a1a855284d1b.gif)
