### PR TITLE
[v4] enable passing `defaultValue` for uncontrolled select inputs

### DIFF
--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -43,6 +43,11 @@ class Select extends PureComponent {
     children: PropTypes.node,
 
     /**
+     * The initial value of an uncontrolled select
+     */
+    defaultValue: PropTypes.any,
+
+    /**
      * Function called when value changes.
      */
     onChange: PropTypes.func,
@@ -91,6 +96,7 @@ class Select extends PureComponent {
       name,
       height,
       children,
+      defaultValue,
       disabled,
       onChange,
       value,
@@ -122,6 +128,7 @@ class Select extends PureComponent {
           id={id}
           name={name}
           onChange={onChange}
+          defaultValue={defaultValue}
           value={value}
           required={required}
           autoFocus={autoFocus}


### PR DESCRIPTION
Currently, we seem to only support the notion of _controlled_ inputs. While this is fine if it's an intentional stance, it may benefit us to be more flexible for consumers who do not want all of their inputs controlled (performance sensitive situations, for instance).

Having the option to pass in `defaultValue` instead of using `value` + `onChange` would be really nice.

This adds that support by blindly plumbing `defaultValue` to the resulting `<select />` element.