### PR TITLE
Update to Select-Menu multiselect docs, example, & story

### DIFF
--- a/src/select-menu/docs/examples/SelectMenu-multi.example
+++ b/src/select-menu/docs/examples/SelectMenu-multi.example
@@ -10,7 +10,7 @@
       options={state.options}
       selected={state.selected}
       onSelect={item => {
-        let  selected = [...state.selected, item.value]
+        const selected = [...state.selected, item.value]
         const selectedItems = selected
         const selectedItemsLength = selectedItems.length
         let selectedNames = ''

--- a/src/select-menu/docs/examples/SelectMenu-multi.example
+++ b/src/select-menu/docs/examples/SelectMenu-multi.example
@@ -1,51 +1,49 @@
-    <Manager>
-      {({ setState, state }) => (
-        <SelectMenu
-          title="Select multiple names"
-          options={options}
-          selected={state.selected}
-          onSelect={item => {
-            let selected
-            if (Array.isArray(state.selected)) {
-              selected = [...state.selected, item.value]
-            } else {
-              selected = arrify(item.value)
-            }
-            const selectedItems = selected
-            const selectedItemsLength = selectedItems.length
-            let selectedNames = ''
-            if (selectedItemsLength === 0) {
-              selectedNames = ''
-            }
-            else if (selectedItemsLength === 1) {
-              selectedNames = selectedItems.toString()
-            } else if (selectedItemsLength > 1 ) {
-              selectedNames = selectedItemsLength.toString() + " selected..."
-            }
-            setState({
-              selected,
-              selectedNames
-            })
-          }}
-          onDeselect={item => {
-            const deselectedItemIndex = state.selected.indexOf(item.value)
-            const selectedItems = state.selected.filter(
-              (_item, i) => i !== deselectedItemIndex
-            )
-            const selectedItemsLength = selectedItems.length
-            let selectedNames = ''
-            if (selectedItemsLength === 0) {
-              selectedNames = ''
-            }
-            else if (selectedItemsLength === 1) {
-              selectedNames = selectedItems.toString()
-            } else if (selectedItemsLength > 1 ) {
-              selectedNames = selectedItemsLength.toString() + " selected..."
-            }
-            setState({ selected: selectedItems, selectedNames })
-          }}
-        >
-          <Button>{state.selectedNames || 'Select multiple...'}</Button>
-        </SelectMenu>
-      )}
-    </Manager>
+<Component
+  initialState={{
+    options: options,
+    selected: [] 
+  }}
+>
+  {({ state, setState }) => (
+    <SelectMenu
+      title="Select multiple names"
+      options={state.options}
+      selected={state.selected}
+      onSelect={item => {
+        let  selected = [...state.selected, item.value]
+        const selectedItems = selected
+        const selectedItemsLength = selectedItems.length
+        let selectedNames = ''
+        if (selectedItemsLength === 0) {
+          selectedNames = ''
+        } else if (selectedItemsLength === 1) {
+          selectedNames = selectedItems.toString()
+        } else if (selectedItemsLength > 1) {
+          selectedNames = selectedItemsLength.toString() + ' selected...'
+        }
+        setState({
+          selected,
+          selectedNames
+        })
+      }}
+      onDeselect={item => {
+        const deselectedItemIndex = state.selected.indexOf(item.value)
+        const selectedItems = state.selected.filter(
+          (_item, i) => i !== deselectedItemIndex
+        )
+        const selectedItemsLength = selectedItems.length
+        let selectedNames = ''
+        if (selectedItemsLength === 0) {
+          selectedNames = ''
+        } else if (selectedItemsLength === 1) {
+          selectedNames = selectedItems.toString()
+        } else if (selectedItemsLength > 1) {
+          selectedNames = selectedItemsLength.toString() + ' selected...'
+        }
+        setState({ selected: selectedItems, selectedNames })
+      }}
+    >
+      <Button>{state.selectedNames || 'Select multiple...'}</Button>
+    </SelectMenu>
+  )}
+</Component>

--- a/src/select-menu/docs/index.js
+++ b/src/select-menu/docs/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Box from 'ui-box'
+import Component from '@reactions/component'
 import SelectMenu from '../src/SelectMenu'
 import { Button } from '../../buttons/'
 import SyntaxHighlighter from '../../../docs/src/components/SyntaxHighlighter'
@@ -67,6 +68,7 @@ const appearanceOptions = null
 const scope = {
   Box,
   SelectMenu,
+  Component,
   Button,
   Manager,
   options
@@ -93,10 +95,10 @@ const components = [
         scope
       },
       {
-        title: 'Multi SelectMenu Example',
+        title: 'SelectMenu Multiselect with Deselect Example',
         description: (
           <div>
-            <p>This example shows basic usage with multiple selected items.</p>
+            <p>This example shows usage with multiple selected items.</p>
             <p>
               This pattern is only an example. Selected values and the
               formatting of their names should be managed wherever you choose to

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -35,7 +35,7 @@ export default class SelectMenu extends PureComponent {
      */
     onSelect: PropTypes.func,
     /**
-     * Function that is called when an option is Deselected.
+     * Function that is called when an option is deselected.
      */
     onDeselect: PropTypes.func,
 

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react'
-import arrify from 'arrify'
+import Component from '@reactions/component'
 import React from 'react'
 import Box from 'ui-box'
 import options from '../docs/starwars-options'
@@ -25,19 +25,19 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
         </SelectMenu>
       )}
     </Manager>
-    <Manager>
-      {({ setState, state }) => (
+    <Component
+      initialState={{
+        options,
+        selected: []
+      }}
+    >
+      {({ state, setState }) => (
         <SelectMenu
           title="Select multiple names"
-          options={options}
+          options={state.options}
           selected={state.selected}
           onSelect={item => {
-            let selected
-            if (Array.isArray(state.selected)) {
-              selected = [...state.selected, item.value]
-            } else {
-              selected = arrify(item.value)
-            }
+            const selected = [...state.selected, item.value]
             const selectedItems = selected
             const selectedItemsLength = selectedItems.length
             let selectedNames = ''
@@ -73,6 +73,6 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
           <Button>{state.selectedNames || 'Select multiple...'}</Button>
         </SelectMenu>
       )}
-    </Manager>
+    </Component>
   </Box>
 ))


### PR DESCRIPTION
Per @jeroenransijn guidance on docs/examples usage here #175 & #198 

- Add import & scope ref for `<Component />`  per #175
- Simplify the state management with options & selected array for the example & story
- Still use options from starwars-options that is scoped in

