### PR TITLE
allow passthrough props on menu item, and always bubble highjacked ev…

### DIFF
--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -54,20 +54,30 @@ class MenuItem extends React.PureComponent {
     is: 'div',
     intent: 'none',
     appearance: 'default',
-    onClick: () => {},
-    onSelect: () => {},
-    onKeyPress: () => {}
+    onSelect: () => {}
   }
 
-  handleClick = () => {
-    this.props.onSelect()
-  }
+  handleClick = event => {
+    this.props.onSelect(event)
 
-  handleKeyPress = e => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      this.props.onSelect()
-      e.preventDefault()
+    /* eslint-disable react/prop-types */
+    if (typeof this.props.onClick === 'function') {
+      this.props.onClick(event)
     }
+    /* eslint-enable react/prop-types */
+  }
+
+  handleKeyPress = event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      this.props.onSelect(event)
+      event.preventDefault()
+    }
+
+    /* eslint-disable react/prop-types */
+    if (typeof this.props.onKeyPress === 'function') {
+      this.props.onKeyPress(event)
+    }
+    /* eslint-enable react/prop-types */
   }
 
   render() {
@@ -78,7 +88,8 @@ class MenuItem extends React.PureComponent {
       appearance,
       secondaryText,
       intent,
-      icon
+      icon,
+      ...passthroughProps
     } = this.props
 
     const themedClassName = theme.getMenuItemClassName(appearance, 'none')
@@ -95,6 +106,7 @@ class MenuItem extends React.PureComponent {
         data-isselecteable="true"
         display="flex"
         alignItems="center"
+        {...passthroughProps}
       >
         {icon && (
           <Icon


### PR DESCRIPTION
This PR enhances the `Menu.Item` component to allow for unknown (user-defined) props in order to fully support using the `is={MyCustomComponent}` prop.

It also changes the behavior of all event handlers that we are hooking into so that we always ensure we bubble those events to consumer props. I generally consider this a "best practice" when it comes to making components extensible and versatile.