### PR TITLE
Fix getPosition

### DIFF
--- a/src/popover/stories/index.stories.js
+++ b/src/popover/stories/index.stories.js
@@ -125,6 +125,11 @@ storiesOf('popover', module)
         document.body.style.height = '100vh'
       })()}
       <Popover content={<PopoverContent />}>
+        <Button position="absolute" right={16} top={40} marginRight={20}>
+          Trigger Popover
+        </Button>
+      </Popover>
+      <Popover content={<PopoverContent />}>
         <Button marginRight={20}>Trigger Popover</Button>
       </Popover>
       <Popover

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -138,7 +138,7 @@ export default class Positioner extends PureComponent {
       document.documentElement.clientHeight + window.scrollY
     const viewportWidth = document.documentElement.clientWidth + window.scrollX
 
-    const position = getPosition({
+    const { rect, transformOrigin } = getPosition({
       position: this.props.position,
       targetRect,
       targetOffset: this.props.targetOffset,
@@ -155,9 +155,9 @@ export default class Positioner extends PureComponent {
 
     this.setState(
       {
-        left: position.left,
-        top: position.top,
-        transformOrigin: position.transformOrigin
+        left: rect.left,
+        top: rect.top,
+        transformOrigin
       },
       () => {
         window.requestAnimationFrame(() => {

--- a/src/positioner/src/getPosition.js
+++ b/src/positioner/src/getPosition.js
@@ -1,7 +1,14 @@
 import Position from './Position'
 
 /**
- * Utility to create rect
+ * Function to create a Rect.
+ * @param {Object} dimensions
+ * @param {Number} dimensions.width
+ * @param {Number} dimensions.height
+ * @param {Object} position
+ * @param {Number} position.left
+ * @param {Number} position.top
+ * @return {Object} Rect { width, height, left, top, right, bottom }
  */
 const makeRect = ({ width, height }, { left, top }) => {
   return {
@@ -14,6 +21,11 @@ const makeRect = ({ width, height }, { left, top }) => {
   }
 }
 
+/**
+ * Function to flip a position upside down.
+ * @param {Position} position
+ * @return {Position} flipped position
+ */
 const flipHorizontal = position => {
   switch (position) {
     case Position.TOP_LEFT:
@@ -32,6 +44,11 @@ const flipHorizontal = position => {
   }
 }
 
+/**
+ * Function that returns if position is aligned on top.
+ * @param {Position} position
+ * @return {Boolean}
+ */
 const isAlignedOnTop = position => {
   switch (position) {
     case Position.TOP_LEFT:
@@ -43,23 +60,40 @@ const isAlignedOnTop = position => {
   }
 }
 
-const isAlignedOnBottom = position => {
-  switch (position) {
-    case Position.BOTTOM_LEFT:
-    case Position.BOTTOM:
-    case Position.BOTTOM_RIGHT:
-      return true
-    default:
-      return false
-  }
-}
-
+/**
+ * Function that returns if a rect fits on bottom.
+ * @param {Rect} rect
+ * @param {Object} viewport
+ * @param {Number} viewportOffset
+ * @return {Boolean}
+ */
 const getFitsOnBottom = (rect, viewport, viewportOffset) => {
   return rect.bottom < viewport.height - viewportOffset
 }
 
+/**
+ * Function that returns if a rect fits on top.
+ * @param {Rect} rect
+ * @param {Number} viewportOffset
+ * @return {Boolean}
+ */
 const getFitsOnTop = (rect, viewportOffset) => {
   return rect.top > viewportOffset
+}
+
+/**
+ * Function that returns the CSS `tranform-origin` property.
+ * @param {Rect} rect
+ * @param {Position} position
+ * @param {Number} targetCenter - center of the target.
+ * @return {String} transform origin
+ */
+const getTransformOrigin = ({ rect, position, targetCenter }) => {
+  const center = Math.round(targetCenter - rect.left)
+  if (isAlignedOnTop(position)) {
+    return `bottom ${center}px`
+  }
+  return `top ${center}px`
 }
 
 /**
@@ -72,151 +106,193 @@ const getFitsOnTop = (rect, viewportOffset) => {
  * @param {Object} viewportOffset - offset from the viewport.
  * @return {Object} - { x: Number, y: Number }
  */
-export default function getPosition({
+export default function getFittedPosition({
   position,
   dimensions,
   targetRect,
   targetOffset,
   viewport,
-  viewportOffset = 8,
-  tries = 1
+  viewportOffset = 8
 }) {
-  const targetCenter =
-    targetRect.left + targetRect.width / 2 - dimensions.width / 2
+  const targetCenter = targetRect.left + targetRect.width / 2
+
+  const { rect, position: finalPosition } = getPosition({
+    position,
+    dimensions,
+    targetRect,
+    targetOffset,
+    viewport,
+    viewportOffset
+  })
+
+  // Push rect to the right if overflowing on the left side of the viewport.
+  if (rect.left < viewportOffset) {
+    rect.right += Math.ceil(Math.abs(rect.left - viewportOffset))
+    rect.left = Math.ceil(viewportOffset)
+  }
+
+  // Push rect to the left if overflowing on the right side of the viewport.
+  if (rect.right > viewport.width - viewportOffset) {
+    const delta = Math.ceil(rect.right - (viewport.width - viewportOffset))
+    rect.left -= delta
+    rect.right -= delta
+  }
+
+  const transformOrigin = getTransformOrigin({
+    rect,
+    position: finalPosition,
+    targetCenter
+  })
+
+  return {
+    rect,
+    position: finalPosition,
+    transformOrigin
+  }
+}
+
+/**
+ * Function that takes in numbers and position and gives the final coords.
+ * @param {Position} position — the position the positioner should be on.
+ * @param {Object} dimensions — the dimensions of the positioner.
+ * @param {Object} targetRect — the rect of the target.
+ * @param {Number} targetOffset - offset from the target.
+ * @param {Object} viewport - the width and height of the viewport.
+ * @param {Object} viewportOffset - offset from the viewport.
+ * @return {Object} - { rect: Rect, position: Position }
+ */
+function getPosition({
+  position,
+  dimensions,
+  targetRect,
+  targetOffset,
+  viewport,
+  viewportOffset = 8
+}) {
+  const positionIsAlignedOnTop = isAlignedOnTop(position)
+  let topRect
+  let bottomRect
+
+  if (positionIsAlignedOnTop) {
+    topRect = getRect({
+      position,
+      dimensions,
+      targetRect,
+      targetOffset
+    })
+    bottomRect = getRect({
+      position: flipHorizontal(position),
+      dimensions,
+      targetRect,
+      targetOffset
+    })
+  } else {
+    topRect = getRect({
+      position: flipHorizontal(position),
+      dimensions,
+      targetRect,
+      targetOffset
+    })
+    bottomRect = getRect({
+      position,
+      dimensions,
+      targetRect,
+      targetOffset
+    })
+  }
+
+  const topRectFitsOnTop = getFitsOnTop(topRect, viewportOffset)
+  const bottomRectFitsOnBottom = getFitsOnBottom(
+    bottomRect,
+    viewport,
+    viewportOffset
+  )
+
+  if (positionIsAlignedOnTop && topRectFitsOnTop) {
+    return {
+      position,
+      rect: topRect
+    }
+  }
+
+  if (!positionIsAlignedOnTop) {
+    if (bottomRectFitsOnBottom) {
+      return {
+        position,
+        rect: bottomRect
+      }
+    } else if (topRectFitsOnTop) {
+      return {
+        position: flipHorizontal(position),
+        rect: topRect
+      }
+    }
+  }
+
+  // Default to most spacious if there is no fit.
+  const spaceBottom = Math.abs(
+    viewport.height - viewportOffset - bottomRect.bottom
+  )
+  const spaceTop = Math.abs(topRect.top - viewportOffset)
+
+  if (spaceBottom < spaceTop) {
+    return {
+      position: positionIsAlignedOnTop ? flipHorizontal(position) : position,
+      rect: bottomRect
+    }
+  }
+
+  return {
+    position: positionIsAlignedOnTop ? position : flipHorizontal(position),
+    rect: topRect
+  }
+}
+
+/**
+ * Function that takes in numbers and position and gives the final coords.
+ * @param {Object} position - the width and height of the viewport.
+ * @param {Number} targetOffset - offset from the target.
+ * @param {Object} dimensions — the dimensions of the positioner.
+ * @param {Object} targetRect — the rect of the target.
+ * @return {Object} - { x: Number, y: Number }
+ */
+function getRect({ position, targetOffset, dimensions, targetRect }) {
+  const leftRect = targetRect.left + targetRect.width / 2 - dimensions.width / 2
   const alignedTopY = targetRect.top - dimensions.height - targetOffset
   const alignedBottomY = targetRect.bottom + targetOffset
   const alignedRightX = targetRect.right - dimensions.width
 
-  // Create a function that will fit the rect inside of the boundaries
-  // and return a new rect.
-  const fitInBoundaries = rect => {
-    const fittedRect = { ...rect }
-
-    if (rect.left < viewportOffset) {
-      fittedRect.left = viewportOffset
-    }
-
-    if (rect.right > viewport.width - viewportOffset) {
-      fittedRect.right = viewport.width - viewportOffset
-    }
-
-    const fitsOnBottom = getFitsOnBottom(fittedRect, viewport, viewportOffset)
-    const fitsOnTop = getFitsOnTop(fittedRect, viewportOffset)
-
-    if (tries === 3) return fittedRect
-
-    if (tries === 2) {
-      const topDelta = targetRect.top - viewportOffset
-      const bottomDelta = viewport.height - viewportOffset - targetRect.bottom
-
-      const shouldBeOnBottom = topDelta < bottomDelta
-      if (isAlignedOnBottom(position) && shouldBeOnBottom) return fittedRect
-
-      return getPosition({
-        position: flipHorizontal(position),
-        dimensions,
-        targetRect,
-        targetOffset,
-        viewport,
-        viewportOffset,
-        tries: tries + 1
-      })
-    }
-
-    if (isAlignedOnBottom(position) && !fitsOnBottom) {
-      return getPosition({
-        position: flipHorizontal(position),
-        dimensions,
-        targetRect,
-        targetOffset,
-        viewport,
-        viewportOffset,
-        tries: tries + 1
-      })
-    }
-
-    if (isAlignedOnTop(position) && !fitsOnTop) {
-      return getPosition({
-        position: flipHorizontal(position),
-        dimensions,
-        targetRect,
-        targetOffset,
-        viewport,
-        viewportOffset,
-        tries: tries + 1
-      })
-    }
-
-    return fittedRect
-  }
-
   switch (position) {
     case Position.TOP:
-      return {
-        position: Position.TOP_TOP,
-        transformOrigin: 'bottom center',
-        ...fitInBoundaries(
-          makeRect(dimensions, {
-            left: targetCenter,
-            top: alignedTopY
-          })
-        )
-      }
+      return makeRect(dimensions, {
+        left: leftRect,
+        top: alignedTopY
+      })
     case Position.TOP_LEFT:
-      return {
-        position: Position.TOP_LEFT,
-        transformOrigin: 'bottom left',
-        ...fitInBoundaries(
-          makeRect(dimensions, {
-            left: targetRect.left,
-            top: alignedTopY
-          })
-        )
-      }
+      return makeRect(dimensions, {
+        left: targetRect.left,
+        top: alignedTopY
+      })
     case Position.TOP_RIGHT:
-      return {
-        position: Position.TOP_RIGHT,
-        transformOrigin: 'bottom right',
-        ...fitInBoundaries(
-          makeRect(dimensions, {
-            left: alignedRightX,
-            top: alignedTopY
-          })
-        )
-      }
+      return makeRect(dimensions, {
+        left: alignedRightX,
+        top: alignedTopY
+      })
     default:
     case Position.BOTTOM:
-      return {
-        position: Position.BOTTOM,
-        transformOrigin: 'top center',
-        ...fitInBoundaries(
-          makeRect(dimensions, {
-            left: targetCenter,
-            top: alignedBottomY
-          })
-        )
-      }
+      return makeRect(dimensions, {
+        left: leftRect,
+        top: alignedBottomY
+      })
     case Position.BOTTOM_LEFT:
-      return {
-        position: Position.BOTTOM_LEFT,
-        transformOrigin: 'top left',
-        ...fitInBoundaries(
-          makeRect(dimensions, {
-            left: targetRect.left,
-            top: alignedBottomY
-          })
-        )
-      }
+      return makeRect(dimensions, {
+        left: targetRect.left,
+        top: alignedBottomY
+      })
     case Position.BOTTOM_RIGHT:
-      return {
-        position: Position.BOTTOM_RIGHT,
-        transformOrigin: 'top right',
-        ...fitInBoundaries(
-          makeRect(dimensions, {
-            left: alignedRightX,
-            top: alignedBottomY
-          })
-        )
-      }
+      return makeRect(dimensions, {
+        left: alignedRightX,
+        top: alignedBottomY
+      })
   }
 }


### PR DESCRIPTION
**This should be released as a patch.**

I have been updating the positioning a couple of times. Each time a learn a bit more and make improvements. The last version live was not super great and had some bugs when overflowing on the right of the viewport.

This version drops the weird recursive behavior and is a lot more stable. Additionally when there is not enough space on either the top or the bottom—the logic choses the side with most space.

## Current Behavior
![image](https://user-images.githubusercontent.com/564463/40146262-ba5b81de-5919-11e8-9adf-8c8a35a400bf.png)

# Solution

The story I use for testing Popover shows that it is working perfectly in each scenario:

## Push to the left to compensate viewport overflow

![image](https://user-images.githubusercontent.com/564463/40146277-cbf682e0-5919-11e8-8296-f1f3c769091d.png)

## Show on top with smart positioning

![image](https://user-images.githubusercontent.com/564463/40146331-f721fbfc-5919-11e8-9dba-4dfaac90649a.png)

## Use the most spacious side to show the popover on when there is no space on either side

![image](https://user-images.githubusercontent.com/564463/40146350-0c2b287a-591a-11e8-8f44-22647c6353c1.png)

## Push to the right to compensate viewport overflow

![image](https://user-images.githubusercontent.com/564463/40146403-33bde30a-591a-11e8-9bf1-d7d0293ea0e8.png)

