### PR TITLE
Bug/select icon margin

### DIFF
--- a/docs/src/componentRoutes.js
+++ b/docs/src/componentRoutes.js
@@ -49,6 +49,10 @@ module.exports = [
     path: '/components/colors'
   },
   {
+    name: 'Select',
+    path: '/components/select'
+  },
+  {
     name: 'Select Menu',
     path: '/components/select-menu'
   },

--- a/docs/src/utils/getComponent.js
+++ b/docs/src/utils/getComponent.js
@@ -7,7 +7,6 @@ import buttonsDocs from '../../../src/buttons/docs'
 import autocompleteDocs from '../../../src/autocomplete/docs/'
 import comboboxDocs from '../../../src/combobox/docs/'
 // import badgesDocs from '../../src/badges/docs/'
-// import selectDocs from '../../src/select/docs/'
 import popoverDocs from '../../../src/popover/docs/'
 // import portalDocs from '../../src/portal/docs/'
 import textInputDocs from '../../../src/text-input/docs/'
@@ -29,6 +28,7 @@ import cornerDialogDocs from '../../../src/corner-dialog/docs/'
 import alertDocs from '../../../src/alert/docs/'
 import toasterDocs from '../../../src/toaster/docs/'
 import selectMenuDocs from '../../../src/select-menu/docs/'
+import selectDocs from '../../../src/select/docs/'
 
 const map = {
   radio: radioDocs,
@@ -41,6 +41,7 @@ const map = {
   layers: layersDocs,
   typography: typographyDocs,
   colors: colorsDocs,
+  select: selectDocs,
   'select menu': selectMenuDocs,
   'text input': textInputDocs,
   'search input': searchInputDocs,

--- a/src/select/docs/examples/Select-basic.example
+++ b/src/select/docs/examples/Select-basic.example
@@ -1,4 +1,4 @@
-<Select onChange={(event) => console.log(event.target.value)}>
+<Select onChange={(event) => alert(event.target.value)}>
   <option value="foo" checked>Foo</option>
   <option value="bar">Bar</option>
 </Select>

--- a/src/select/docs/examples/Select-basic.example
+++ b/src/select/docs/examples/Select-basic.example
@@ -1,0 +1,4 @@
+<Select onChange={(event) => console.log(event.target.value)}>
+  <option value="foo" checked>Foo</option>
+  <option value="bar">Bar</option>
+</Select>

--- a/src/select/docs/index.js
+++ b/src/select/docs/index.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import Box from 'ui-box'
+import Component from '@reactions/component'
+import Select from '../src/Select'
+
+/* eslint-disable import/no-unresolved, import/no-webpack-loader-syntax */
+import sourceSelect from '!raw-loader!../src/Select'
+/* eslint-enable import/no-unresolved, import/no-webpack-loader-syntax */
+
+/**
+ * Code examples
+ */
+import exampleSelectBasic from './examples/Select-basic.example'
+
+const title = 'Select'
+const subTitle = 'A styled native <select> for choosing items from a list.'
+
+const introduction = (
+  <div>
+    <p>
+      The <code>Select</code> component is a styled wrapper around a native{' '}
+      <code>select</code> element, which allows selection of one item from a
+      dropdown list. Anytime you would reach for a native select, use this.
+    </p>
+  </div>
+)
+
+const appearanceOptions = null
+
+const scope = {
+  Box,
+  Select,
+  Component
+}
+
+const components = [
+  {
+    name: 'Select',
+    source: sourceSelect,
+    description: (
+      <p>
+        The <code>Select</code> component.
+      </p>
+    ),
+    examples: [
+      {
+        title: 'Basic Select Example',
+        description: (
+          <div>
+            <p>This example shows basic usage with a selected item.</p>
+          </div>
+        ),
+        codeText: exampleSelectBasic,
+        scope
+      }
+    ]
+  }
+]
+
+export default {
+  title,
+  subTitle,
+  introduction,
+  appearanceOptions,
+  components
+}

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -1,1 +1,2 @@
 export Select from './src/Select'
+export SelectField from './src/SelectField'

--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -105,13 +105,14 @@ class Select extends PureComponent {
     const textSize = theme.getTextSizeForControlHeight(height)
     const borderRadius = theme.getBorderRadiusForControlHeight(height)
     const iconSize = theme.getIconSizeForSelect(height)
+    const iconMargin = height >= 36 ? 12 : 8
 
     return (
       <Box
         display="inline-flex"
         flex={1}
         position="relative"
-        width={200}
+        width="auto"
         height={height}
         {...props}
       >
@@ -130,6 +131,8 @@ class Select extends PureComponent {
           borderRadius={borderRadius}
           textTransform="default"
           paddingLeft={Math.round(height / 3.2)}
+          // Provide enough space for auto-sizing select including the icon
+          paddingRight={iconMargin * 2 + iconSize}
         >
           {children}
         </Text>
@@ -140,7 +143,7 @@ class Select extends PureComponent {
           position="absolute"
           top="50%"
           marginTop={-iconSize / 2}
-          right={height >= 36 ? 12 : 8}
+          right={iconMargin}
           pointerEvents="none"
         />
       </Box>

--- a/src/select/src/SelectField.js
+++ b/src/select/src/SelectField.js
@@ -2,16 +2,16 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { splitBoxProps } from 'ui-box'
 import { FormField } from '../../form-field'
-import TextInput from './TextInput'
+import Select from './Select'
 
 let idCounter = 0
 
 export default class TextInputField extends PureComponent {
   static propTypes = {
     /**
-     * Composes the TextInput component as the base.
+     * Composes the Select component as the base.
      */
-    ...TextInput.propTypes,
+    ...Select.propTypes,
     ...FormField.propTypes,
 
     /**
@@ -86,14 +86,12 @@ export default class TextInputField extends PureComponent {
       required,
       isInvalid,
       appearance,
-      placeholder,
-      spellCheck,
 
       // Rest props are spread on the FormField
       ...props
     } = this.props
 
-    const id = `TextInputField-${this.state.id}`
+    const id = `SelectField-${this.state.id}`
 
     /**
      * Split the wrapper props from the input props.
@@ -111,7 +109,7 @@ export default class TextInputField extends PureComponent {
         labelFor={id}
         {...matchedProps}
       >
-        <TextInput
+        <Select
           id={id}
           width={inputWidth}
           height={inputHeight}
@@ -119,8 +117,6 @@ export default class TextInputField extends PureComponent {
           required={required}
           isInvalid={isInvalid}
           appearance={appearance}
-          placeholder={placeholder}
-          spellCheck={spellCheck}
           {...remainingProps}
         />
       </FormField>


### PR DESCRIPTION
This fixes a style issue with `<Select />` when placed inside flex containers or when allowed to have an unconstrained width (`width: auto`) by including `paddingRight={sizeOfIconPlusPaddingX}`.

It also adds `/docs` and a `SelectField` component that matches the implementation for `TextInputField`.

We may have opportunities for refactoring later, but for now making this available is really great.

<img width="1792" alt="screen shot 2018-07-20 at 11 31 04 am" src="https://user-images.githubusercontent.com/710752/43014013-6a70ee28-8c10-11e8-988c-95bc3e4628c2.png">
