### PR TITLE
update(docs): view on github link

### DIFF
--- a/docs/src/components/ComponentReadme.js
+++ b/docs/src/components/ComponentReadme.js
@@ -41,7 +41,9 @@ export default class ComponentReadme extends PureComponent {
               {subTitle}{' '}
               <a
                 className="ComponentReadme-githubLink"
-                href={`https://github.com/segmentio/evergreen/tree/master/src/${name}`}
+                href={`https://github.com/segmentio/evergreen/tree/master/src/${name
+                  .toLowerCase()
+                  .replace(/\s+/g, '-')}`}
                 target="_blank"
               >
                 View on GitHub


### PR DESCRIPTION
Hi!
I found the **'View on GitHub'** link  in the document to be ineffective.
https://evergreen.surge.sh/components
like this [components-Alert](https://github.com/segmentio/evergreen/tree/master/src/Alert)

I tried to modify the suffix parameter. **lower case** and **replace space to -**

Sorry. My English is not good. I hope you understand. Thank you.

Finally, Evergreen is very nice :)