### PR TITLE
Fix wording in Toaster docs

### DIFF
--- a/src/toaster/docs/index.js
+++ b/src/toaster/docs/index.js
@@ -100,7 +100,7 @@ const examples = [
     scope
   },
   {
-    title: 'Toasts with Custom Description',
+    title: 'Toasts with Custom Duration',
     description: (
       <p>
         It is possible to add a custom duration when showing a toast. The


### PR DESCRIPTION
That section is about custom duration and not custom description.

Probably copy pasted from example above.