### PR TITLE
fix conflict between v3 and v4 toaster init order

### DIFF
--- a/src/toaster/src/Toaster.js
+++ b/src/toaster/src/Toaster.js
@@ -2,7 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import ToastManager from './ToastManager'
 
-const ID = 'evergreen-toaster'
 const isBrowser =
   typeof window !== 'undefined' && typeof window.document !== 'undefined'
 
@@ -13,17 +12,10 @@ const isBrowser =
 export default class Toaster {
   constructor() {
     if (!isBrowser) return
-    let container
 
-    const element = document.getElementById(ID)
-    if (element) {
-      container = element
-    } else {
-      // Create container if not exists yet.
-      container = document.createElement('div')
-      container.id = ID
-      document.body.appendChild(container)
-    }
+    const container = document.createElement('div')
+    container.setAttribute('data-evergreen-toaster-container', '')
+    document.body.appendChild(container)
 
     ReactDOM.render(
       <ToastManager


### PR DESCRIPTION
Fix init order conflict between v4 and v3. Right now because both v3 and v4 use the same element `id` whichever one initializes last wins. This change will get rid of the check for the existing element so that we always create a new one – which should only happen once on first import.