### PR TITLE
dialog: add horizontal scrolling support

### DIFF
--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -217,6 +217,11 @@ class Dialog extends React.Component {
       minHeightContent
     } = this.props
 
+    const sideOffsetWithUnit = Number.isInteger(sideOffset)
+      ? `${sideOffset}px`
+      : sideOffset
+    const maxWidth = `calc(100% - ${sideOffsetWithUnit} * 2)`
+
     const topOffsetWithUnit = Number.isInteger(topOffset)
       ? `${topOffset}px`
       : topOffset
@@ -240,8 +245,9 @@ class Dialog extends React.Component {
             elevation={4}
             borderRadius={8}
             width={width}
+            maxWidth={maxWidth}
             maxHeight={maxHeight}
-            marginX={sideOffset}
+            marginX={sideOffsetWithUnit}
             marginY={topOffsetWithUnit}
             display="flex"
             flexDirection="column"
@@ -267,7 +273,7 @@ class Dialog extends React.Component {
             <Pane
               data-state={state}
               display="flex"
-              overflowY="auto"
+              overflow="auto"
               padding={16}
               flexDirection="column"
               minHeight={minHeightContent}


### PR DESCRIPTION
This allows the Dialog to gracefully handle block level content that's too wide by scrolling, preventing the Dialog from overflowing the sides of the viewport.

This should be a non-breaking change.

![kapture 2018-08-30 at 22 43 51](https://user-images.githubusercontent.com/605501/44894752-41020480-aca6-11e8-9a87-46dba23f99ca.gif)
