### PR TITLE
allow default TableRow keypress event behavior (#211)

### DIFF
--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -54,11 +54,21 @@ export default class TableRow extends PureComponent {
     }
   }
 
+  onRef = node => {
+    this.node = node
+  }
+
   handleKeyPress = e => {
     if (this.props.isSelectable) {
       if (e.key === 'Enter' || e.key === ' ') {
         this.props.onSelect()
-        e.preventDefault()
+
+        // NOTE: In scenarios where the target for key press is our
+        // tabIndex <Pane> below, prevent the default event action
+        // so that browser scroll will not occur.
+        if (e.target === this.node) {
+          e.preventDefault()
+        }
       }
     }
 
@@ -83,6 +93,7 @@ export default class TableRow extends PureComponent {
 
     return (
       <Pane
+        innerRef={this.onRef}
         display="flex"
         {...(isSelectable
           ? {

--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -89,6 +89,17 @@ storiesOf('table', module)
       <TableRow>TableRow</TableRow>
     </Box>
   ))
+  .add('TableRow isSelectable with nested UI', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <TableRow isSelectable>
+        <input type="text" placeholder="type a space" />
+      </TableRow>
+    </Box>
+  ))
   .add('TableHeaderCell', () => (
     <Box padding={40}>
       {(() => {


### PR DESCRIPTION
allow default TableRow keypress event behavior (#211)

Thanks for creating evergreen! 🌲

_tl;dr remove the `e.preventDefault()` function call so that `input` and `change` events can be fired normally after the `keypress` event ._

* [Web standards specify that a `keypress` event should be fired **prior** to the corresponding `input` event for the same key](https://www.w3.org/TR/DOM-Level-3-Events/#keypress-event-order)

* [Web standards also specify that cancelling a `keypress` event will also prevent subsequent `input` events from being fired](https://www.w3.org/TR/DOM-Level-3-Events/#ref-for-input-31)

* [Web standards further specify that a `input` event should be fired **prior** to any `change` events for a given input](https://html.spec.whatwg.org/multipage/input.html#common-input-element-events)
  
* From all this, we can conclude that `keypress` event handlers will be invoked prior to any `change` handlers attached in our DOM tree. These two examples confirm this for both [native DOM](https://codesandbox.io/s/r7qllw2r5p?expanddevtools=1&hidenavigation=1) and [React SyntheticEvent](https://codesandbox.io/s/l56198rlzq?expanddevtools=1&hidenavigation=1). In addition, cancelling the default behavior for a `keypress` event will prevent `input` and `change` events from firing for the same user interaction, the cause of our bug here!

