### PR TITLE
Replace &nbsp; with normal space in CornerDialog example

### DIFF
--- a/src/corner-dialog/stories/index.stories.js
+++ b/src/corner-dialog/stories/index.stories.js
@@ -56,7 +56,7 @@ storiesOf('corner-dialog', module).add('CornerDialog', () => (
             confirmLabel="View Agreement"
             onCloseComplete={() => setState({ isShown: false })}
           >
-            Segment now offers a Data Processing Agreement and EU&nbsp;Model
+            Segment now offers a Data Processing Agreement and EU Model
             Contract Clauses as a means of meeting the adequacy and security
             requirements of the GDPR.
           </CornerDialog>


### PR DESCRIPTION
The example was not interpreting this as a non-breaking space, but rather it was rendering the literal string `&nbsp;`:

![image](https://user-images.githubusercontent.com/1863540/47107749-f65d2d00-d1fe-11e8-87ec-4a1a366c0988.png)

There doesn't seem to be any issue just replacing the `&nbsp;` with a literal space character though, so that's what I've done.