### PR TITLE
[v4] Add Table.VirtualBody

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-config-xo-react": "^0.14.0",
     "eslint-plugin-react": "^7.5.1",
     "execa": "^0.8.0",
+    "faker": "^4.1.0",
     "file-loader": "^1.1.5",
     "fs-extra": "^4.0.3",
     "husky": "^0.14.3",

--- a/src/table/src/Table.js
+++ b/src/table/src/Table.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import { Pane } from '../../layers'
 import TableBody from './TableBody'
+import TableVirtualBody from './TableVirtualBody'
 import TableCell from './TableCell'
 import TableHead from './TableHead'
 import TableHeaderCell from './TableHeaderCell'
@@ -11,6 +12,7 @@ import SearchTableHeaderCell from './SearchTableHeaderCell'
 
 export default class Table extends PureComponent {
   static Body = TableBody
+  static VirtualBody = TableVirtualBody
   static Head = TableHead
   static HeaderCell = TableHeaderCell
   static TextHeaderCell = TextTableHeaderCell

--- a/src/table/src/Table.js
+++ b/src/table/src/Table.js
@@ -30,10 +30,6 @@ export default class Table extends PureComponent {
 
   render() {
     const { children, ...props } = this.props
-    return (
-      <Pane border {...props}>
-        {children}
-      </Pane>
-    )
+    return <Pane {...props}>{children}</Pane>
   }
 }

--- a/src/table/src/TableHead.js
+++ b/src/table/src/TableHead.js
@@ -45,6 +45,7 @@ export default class TableHead extends PureComponent {
     return (
       <Pane
         display="flex"
+        flexShrink={0}
         paddingRight={scrollbarWidth}
         borderBottom="default"
         background="tint2"

--- a/src/table/src/TableVirtualBody.js
+++ b/src/table/src/TableVirtualBody.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
 import VirtualList from 'react-tiny-virtual-list'
+import debounce from 'lodash.debounce'
 import { Pane } from '../../layers'
 
 export default class TableVirtualBody extends PureComponent {
@@ -7,27 +9,250 @@ export default class TableVirtualBody extends PureComponent {
     /**
      * Composes the Pane component as the base.
      */
-    ...Pane.propTypes
+    ...Pane.propTypes,
+
+    /**
+     * Children needs to be an array of a single node.
+     */
+    children: PropTypes.arrayOf(PropTypes.node),
+
+    /**
+     * Default height of each row.
+     * 48 is the default height of a TableRow.
+     */
+    defaultHeight: PropTypes.number,
+
+    /**
+     * When true, support `height="auto"` on children being rendered.
+     * This is somewhat of an expirmental feature.
+     */
+    allowAutoHeight: PropTypes.bool,
+
+    /**
+     * When passed, this is used as the `estimatedItemSize` in react-tiny-virtual-list.
+     * Only when `allowAutoHeight` and`useAverageAutoHeightEstimation` are false.
+     */
+    estimatedItemSize: PropTypes.number,
+
+    /**
+     * When allowAutoHeight is true and this prop is true, the estimated height
+     * will be computed based on the average height of auto height rows.
+     */
+    useAverageAutoHeightEstimation: PropTypes.bool
+  }
+
+  static defaultProps = {
+    defaultHeight: 48,
+    allowAutoHeight: false,
+    useAverageAutoHeightEstimation: true
+  }
+
+  state = {
+    isIntegerHeight: false,
+    calculatedHeight: 0
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (props.height !== state.calculatedHeight) {
+      return {
+        isIntegerHeight: Number.isInteger(props.height)
+      }
+    }
+
+    // Return null to indicate no change to state.
+    return null
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.initializeHelpers()
+
+    // Add a onResize.
+    this.onResize = debounce(this.onResize, 200)
+  }
+
+  componentDidMount() {
+    // Call this to initialize and set
+    this.updateOnResize()
+    window.addEventListener('resize', this.onResize, false)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.onResize)
+  }
+
+  initializeHelpers = () => {
+    this.autoHeights = []
+    this.autoHeightRefs = []
+    this.averageAutoHeight = this.props.defaultHeight
+  }
+
+  /**
+   * This function will process all items that have height="auto" set.
+   * It will loop through all refs and get calculate the height.
+   */
+  processAutoHeights = () => {
+    let isUpdated = false
+
+    // This will determine the averageAutoHeight.
+    let total = 0
+    let totalAmount = 0
+
+    // Loop through all of the refs that have height="auto".
+    this.autoHeightRefs.forEach((ref, index) => {
+      // If the height is already calculated, skip it,
+      // but calculate the height for the total.
+      if (this.autoHeights[index]) {
+        total += this.autoHeights[index]
+        totalAmount += 1
+        return
+      }
+
+      // Make sure the ref has a child
+      if (
+        ref &&
+        ref.childNodes &&
+        ref.childNodes[0] &&
+        Number.isInteger(ref.childNodes[0].offsetHeight)
+      ) {
+        const height = ref.childNodes[0].offsetHeight
+
+        // Add to the total to calculate the averageAutoHeight.
+        total += height
+        totalAmount += 1
+
+        // Cache the height.
+        this.autoHeights[index] = height
+
+        // Set the update flag to true.
+        isUpdated = true
+      }
+    })
+
+    // Save the average height.
+    this.averageAutoHeight = total / totalAmount
+
+    // There are some new heights detected that had previously not been calculated.
+    // Call forceUpdate to make sure the virtual list renders again.
+    if (isUpdated) this.forceUpdate()
+  }
+
+  onRef = ref => {
+    this.paneRef = ref
+  }
+
+  onVirtualHelperRef = (index, ref) => {
+    this.autoHeightRefs[index] = ref
+
+    requestAnimationFrame(() => {
+      this.processAutoHeights()
+    })
+  }
+
+  onResize = () => {
+    this.updateOnResize()
+  }
+
+  updateOnResize = () => {
+    this.initializeHelpers()
+
+    // Simply return when we now the height of the pane is fixed.
+    if (this.state.isIntegerHeight) return
+
+    // Return if we are in a weird edge case in which the ref is no longer valid.
+    if (!this.paneRef) return
+
+    // Save the calculated height which is needed for the VirtualList.
+    this.setState({
+      calculatedHeight: this.paneRef.offsetHeight
+    })
   }
 
   render() {
-    const { children, height, ...props } = this.props
+    const {
+      children = [],
+      height: paneHeight,
+      defaultHeight,
+      allowAutoHeight,
+      estimatedItemSize,
+      useAverageAutoHeightEstimation,
+      ...props
+    } = this.props
+
+    // VirtualList needs a fixed height.
+    const { calculatedHeight } = this.state
+
     return (
-      <Pane flex="1" overflowY="scroll" height={height} {...props}>
+      <Pane
+        innerRef={this.onRef}
+        height={paneHeight}
+        flex="1"
+        overflow="hidden"
+        {...props}
+      >
         <VirtualList
-          height={height}
+          height={calculatedHeight}
           width="100%"
-          itemSize={48}
-          overscanCount={3}
-          itemCount={children.length}
+          estimatedItemSize={
+            allowAutoHeight && useAverageAutoHeightEstimation
+              ? this.averageAutoHeight
+              : estimatedItemSize || null
+          }
+          itemSize={index => {
+            const { height } = children[index].props
+
+            // When the height is number simply, simply return it.
+            if (Number.isInteger(height)) {
+              return height
+            }
+
+            // When allowAutoHeight is set and  the height is set to "auto"...
+            if (allowAutoHeight && children[index].props.height === 'auto') {
+              // ... and the height is calculated, return the calculated height.
+              if (this.autoHeights[index]) return this.autoHeights[index]
+
+              // ... if the height is not yet calculated, return the averge
+              if (useAverageAutoHeightEstimation) return this.averageAutoHeight
+            }
+
+            // Return the default height.
+            return defaultHeight
+          }}
+          overscanCount={5}
+          itemCount={React.Children.count(children)}
           renderItem={({ index, style }) => {
-            console.log(children[index])
+            // When allowing height="auto" for rows, and a auto height item is
+            // rendered for the first time...
+            if (
+              allowAutoHeight &&
+              children[index].props.height === 'auto' &&
+              // ... and only when the height is not already been calculated.
+              !this.autoHeights[index]
+            ) {
+              // ... render the item in a helper div, the ref is used to calculate
+              // the height of its children.
+              return (
+                <div
+                  ref={ref => this.onVirtualHelperRef(index, ref)}
+                  data-virtual-index={index}
+                  style={{
+                    opacity: 0,
+                    ...style
+                  }}
+                >
+                  {children[index]}
+                </div>
+              )
+            }
+
+            // When allowAutoHeight is false, or when the height is known.
+            // Simply render the item.
             return React.cloneElement(children[index], {
               style
             })
           }}
         />
-        {children}
       </Pane>
     )
   }

--- a/src/table/src/TableVirtualBody.js
+++ b/src/table/src/TableVirtualBody.js
@@ -1,0 +1,34 @@
+import React, { PureComponent } from 'react'
+import VirtualList from 'react-tiny-virtual-list'
+import { Pane } from '../../layers'
+
+export default class TableVirtualBody extends PureComponent {
+  static propTypes = {
+    /**
+     * Composes the Pane component as the base.
+     */
+    ...Pane.propTypes
+  }
+
+  render() {
+    const { children, height, ...props } = this.props
+    return (
+      <Pane flex="1" overflowY="scroll" height={height} {...props}>
+        <VirtualList
+          height={height}
+          width="100%"
+          itemSize={48}
+          overscanCount={3}
+          itemCount={children.length}
+          renderItem={({ index, style }) => {
+            console.log(children[index])
+            return React.cloneElement(children[index], {
+              style
+            })
+          }}
+        />
+        {children}
+      </Pane>
+    )
+  }
+}

--- a/src/table/stories/AdvancedTable.js
+++ b/src/table/stories/AdvancedTable.js
@@ -254,9 +254,7 @@ export default class AdvancedTable extends React.Component {
           <Table.HeaderCell width={48} flex="none" />
         </Table.Head>
         <Table.VirtualBody height={640}>
-          {items.map(({ item, index }) =>
-            this.renderRow({ profile: item[index] })
-          )}
+          {items.map(item => this.renderRow({ profile: item }))}
         </Table.VirtualBody>
       </Table>
     )

--- a/src/table/stories/AdvancedTable.js
+++ b/src/table/stories/AdvancedTable.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { filter } from 'fuzzaldrin-plus'
-import VirtualList from 'react-tiny-virtual-list'
 import { Table } from '../../table'
 import { Popover } from '../../popover'
 import { Position } from '../../positioner'
@@ -218,9 +217,9 @@ export default class AdvancedTable extends React.Component {
     )
   }
 
-  renderRow = ({ profile, style }) => {
+  renderRow = ({ profile }) => {
     return (
-      <Table.Row key={profile.id} style={style}>
+      <Table.Row key={profile.id}>
         <Table.Cell display="flex" alignItems="center">
           <Avatar name={profile.name} flexShrink={0} />
           <Text marginLeft={8} size={300} fontWeight={500}>
@@ -254,18 +253,11 @@ export default class AdvancedTable extends React.Component {
           {this.renderLTVTableHeaderCell()}
           <Table.HeaderCell width={48} flex="none" />
         </Table.Head>
-        <Table.Body height={640}>
-          <VirtualList
-            height={640}
-            width="100%"
-            itemSize={48}
-            overscanCount={3}
-            itemCount={items.length}
-            renderItem={({ index, style }) => {
-              return this.renderRow({ profile: items[index], style })
-            }}
-          />
-        </Table.Body>
+        <Table.VirtualBody height={640}>
+          {items.map(({ item, index }) =>
+            this.renderRow({ profile: item[index] })
+          )}
+        </Table.VirtualBody>
       </Table>
     )
   }

--- a/src/table/stories/VirtualTable.js
+++ b/src/table/stories/VirtualTable.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import faker from 'faker'
+import { Table } from '../'
+import { Pane } from '../../layers'
+import { Paragraph } from '../../typography'
+
+const range = N => Array.from({ length: N }, (v, k) => k + 1)
+
+const randomLengthContent = [
+  `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`,
+  `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.`,
+  `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`
+]
+
+// Generate a bunch of users.
+const users = range(1000)
+  .map(() => ({
+    name: faker.name.findName(),
+    email: faker.internet.email(),
+    height: faker.random.arrayElement([32, 40, 56, 'auto'])
+  }))
+  .map(item => {
+    // When height is auto, use a variable length piece of content to render.
+    if (item.height === 'auto') {
+      return {
+        ...item,
+        content: faker.random.arrayElement(randomLengthContent)
+      }
+    }
+    return item
+  })
+
+export default class VirtualTable extends React.PureComponent {
+  render() {
+    return (
+      <Pane border height="80vh" display="flex" flexGrow={0}>
+        <Table flex={1} display="flex" flexDirection="column">
+          <Table.Head>
+            <Table.TextHeaderCell>Index</Table.TextHeaderCell>
+            <Table.TextHeaderCell>Height</Table.TextHeaderCell>
+            <Table.TextHeaderCell>Name</Table.TextHeaderCell>
+            <Table.TextHeaderCell>Email</Table.TextHeaderCell>
+          </Table.Head>
+          <Table.VirtualBody flex={1} allowAutoHeight>
+            {users.map((user, index) => {
+              return (
+                <Table.Row key={user.email} height={user.height}>
+                  <Table.TextCell>{index}</Table.TextCell>
+                  <Table.TextCell>{user.height}</Table.TextCell>
+                  <Table.TextCell>{user.name}</Table.TextCell>
+                  {user.height === 'auto' ? (
+                    <Table.Cell>
+                      <Paragraph marginY={24}>{user.content}</Paragraph>
+                    </Table.Cell>
+                  ) : (
+                    <Table.TextCell>This is a static height row</Table.TextCell>
+                  )}
+                </Table.Row>
+              )
+            })}
+          </Table.VirtualBody>
+        </Table>
+      </Pane>
+    )
+  }
+}

--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Box from 'ui-box'
 import { Table } from '../../table'
 import AdvancedTable from './AdvancedTable'
+import VirtualTable from './VirtualTable'
 
 storiesOf('table', module)
   .add('advanced example', () => (
@@ -12,6 +13,15 @@ storiesOf('table', module)
         document.body.style.height = '100vh'
       })()}
       <AdvancedTable />
+    </Box>
+  ))
+  .add('virtual table', () => (
+    <Box padding={24} height="100vh">
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <VirtualTable />
     </Box>
   ))
   .add('Table.Cell', () => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,6 +3535,10 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
+
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"


### PR DESCRIPTION
This PR tries to give consumers a easy way to deal with virtualization. Simply change `Table.Body` for `Table.VirtualBody` and everything should work the same — except you are now using `react-tiny-virtual-list` to render your table.

Your use case of virtualization might be more complex than what `Table.VirtualBody` can offer. It's not meant as a component to tackle all use cases. Instead it's meant to be used for simpler use cases, in which you don't always have the time to opt-in for virtualization.


**See `VirtualTable.js` for the most complicated example**

![virtual body](https://user-images.githubusercontent.com/564463/43347958-7e802f90-91ac-11e8-9fe3-5d742b19df48.gif)
![virtual body](https://user-images.githubusercontent.com/564463/43348013-c77eb63a-91ac-11e8-9b47-b814ba49dc39.gif)


## In this PR

* Export `Table.VirtualBody`
* Add `flexShrink={0}` to TableHead
* Remove `border` from `Table`

## Simplest use case

* Resizing the browser will update the table.
* Uses default table row height (48)

```jsx
<Table.VirtualBody>
  {users.map((user, index) => {
    return (
      <Table.Row key={user.email}>
        <Table.TextCell>{index}</Table.TextCell>
        <Table.TextCell>{user.height}</Table.TextCell>
        <Table.TextCell>{user.name}</Table.TextCell>
      </Table.Row>
    )
  })}
</Table.VirtualBody>
```

## Dynamic height rows

* You can simply set different fixed heights on your `Table.Row` and it will still work.
* This is useful when you are rendering a table with normal rows and heading rows.
* Resizing the browser will update the table.

```jsx
<Table.VirtualBody>
  {users.map((user, index) => {
    return (
      <Table.Row key={user.email} height={Math.random() > 0.5 ? 24 : 56}>
        <Table.TextCell>{index}</Table.TextCell>
        <Table.TextCell>{user.height}</Table.TextCell>
        <Table.TextCell>{user.name}</Table.TextCell>
      </Table.Row>
    )
  })}
</Table.VirtualBody>
```

## Auto height rows

*This feature is still somewhat experimental and needs more real use case validation.*

* When you don't know the height of rows up front.
* Simply set the `allowAutoHeight` prop to true and let Evergreen figure out the rest.
* Resizing the browser will update the table.

```jsx
<Table.VirtualBody allowAutoHeight>
  {users.map((user, index) => {
    return (
      <Table.Row key={user.email} height="auto">
        <Table.TextCell>{index}</Table.TextCell>
        <Table.TextCell>{user.height}</Table.TextCell>
        // Arbitrary sized content
        <Table.TextCell>{user.content}</Table.TextCell>
      </Table.Row>
    )
  })}
</Table.VirtualBody>
```

## Mix auto rows and fixed rows

* When you don't know the height of **some** rows up front.
* Simply set the `allowAutoHeight` prop to true and let Evergreen figure out the rest.
* Resizing the browser will update the table.

```jsx
<Table.VirtualBody allowAutoHeight>
  {users.map((user, index) => {
    return (
      <Table.Row key={user.email} height={Math.random() > 0.5 ? 'auto' : 32}>
        <Table.TextCell>{index}</Table.TextCell>
        <Table.TextCell>{user.height}</Table.TextCell>
        // Arbitrary sized content
        <Table.TextCell>{user.content}</Table.TextCell>
      </Table.Row>
    )
  })}
</Table.VirtualBody>
```

