### PR TITLE
Add intent prop to the Danger intent example

### DIFF
--- a/docs/src/pages/components/dialog.mdx
+++ b/docs/src/pages/components/dialog.mdx
@@ -64,6 +64,7 @@ The `intent` prop determines the appearance of the confirm button, `danger` is r
       <Dialog
         isShown={state.isShown}
         title="Danger intent"
+        intent="danger"
         onCloseComplete={() => setState({ isShown: false })}
         confirmLabel="Delete Something"
       >


### PR DESCRIPTION
The example code in the Default with danger intent example doesn't actually have the intent prop specified, so the confirm button remains blue. This should fix that. :smile: