### PR TITLE
[V4] Use Tooltip inside of a Popover

### DIFF
--- a/docs/src/componentRoutes.js
+++ b/docs/src/componentRoutes.js
@@ -49,6 +49,10 @@ module.exports = [
     path: '/components/colors'
   },
   {
+    name: 'Select',
+    path: '/components/select'
+  },
+  {
     name: 'Select Menu',
     path: '/components/select-menu'
   },

--- a/docs/src/utils/getComponent.js
+++ b/docs/src/utils/getComponent.js
@@ -7,7 +7,6 @@ import buttonsDocs from '../../../src/buttons/docs'
 import autocompleteDocs from '../../../src/autocomplete/docs/'
 import comboboxDocs from '../../../src/combobox/docs/'
 // import badgesDocs from '../../src/badges/docs/'
-// import selectDocs from '../../src/select/docs/'
 import popoverDocs from '../../../src/popover/docs/'
 // import portalDocs from '../../src/portal/docs/'
 import textInputDocs from '../../../src/text-input/docs/'
@@ -29,6 +28,7 @@ import cornerDialogDocs from '../../../src/corner-dialog/docs/'
 import alertDocs from '../../../src/alert/docs/'
 import toasterDocs from '../../../src/toaster/docs/'
 import selectMenuDocs from '../../../src/select-menu/docs/'
