### PR TITLE
🌲 CI status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 	<br>
   <br>
   <a href="https://circleci.com/gh/segmentio/evergreen/tree/master">
-    <img src="https://circleci.com/gh/segmentio/ui-box/tree/master.svg?style=svg" alt="Build Status">
+    <img src="https://circleci.com/gh/segmentio/evergreen.svg?style=svg" alt="Build Status">
   </a>
 	<br>
   <br>


### PR DESCRIPTION
We where pointing to `ui-box` CI status image, now , we point to 🌲's CI status image.

![image](https://user-images.githubusercontent.com/952992/43283418-d1e80f16-90e6-11e8-83dd-bd926177bb4f.png)
