### PR TITLE
[v4] Table.EditableCell position fix + tiny pixel shift Radio

### DIFF
--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -142,7 +142,7 @@ class Radio extends PureComponent {
           display="flex"
           alignItems="center"
           justifyContent="center"
-          marginTop={size === 12 ? 2 : 3}
+          marginTop={2}
           width={size}
           height={size}
         >

--- a/src/table/src/EditableCellField.js
+++ b/src/table/src/EditableCellField.js
@@ -164,7 +164,7 @@ export default class EditableCellField extends React.PureComponent {
         height={null}
         width={null}
         minHeight={null}
-        position="absolute"
+        position="fixed"
         defaultValue={value}
       />
     )

--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -40,6 +40,15 @@ storiesOf('table', module)
       <EditableTable />
     </Box>
   ))
+  .add('Editable Table offset test ', () => (
+    <Box padding={24} paddingTop={800} height="100vh">
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <EditableTable />
+    </Box>
+  ))
   .add('Table.Cell', () => (
     <Box padding={40}>
       {(() => {


### PR DESCRIPTION
## `Table.EditableCell`

- [Bug fix] Table.EditableCell position should be relative to viewport #285 

## `Radio`

- [Design improvement] changing marginTop from `3` to `2`.  