### PR TITLE
Fix hiding <Tooltip> by explicitly setting `isShown` to `false`

### DIFF
--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -156,8 +156,13 @@ export default class Tooltip extends PureComponent {
     } = this.props
     const { isShown: stateIsShown, isShownByTarget } = this.state
 
-    const shown =
+    let shown =
       (isShown || stateIsShown || isShownByTarget) && !this.isPopoverShown()
+
+    // Tooltip was explicitly set to not be shown
+    if (isShown === false) {
+      shown = false
+    }
 
     return (
       <Positioner

--- a/src/tooltip/stories/index.stories.js
+++ b/src/tooltip/stories/index.stories.js
@@ -20,5 +20,10 @@ storiesOf('tooltip', module).add('Tooltip', () => (
         Hover to trigger
       </Text>
     </Tooltip>
+    <Tooltip isShown={false} content="Should never see it">
+      <Text marginLeft={40} display="inline-block" cursor="help">
+        Disabled tooltip
+      </Text>
+    </Tooltip>
   </Box>
 ))


### PR DESCRIPTION
Fixes https://github.com/segmentio/evergreen/issues/251.

Previously `<Tooltip>` was still visible on hover, even if `isShown` was explicitly set to `false`.