### PR TITLE
Fix broken blueprint link

### DIFF
--- a/src/icon/docs/index.js
+++ b/src/icon/docs/index.js
@@ -21,7 +21,7 @@ const introduction = (
     <p>
       Evergreen uses the amazing{' '}
       <a
-        href="http://blueprintjs.com/docs/v2/#icons"
+        href="http://blueprintjs.com/docs/versions/2/#icons"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
Fixes a broken link in the docs for icons. 

```
http://blueprintjs.com/docs/v2/#icons -> http://blueprintjs.com/docs/versions/2/#icons
```