### PR TITLE
fix passing server-rendered css in ssr-next example

### DIFF
--- a/examples/ssr-next/pages/_document.js
+++ b/examples/ssr-next/pages/_document.js
@@ -29,7 +29,7 @@ export default class MyDocument extends Document {
       <html>
         <Head>
           <title>SSR in Next.js</title>
-          <style>{css}</style>
+          <style dangerouslySetInnerHTML={{ __html: css }} />
         </Head>
 
         <body>


### PR DESCRIPTION
This fix avoid escaping of certain characters in style tag by using `dangerouslySetInnerHTML`. Previously it led to invalid css for some rules.

<img width="374" alt="screenshot 2018-10-17 at 13 06 10" src="https://user-images.githubusercontent.com/5165202/47079181-7d190680-d20d-11e8-9ea7-4f1ffd733db6.png">
<img width="348" alt="screenshot 2018-10-17 at 13 06 27" src="https://user-images.githubusercontent.com/5165202/47079183-7ee2ca00-d20d-11e8-91f2-bc91087a9094.png">
