### PR TITLE
[v4] Table.(Editable/SelectMenu)Cell Fixes

### DIFF
--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -18,7 +18,7 @@ class EditableCell extends React.PureComponent {
     * Makes the TableCell focusable.
     * Will add tabIndex={-1 || this.props.tabIndex}.
     */
-    isSelectable: PropTypes.bool,
+    isSelectable: PropTypes.bool.isRequired,
 
     /**
      * When true, the cell can't be edited.

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -147,7 +147,6 @@ class EditableCell extends React.PureComponent {
           onClick={this.handleClick}
           onDoubleClick={this.handleDoubleClick}
           onKeyDown={this.handleKeyDown}
-          size={size}
           cursor={disabled ? 'not-allowed' : isSelectable ? 'default' : 'text'}
           textProps={{
             size,

--- a/src/table/src/SelectMenuCell.js
+++ b/src/table/src/SelectMenuCell.js
@@ -41,7 +41,8 @@ class SelectMenuCell extends React.PureComponent {
   }
 
   static defaultProps = {
-    size: 300
+    size: 300,
+    isSelectable: true
   }
 
   state = {
@@ -135,7 +136,6 @@ class SelectMenuCell extends React.PureComponent {
               }
               aria-haspopup
               aria-expanded={isShown}
-              size={size}
               cursor={
                 disabled ? 'not-allowed' : isSelectable ? 'default' : 'text'
               }

--- a/src/table/src/SelectMenuCell.js
+++ b/src/table/src/SelectMenuCell.js
@@ -20,7 +20,7 @@ class SelectMenuCell extends React.PureComponent {
     * Makes the TableCell focusable.
     * Will add tabIndex={-1 || this.props.tabIndex}.
     */
-    isSelectable: PropTypes.bool,
+    isSelectable: PropTypes.bool.isRequired,
 
     /**
      * When true, the cell can't be edited.


### PR DESCRIPTION
## `Table.EditableCell`

- [Bug fix] Filter out size property. #282 

## `Table.SelectMenuCell`

- [Bug fix] `isSelectable` default prop is now `true`. #283 
- [Bug fix] Filter out size property. #282 