### PR TITLE
add iconSize to IconButton component. closes #316

### DIFF
--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -97,7 +97,7 @@ class IconButton extends PureComponent {
       intent,
       ...props
     } = this.props
-    const size = iconSize || this.props.theme.getIconSizeForIconButton(height)
+    const size = iconSize || theme.getIconSizeForIconButton(height)
 
     return (
       <Button

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -42,6 +42,11 @@ class IconButton extends PureComponent {
     icon: PropTypes.string,
 
     /**
+     * Specifies an explicit icon size instead of the default value
+     */
+    iconSize: PropTypes.number,
+
+    /**
      * The intent of the button.
      */
     intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger'])
@@ -83,8 +88,16 @@ class IconButton extends PureComponent {
   }
 
   render() {
-    const { theme, iconAim, icon, height, intent, ...props } = this.props
-    const iconSize = theme.getIconSizeForIconButton(height)
+    const {
+      theme,
+      iconAim,
+      icon,
+      iconSize,
+      height,
+      intent,
+      ...props
+    } = this.props
+    const size = iconSize || this.props.theme.getIconSizeForIconButton(height)
 
     return (
       <Button
@@ -99,7 +112,7 @@ class IconButton extends PureComponent {
       >
         <Icon
           icon={icon}
-          size={iconSize}
+          size={size}
           color={intent === 'none' ? 'default' : 'currentColor'}
         />
       </Button>


### PR DESCRIPTION
This allows consumers to specify the size of an icon when the theme-based size isn't meeting their needs.

Closes https://github.com/segmentio/evergreen/issues/316