### PR TITLE
fix prop warnings and make list components more flexible

### DIFF
--- a/src/typography/src/OrderedList.js
+++ b/src/typography/src/OrderedList.js
@@ -13,6 +13,10 @@ export default class OrderedList extends PureComponent {
     size: PropTypes.oneOf([300, 400, 500, 600]).isRequired
   }
 
+  static defaultProps = {
+    size: 400
+  }
+
   static styles = {
     is: 'ol',
     margin: 0,
@@ -23,7 +27,7 @@ export default class OrderedList extends PureComponent {
   }
 
   render() {
-    const { children, ...props } = this.props
+    const { children, size, ...props } = this.props
 
     const finalChildren = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -32,7 +36,7 @@ export default class OrderedList extends PureComponent {
 
       return React.cloneElement(child, {
         // Prefer more granularly defined icon if present
-        size: child.props.size || this.props.size
+        size: child.props.size || size
       })
     })
 

--- a/src/typography/src/UnorderedList.js
+++ b/src/typography/src/UnorderedList.js
@@ -24,6 +24,10 @@ export default class UnorderedList extends PureComponent {
     iconColor: PropTypes.string
   }
 
+  static defaultProps = {
+    size: 400
+  }
+
   static styles = {
     is: 'ul',
     margin: 0,
@@ -34,7 +38,10 @@ export default class UnorderedList extends PureComponent {
   }
 
   render() {
-    const { children, ...props } = this.props
+    const { children, size, icon, iconColor, ...props } = this.props
+
+    // Only pass down icon-related props if specified
+    const inheritedProps = icon ? { size, icon, iconColor } : { size }
 
     const finalChildren = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -42,10 +49,9 @@ export default class UnorderedList extends PureComponent {
       }
 
       return React.cloneElement(child, {
+        ...inheritedProps,
         // Prefer more granularly defined icon if present
-        size: child.props.size || this.props.size,
-        icon: child.props.icon || this.props.icon,
-        iconColor: child.props.iconColor || this.props.iconColor
+        ...child.props
       })
     })
 


### PR DESCRIPTION
This fixes those pesky prop-type warnings by providing some sensible default values. It also only passes down props when defined (and removes unnecessary props from the wrapper Box via destructuring).