### PR TITLE
Fix Checkboxes and Radios is some cases

### DIFF
--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -136,6 +136,7 @@ class Checkbox extends PureComponent {
       <Box
         is="label"
         cursor={disabled ? 'not-allowed' : 'pointer'}
+        position="relative"
         display="flex"
         marginY={16}
         {...props}
@@ -150,7 +151,7 @@ class Checkbox extends PureComponent {
           checked={checked || indeterminate}
           onChange={onChange}
           disabled={disabled}
-          {...(isInvalid ? { 'aria-invalid': true } : {})}
+          aria-invalid={isInvalid}
           innerRef={this.setIndeterminate}
         />
         <Box

--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -119,6 +119,7 @@ class Radio extends PureComponent {
       <Box
         is="label"
         cursor={disabled ? 'not-allowed' : 'pointer'}
+        position="relative"
         display="flex"
         marginY={size === 12 ? 8 : 12}
         {...props}


### PR DESCRIPTION
The `input` is hidden inside of checkboxes and radios. The wrapper (`label`) didn't  have `position: relative;` and this caused some issues in scrollable lists and tables. The browser tried to bring in focus of the checkbox/radio and the actual location of the checkbox/radio input could be way of somewhere.