### PR TITLE
Remove sidebar tab icon

### DIFF
--- a/src/tabs/src/SidebarTab.js
+++ b/src/tabs/src/SidebarTab.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react'
 import Box from 'ui-box'
-import { Icon } from '../../icon'
 import Tab from './Tab'
 
 export default class SidebarTab extends PureComponent {
@@ -33,7 +32,6 @@ export default class SidebarTab extends PureComponent {
         <Box is="span" flex="1">
           {children}
         </Box>
-        {isSelected && <Icon icon="caret-right" size={14} marginRight={10} />}
       </Tab>
     )
   }


### PR DESCRIPTION
Closes https://github.com/segmentio/evergreen/issues/249

Remove the caret-right icon from side bar tab.

![image](https://user-images.githubusercontent.com/7209644/43106021-d2ff80e4-8e8b-11e8-9d3f-44cd2745f006.png)
