### PR TITLE
BREAKING: bubble event in radio onChange

### DIFF
--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -46,7 +46,11 @@ class Radio extends PureComponent {
     value: PropTypes.string,
 
     /**
-     * Function called when state changes.
+     * Function called when state changes
+     * Signature:
+     * ```
+     * function(event: object, checked: boolean) => void
+     * ```
      */
     onChange: PropTypes.func,
 
@@ -96,6 +100,10 @@ class Radio extends PureComponent {
     isInvalid: false
   }
 
+  handleChange = event => {
+    this.props.onChange(event, event.target.checked)
+  }
+
   render() {
     const {
       theme,
@@ -132,7 +140,7 @@ class Radio extends PureComponent {
           name={name}
           value={value}
           checked={checked}
-          onChange={e => onChange(e.target.value)}
+          onChange={this.handleChange}
           disabled={disabled}
           aria-invalid={isInvalid}
           required={isRequired}

--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -77,7 +77,9 @@ export default class RadioGroup extends PureComponent {
     radioCount += 1
   }
 
-  handleChange = value => {
+  handleChange = event => {
+    const value = event.target.value
+
     // Save a render cycle when it's a controlled input
     if (!this.props.value) {
       this.setState({ value })
@@ -119,7 +121,7 @@ export default class RadioGroup extends PureComponent {
             label={item.label}
             checked={selected === item.value}
             disabled={item.isDisabled}
-            onChange={() => this.handleChange(item.value)}
+            onChange={this.handleChange}
             isRequired={isRequired}
           />
         ))}


### PR DESCRIPTION
This is a breaking change.

We should always bubble the `event` for consumers. This allows consumers to pull out the `value` or `checked` properties of a radio input on change.