### PR TITLE
Fix typo in Tooltip proptypes

### DIFF
--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -31,7 +31,7 @@ export default class Tooltip extends PureComponent {
     /**
      * The target button of the Tooltip.
      */
-    children: PropTypes.node.isRequried,
+    children: PropTypes.node.isRequired,
 
     /**
      * Properties passed through to the Tooltip.


### PR DESCRIPTION
Fixes issue: https://github.com/segmentio/evergreen/issues/320

Spelling mistake here: https://github.com/segmentio/evergreen/blob/de5ebddc8a07bfc910cde63c9fd0389025d5a12e/src/tooltip/src/Tooltip.js#L34

That is causing the following error to be logged to the console in a browser:

```
Warning: Failed prop type: Tooltip: prop type `children` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.
```
