### PR TITLE
Fix misspelling of ListItem component name

### DIFF
--- a/src/typography/src/ListItem.js
+++ b/src/typography/src/ListItem.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import Text from './Text'
 
-export default class Paragraph extends PureComponent {
+export default class ListItem extends PureComponent {
   static propTypes = {
     ...Text.propTypes
   }


### PR DESCRIPTION
Small fix on component name (wrong copy/paste 😏).
BTW I love your `Box` and `Text` components, they drastically simplify development of new components. Thank you!