### PR TITLE
Upgrade Downshift

### DIFF
--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -99,7 +99,7 @@ Get the `openMenu` prop to manually open the menu on certain events such as `onF
 >
   {({
     getInputProps,
-    getButtonProps,
+    getToggleButtonProps,
     getRef,
     inputValue,
     toggleMenu
@@ -110,7 +110,7 @@ Get the `openMenu` prop to manually open the menu on certain events such as `onF
         value={inputValue}
         {...getInputProps()}
       />
-      <Button onClick={toggleMenu} {...getButtonProps()}>
+      <Button onClick={toggleMenu} {...getToggleButtonProps()}>
         Trigger
       </Button>
     </Pane>
@@ -133,7 +133,7 @@ Consider using that component before using the `Autocomplete` component directly
   {({
     key,
     getInputProps,
-    getButtonProps,
+    getToggleButtonProps,
     getRef,
     inputValue,
     openMenu,
@@ -151,7 +151,7 @@ Consider using that component before using the `Autocomplete` component directly
         onFocus={openMenu}
         {...getInputProps()}
       />
-      <Button onClick={toggleMenu} {...getButtonProps()}>
+      <Button onClick={toggleMenu} {...getToggleButtonProps()}>
         Trigger
       </Button>
     </Pane>

--- a/docs/src/pages/components/colors.mdx
+++ b/docs/src/pages/components/colors.mdx
@@ -18,14 +18,4 @@ The color system in Evergreen is located in the theme and is used throughout the
 There is no real dependency on any of the colors directly within components.
 Components always access a theme color or property through a get function. For example, `theme.getTextColor` is a required function in the Evergreen theme, theme.colors is not a required property.
 
-## Accessing Colors
-
-You can programatically access colors with a theme's `palette` property.
-
-```js
-import { defaultTheme } from 'evergreen-v4'
-
-console.log(defaultTheme.palette.blue.lightest) // #F7F9FD
-```
-
 <ColorExamples marginTop={40} />

--- a/docs/src/pages/components/combobox.mdx
+++ b/docs/src/pages/components/combobox.mdx
@@ -72,7 +72,7 @@ Typing in the text input will filter the list.
 
 ```jsx
 <Combobox
-  defaultSelectedItem={{ label: 'Banana' }}
+  initialSelectedItem={{ label: 'Banana' }}
   items={[{ label: 'Banana' }, { label: 'Pear' }, { label: 'Kiwi' }]}
   itemToString={item => item.label}
   onChange={selected => console.log(selected)}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.2.1",
-    "downshift": "^1.31.16",
+    "downshift": "^3.1.1",
     "fuzzaldrin-plus": "^0.6.0",
     "glamor": "^2.20.40",
     "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   "size-limit": [
     {
       "path": "commonjs/index.js",
-      "limit": "200 KB"
+      "limit": "205 KB"
     }
   ],
   "husky": {

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -35,7 +35,7 @@ export default class Autocomplete extends PureComponent {
     /**
      * The selected item to be selected & shown by default on the autocomplete
      */
-    defaultSelectedItem: PropTypes.any,
+    initialSelectedItem: PropTypes.any,
 
     /**
      * In case the array of items is not an array of strings,
@@ -115,9 +115,9 @@ export default class Autocomplete extends PureComponent {
     width,
     inputValue,
     highlightedIndex,
-    selectItemAtIndex,
     selectedItem,
-    getItemProps
+    getItemProps,
+    getMenuProps
   }) => {
     const {
       title,
@@ -137,8 +137,13 @@ export default class Autocomplete extends PureComponent {
 
     if (items.length === 0) return null
 
+    // Pass the actual DOM ref to downshift, this fixes touch support
+    const menuProps = getMenuProps()
+    menuProps.innerRef = menuProps.ref
+    delete menuProps.ref
+
     return (
-      <Pane width={width}>
+      <Pane width={width} {...menuProps}>
         {title && (
           <Pane padding={8} borderBottom="muted">
             <Heading size={100}>{title}</Heading>
@@ -163,10 +168,7 @@ export default class Autocomplete extends PureComponent {
                   index,
                   style,
                   children: itemString,
-                  onMouseUp: () => {
-                    selectItemAtIndex(index)
-                  },
-                  isSelected: itemToString(selectedItem) === itemString,
+                  isSelected: selectedItem === item,
                   isHighlighted: highlightedIndex === index
                 })
               )
@@ -180,22 +182,30 @@ export default class Autocomplete extends PureComponent {
   render() {
     const {
       children,
+      items,
       itemSize,
       position,
       renderItem,
       itemsFilter,
       popoverMaxHeight,
       popoverMinWidth,
-      defaultSelectedItem,
+      initialSelectedItem,
+      itemToString,
       ...props
     } = this.props
 
     return (
-      <Downshift defaultSelectedItem={defaultSelectedItem} {...props}>
+      <Downshift
+        initialSelectedItem={initialSelectedItem}
+        itemCount={items.length}
+        itemToString={itemToString}
+        {...props}
+      >
         {({
           isOpen: isShown,
           inputValue,
           getItemProps,
+          getMenuProps,
           selectedItem,
           highlightedIndex,
           selectItemAtIndex,
@@ -217,6 +227,7 @@ export default class Autocomplete extends PureComponent {
                   width: Math.max(this.state.targetWidth, popoverMinWidth),
                   inputValue,
                   getItemProps,
+                  getMenuProps,
                   selectedItem,
                   highlightedIndex,
                   selectItemAtIndex

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -168,7 +168,7 @@ export default class Autocomplete extends PureComponent {
                   index,
                   style,
                   children: itemString,
-                  isSelected: selectedItem === item,
+                  isSelected: itemToString(selectedItem) === itemString,
                   isHighlighted: highlightedIndex === index
                 })
               )
@@ -208,7 +208,6 @@ export default class Autocomplete extends PureComponent {
           getMenuProps,
           selectedItem,
           highlightedIndex,
-          selectItemAtIndex,
           ...restDownshiftProps
         }) => (
           <div>
@@ -229,8 +228,7 @@ export default class Autocomplete extends PureComponent {
                   getItemProps,
                   getMenuProps,
                   selectedItem,
-                  highlightedIndex,
-                  selectItemAtIndex
+                  highlightedIndex
                 })
               }}
               minHeight={0}
@@ -248,7 +246,6 @@ export default class Autocomplete extends PureComponent {
                   inputValue,
                   selectedItem,
                   highlightedIndex,
-                  selectItemAtIndex,
                   ...restDownshiftProps
                 })
               }

--- a/src/autocomplete/stories/index.stories.js
+++ b/src/autocomplete/stories/index.stories.js
@@ -128,7 +128,7 @@ storiesOf('autocomplete', module).add('Autocomplete', () => (
       <Autocomplete onChange={handleChange} items={items}>
         {({
           getInputProps,
-          getButtonProps,
+          getToggleButtonProps,
           getRef,
           inputValue,
           toggleMenu
@@ -139,7 +139,7 @@ storiesOf('autocomplete', module).add('Autocomplete', () => (
               value={inputValue}
               {...getInputProps()}
             />
-            <Button onClick={toggleMenu} {...getButtonProps()}>
+            <Button onClick={toggleMenu} {...getToggleButtonProps()}>
               Trigger
             </Button>
           </Box>

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -38,7 +38,7 @@ export default class Combobox extends PureComponent {
     /**
      * Default selected item when uncontrolled.
      */
-    defaultSelectedItem: PropTypes.any,
+    initialSelectedItem: PropTypes.any,
 
     /**
      * The placeholder text when there is no value present.
@@ -91,7 +91,7 @@ export default class Combobox extends PureComponent {
     const {
       items,
       selectedItem,
-      defaultSelectedItem,
+      initialSelectedItem,
       itemToString,
       width,
       height,
@@ -108,7 +108,7 @@ export default class Combobox extends PureComponent {
       <Autocomplete
         items={items}
         selectedItem={selectedItem}
-        defaultSelectedItem={defaultSelectedItem}
+        initialSelectedItem={initialSelectedItem}
         itemToString={itemToString}
         onChange={onChange}
         onStateChange={this.handleStateChange}
@@ -121,7 +121,7 @@ export default class Combobox extends PureComponent {
           openMenu,
           inputValue,
           getInputProps,
-          getButtonProps,
+          getToggleButtonProps,
           clearSelection
         }) => (
           <Box
@@ -167,7 +167,7 @@ export default class Combobox extends PureComponent {
               paddingRight={0}
               borderTopLeftRadius={0}
               borderBottomLeftRadius={0}
-              {...getButtonProps({
+              {...getToggleButtonProps({
                 ...buttonProps,
                 onClick: () => {
                   if (!isShown) {

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -50,7 +50,7 @@ storiesOf('combobox', module).add('Combobox', () => (
     <Box marginBottom={16}>
       <Heading>Default value</Heading>
       <Combobox
-        defaultSelectedItem="Yoda"
+        initialSelectedItem="Yoda"
         items={items}
         onChange={handleChange}
       />
@@ -58,7 +58,7 @@ storiesOf('combobox', module).add('Combobox', () => (
     <Box marginBottom={16}>
       <Heading>Custom item objects</Heading>
       <Combobox
-        defaultSelectedItem={customItems[0]}
+        initialSelectedItem={customItems[0]}
         items={customItems}
         itemToString={i => i.label}
         onChange={handleChange}

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -232,6 +232,7 @@ export default class Positioner extends PureComponent {
 
               <Transition
                 in={isShown}
+                appear // Show the children if isShown is true on initial render
                 timeout={animationDuration}
                 onEnter={this.handleEnter}
                 onEntered={this.props.onOpenComplete}

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -144,8 +144,8 @@ class TableRow extends PureComponent {
           innerRef={this.onRef}
           className={cx(themedClassName, className)}
           display="flex"
-          aria-selected={isHighlighted}
-          aria-current={isSelected}
+          data-ishighlighted={isHighlighted}
+          aria-selected={isSelected}
           data-isselectable={isSelectable}
           tabIndex={isSelectable ? tabIndex : undefined}
           onClick={this.handleClick}

--- a/src/themer/src/createRowAppearance.js
+++ b/src/themer/src/createRowAppearance.js
@@ -2,9 +2,11 @@ import createAppearance from './createAppearance'
 import missingStateWarning from './missingStateWarning'
 
 const hoverState = '&[data-isselectable="true"]:hover'
-const focusState = '&[data-isselectable="true"]:focus, &[aria-selected="true"]'
-const activeState = '&[aria-current="true"], &[data-isselectable="true"]:active'
-const currentState = '&[aria-current="true"]'
+const focusState =
+  '&[data-isselectable="true"]:focus, &[data-ishighlighted="true"]'
+const activeState =
+  '&[aria-selected="true"], &[data-isselectable="true"]:active'
+const currentState = '&[aria-selected="true"]'
 
 const baseStyle = {
   '&[data-isselectable="true"]': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3664,6 +3664,11 @@ compression-webpack-plugin@^2.0.0:
     serialize-javascript "^1.4.0"
     webpack-sources "^1.0.1"
 
+compute-scroll-into-view@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
+  integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4497,10 +4502,14 @@ dotenv@^5.0.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
 
-downshift@^1.31.16:
-  version "1.31.16"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
-  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
+downshift@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.1.1.tgz#91e14d45d6ee3e239023cdfcc06248c7f5a1b2b2"
+  integrity sha512-teJ4ACfySJPC1+nOg6XqSMtCwjQkdXLfM2FlObr5FQAIR2r9TTFFDbXUTvzRA7mSJVf3FQZ/cx9i67Ox0iEy1Q==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    compute-scroll-into-view "^1.0.9"
+    prop-types "^15.6.0"
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
This upgrades Downshift from v1 to v3 and fixes a couple of bugs.

### Bug fixes
- Pressing the up arrow key in the text input now correctly takes you to the bottom of the list.
- The Popover's Portal is now properly supported which improves accessibility and fixes touch screen support.
- Anything using Positioner will now render correctly if `isShown` is `true` on initial render.

### Breaking changes
Because all the Downshift props are exposed directly, these breaking changes are introduced to `Autocomplete` and `Combobox`:
- https://github.com/paypal/downshift/releases/tag/v2.0.0
- https://github.com/paypal/downshift/releases/tag/v3.0.0