+import selectDocs from '../../../src/select/docs/'
 
 const map = {
   radio: radioDocs,
@@ -41,6 +41,7 @@ const map = {
   layers: layersDocs,
   typography: typographyDocs,
   colors: colorsDocs,
+  select: selectDocs,
   'select menu': selectMenuDocs,
   'text input': textInputDocs,
   'search input': searchInputDocs,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "4.0.0-14",
+  "version": "4.0.0-15",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export { Radio, RadioGroup } from './radio'
 export { minorScale, majorScale } from './scales'
 export { SearchInput } from './search-input'
 export { SegmentedControl } from './segmented-control'
-export { Select } from './select'
+export { Select, SelectField } from './select'
 export {
   OptionShapePropType,
   OptionsList,

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Position, Positioner } from '../../positioner'
+import { Tooltip } from '../../tooltip'
 import PopoverStateless from './PopoverStateless'
 
 export default class Popover extends Component {
@@ -237,12 +238,16 @@ export default class Popover extends Component {
 
   renderTarget = ({ getRef, isShown }) => {
     const { children } = this.props
+    const isTooltipInside = children.type === Tooltip
 
     const getTargetRef = ref => {
       this.targetRef = ref
       getRef(ref)
     }
 
+    /**
+     * When a function is passed, you can control the Popover manually.
+     */
     if (typeof children === 'function') {
       return children({
         toggle: this.toggle,
@@ -251,13 +256,39 @@ export default class Popover extends Component {
       })
     }
 
-    return React.cloneElement(children, {
+    const popoverTargetProps = {
       onClick: this.toggle,
       onKeyDown: this.handleKeyDown,
-      innerRef: getTargetRef,
       role: 'button',
       'aria-expanded': isShown,
       'aria-haspopup': true
+    }
+
+    /**
+     * Tooltips can be used within a Popover (not the other way around)
+     * In this case the children is the Tooltip instead of a button.
+     * Pass the properties to the Tooltip and let the Tooltip
+     * add the properties to the target.
+     */
+    if (isTooltipInside) {
+      return React.cloneElement(children, {
+        popoverProps: {
+          getTargetRef,
+          isShown,
+
+          // These propeties will be spread as `popoverTargetProps`
+          // in the Tooltip component.
+          ...popoverTargetProps
+        }
+      })
+    }
+
+    /**
+     * With normal usage only popover props end up on the target.
+     */
+    return React.cloneElement(children, {
+      innerRef: getTargetRef,
+      ...popoverTargetProps
     })
   }
 

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -238,7 +238,7 @@ export default class Popover extends Component {
 
   renderTarget = ({ getRef, isShown }) => {
     const { children } = this.props
-    const isTooltipInside = children.type === Tooltip
+    const isTooltipInside = children && children.type === Tooltip
 
     const getTargetRef = ref => {
       this.targetRef = ref

--- a/src/popover/stories/index.stories.js
+++ b/src/popover/stories/index.stories.js
@@ -3,9 +3,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { Popover } from '../../popover'
+import { Tooltip } from '../../tooltip'
 import { TextInputField } from '../../text-input'
 import { Pane } from '../../layers'
-import { Text } from '../../typography'
+import { Heading, Paragraph, Text } from '../../typography'
 import { Button } from '../../buttons'
 import { Position } from '../../positioner'
 import { Icon, IconNames } from '../../icon'
@@ -183,6 +184,40 @@ storiesOf('popover', module)
         <Button marginRight={20}>
           <Icon icon={IconNames.CIRCLE_ARROW_DOWN} />
         </Button>
+      </Popover>
+    </Box>
+  ))
+  .add('Popover with tooltip', () => (
+    <Box padding={120}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <Popover content={<PopoverContentWithTextInput />}>
+        <Tooltip content="Click me">
+          <Button marginRight={20}>Tooltip Card + Popover</Button>
+        </Tooltip>
+      </Popover>
+      <Popover content={<PopoverContentWithTextInput />}>
+        <Tooltip
+          appearance="card"
+          content={
+            <React.Fragment>
+              <Heading>Heading</Heading>
+              <Paragraph color="muted" marginTop={4}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              </Paragraph>
+            </React.Fragment>
+          }
+          statelessProps={{
+            paddingY: 24,
+            paddingX: 24,
+            maxWidth: 280
+          }}
+        >
+          <Button>Tooltip + Popover</Button>
+        </Tooltip>
       </Popover>
     </Box>
   ))

--- a/src/select/docs/examples/Select-basic.example
+++ b/src/select/docs/examples/Select-basic.example
@@ -1,0 +1,4 @@
+<Select onChange={(event) => alert(event.target.value)}>
+  <option value="foo" checked>Foo</option>
+  <option value="bar">Bar</option>
+</Select>

--- a/src/select/docs/index.js
+++ b/src/select/docs/index.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import Box from 'ui-box'
+import Component from '@reactions/component'
+import Select from '../src/Select'
+
+/* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
+import sourceSelect from '!raw-loader!../src/Select'
+/* eslint-enable import/no-unresolved, import/no-webpack-loader-syntax */
+
+/**
+ * Code examples
+ */
+import exampleSelectBasic from './examples/Select-basic.example'
+
+const title = 'Select'
+const subTitle = 'A styled native <select> for choosing items from a list.'
+
+const introduction = (
+  <div>
+    <p>
+      The <code>Select</code> component is a styled wrapper around a native{' '}
+      <code>select</code> element, which allows selection of one item from a
+      dropdown list. Anytime you would reach for a native select, use this.
+    </p>
+  </div>
+)
+
+const appearanceOptions = null
+
+const scope = {
+  Box,
+  Select,
+  Component
+}
+
+const components = [
+  {
+    name: 'Select',
+    source: sourceSelect,
+    description: (
+      <p>
+        The <code>Select</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Select Example',
+        description: (
+          <div>
+            <p>This example shows basic usage with a selected item.</p>
+          </div>
+        ),
+        codeText: exampleSelectBasic,
+        scope
+      }
+    ]
+  }
+]
+
+export default {
+  title,
+  subTitle,
+  introduction,
+  appearanceOptions,
+  components
+}

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -1,1 +1,2 @@
 export Select from './src/Select'
+export SelectField from './src/SelectField'

--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -105,13 +105,14 @@ class Select extends PureComponent {
     const textSize = theme.getTextSizeForControlHeight(height)
     const borderRadius = theme.getBorderRadiusForControlHeight(height)
     const iconSize = theme.getIconSizeForSelect(height)
+    const iconMargin = height >= 36 ? 12 : 8
 
     return (
       <Box
         display="inline-flex"
         flex={1}
         position="relative"
-        width={200}
+        width="auto"
         height={height}
         {...props}
       >
@@ -130,6 +131,8 @@ class Select extends PureComponent {
           borderRadius={borderRadius}
           textTransform="default"
           paddingLeft={Math.round(height / 3.2)}
+          // Provide enough space for auto-sizing select including the icon
+          paddingRight={iconMargin * 2 + iconSize}
         >
           {children}
         </Text>
@@ -140,7 +143,7 @@ class Select extends PureComponent {
           position="absolute"
           top="50%"
           marginTop={-iconSize / 2}
-          right={height >= 36 ? 12 : 8}
+          right={iconMargin}
           pointerEvents="none"
         />
       </Box>

--- a/src/select/src/SelectField.js
+++ b/src/select/src/SelectField.js
@@ -2,16 +2,16 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { splitBoxProps } from 'ui-box'
 import { FormField } from '../../form-field'
-import TextInput from './TextInput'
+import Select from './Select'
 
 let idCounter = 0
 
 export default class TextInputField extends PureComponent {
   static propTypes = {
     /**
-     * Composes the TextInput component as the base.
+     * Composes the Select component as the base.
      */
-    ...TextInput.propTypes,
+    ...Select.propTypes,
     ...FormField.propTypes,
 
     /**
@@ -86,14 +86,12 @@ export default class TextInputField extends PureComponent {
       required,
       isInvalid,
       appearance,
-      placeholder,
-      spellCheck,
 
       // Rest props are spread on the FormField
       ...props
     } = this.props
 
-    const id = `TextInputField-${this.state.id}`
+    const id = `SelectField-${this.state.id}`
 
     /**
      * Split the wrapper props from the input props.
@@ -111,7 +109,7 @@ export default class TextInputField extends PureComponent {
         labelFor={id}
         {...matchedProps}
       >
-        <TextInput
+        <Select
           id={id}
           width={inputWidth}
           height={inputHeight}
@@ -119,8 +117,6 @@ export default class TextInputField extends PureComponent {
           required={required}
           isInvalid={isInvalid}
           appearance={appearance}
-          placeholder={placeholder}
-          spellCheck={spellCheck}
           {...remainingProps}
         />
       </FormField>

--- a/src/theme/src/default-theme/component-specific/getTooltipProps.js
+++ b/src/theme/src/default-theme/component-specific/getTooltipProps.js
@@ -1,11 +1,21 @@
 import tinycolor from 'tinycolor2'
 import palette from '../foundational-styles/palette'
 
-const getTooltipProps = () => {
-  return {
-    backgroundColor: tinycolor(palette.neutral.base)
-      .setAlpha(0.95)
-      .toString()
+const getTooltipProps = appearance => {
+  switch (appearance) {
+    case 'card':
+      return {
+        backgroundColor: 'white',
+        elevation: 3
+      }
+    case 'default':
+    default:
+      return {
+        color: 'white',
+        backgroundColor: tinycolor(palette.neutral.base)
+          .setAlpha(0.95)
+          .toString()
+      }
   }
 }
 

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -36,7 +36,7 @@ export default class Tooltip extends PureComponent {
     /**
      * The target button of the Tooltip.
      */
-    children: PropTypes.node.isRequried,
+    children: PropTypes.node.isRequired,
 
     /**
      * Properties passed through to the Tooltip.

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -41,13 +41,7 @@ export default class Tooltip extends PureComponent {
     /**
      * Properties passed through to the Tooltip.
      */
-    statelessProps: PropTypes.object,
-
-    /**
-     * This is an implementation detail. Please ignore.
-     * This is passed when a Tooltip is inside a Popover.
-     */
-    popoverProps: PropTypes.object
+    statelessProps: PropTypes.object
   }
 
   static defaultProps = {
@@ -101,9 +95,12 @@ export default class Tooltip extends PureComponent {
      * When a Tooltip is used within a Popover, the Popover passes
      * its props to the Tooltip in a `popoverProps` object.
      */
+    // eslint-disable-next-line react/prop-types
     if (this.props.popoverProps) {
       const {
+        // eslint-disable-next-line react/prop-types
         getTargetRef,
+        // eslint-disable-next-line react/prop-types
         isShown,
         ...popoverTargetProps
       } = this.props.popoverProps

--- a/src/tooltip/src/TooltipStateless.js
+++ b/src/tooltip/src/TooltipStateless.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import Box from 'ui-box'
+import { Pane } from '../../layers'
 import { Paragraph } from '../../typography'
 import { withTheme } from '../../theme'
 
@@ -9,17 +9,24 @@ class TooltipStateless extends PureComponent {
     children: PropTypes.node,
 
     /**
+     * The appearance of the tooltip.
+     */
+    appearance: PropTypes.oneOf(['default', 'card']).isRequired,
+
+    /**
      * Theme provided by ThemeProvider.
      */
     theme: PropTypes.object.isRequired
   }
 
   render() {
-    const { theme, children, ...props } = this.props
+    const { theme, children, appearance, ...props } = this.props
+    const { color, ...themedProps } = theme.getTooltipProps(appearance)
+
     let child
     if (typeof children === 'string') {
       child = (
-        <Paragraph color="white" size={400}>
+        <Paragraph color={color} size={400}>
           {children}
         </Paragraph>
       )
@@ -28,16 +35,16 @@ class TooltipStateless extends PureComponent {
     }
 
     return (
-      <Box
-        {...theme.getTooltipProps()}
+      <Pane
         borderRadius={3}
         paddingX={8}
         paddingY={4}
         maxWidth={240}
+        {...themedProps}
         {...props}
       >
         {child}
-      </Box>
+      </Pane>
     )
   }
 }


### PR DESCRIPTION
This PR implements the support of putting a `Tooltip` inside of a `Popover`.

## Preview
![popover tooltip styled](https://user-images.githubusercontent.com/564463/42973586-8a51447a-8b68-11e8-8e4e-8c4f64fed77a.gif)

## Code Example

The above example is rendered by the following code.

```jsx
<Popover content={<PopoverContentWithTextInput />}>
  <Tooltip content="Click me">
    <Button marginRight={20}>Tooltip Card + Popover</Button>
  </Tooltip>
</Popover>
<Popover content={<PopoverContentWithTextInput />}>
  <Tooltip
    appearance="card"
    content={
      <React.Fragment>
        <Heading>Heading</Heading>
        <Paragraph color="muted" marginTop={4}>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
          eiusmod tempor incididunt ut labore et dolore magna aliqua.
        </Paragraph>
      </React.Fragment>
    }
    statelessProps={{
      paddingY: 24,
      paddingX: 24,
      maxWidth: 280
    }}
  >
    <Button>Tooltip + Popover</Button>
  </Tooltip>
</Popover>
```

## Other additions

This PR also adds the support for 2 appearances on a `Tooltip`: `default` and `card`.