### PR TITLE
fix githubLink pathname on ComponentReadme

### DIFF
--- a/docs/src/components/ComponentReadme.js
+++ b/docs/src/components/ComponentReadme.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import kebabCase from '../utils/kebabCase'
 import ComponentBlock from './ComponentBlock'
 import AppearanceOption from './ApppearanceOption'
 import PlaygroundExampleGroup from './PlaygroundExampleGroup'
@@ -41,7 +42,9 @@ export default class ComponentReadme extends PureComponent {
               {subTitle}{' '}
               <a
                 className="ComponentReadme-githubLink"
-                href={`https://github.com/segmentio/evergreen/tree/master/src/${name}`}
+                href={`https://github.com/segmentio/evergreen/tree/master/src/${kebabCase(
+                  name
+                )}`}
                 target="_blank"
               >
                 View on GitHub

--- a/docs/src/utils/kebabCase.js
+++ b/docs/src/utils/kebabCase.js
@@ -1,0 +1,25 @@
+/**
+ * Credit to https://gist.github.com/tdukart/b87afb278c41245741ae7a0c355a0a0b
+ *
+ * @param {*} string
+ */
+
+export default function kebabCase(string) {
+  let result = string
+
+  // Convert camelCase capitals to kebab-case.
+  result = result.replace(/([a-z][A-Z])/g, match => {
+    return match.substr(0, 1) + '-' + match.substr(1, 1).toLowerCase()
+  })
+
+  // Convert non-camelCase capitals to lowercase.
+  result = result.toLowerCase()
+
+  // Convert non-alphanumeric characters to hyphens
+  result = result.replace(/[^-a-z0-9]+/g, '-')
+
+  // Remove hyphens from both ends
+  result = result.replace(/^-+/, '').replace(/-$/, '')
+
+  return result
+}


### PR DESCRIPTION
The component links to be seen in github are broken. I used the kebabCase function in the component headings and this fixes this problem.