### PR TITLE
Convert NodeList to array with Array.from and prevent XO linter from fixing

### DIFF
--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -34,7 +34,8 @@ export default class Menu extends React.PureComponent {
 
   componentDidMount() {
     // Get the menu item buttons
-    this.menuItems = Array.prototype.slice.call(
+    // eslint-disable-next-line unicorn/prefer-spread
+    this.menuItems = Array.from(
       this.menuRef.querySelectorAll('[role="menuitemradio"], [role="menuitem"]')
     )
 

--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -34,11 +34,9 @@ export default class Menu extends React.PureComponent {
 
   componentDidMount() {
     // Get the menu item buttons
-    this.menuItems = [
-      ...this.menuRef.querySelectorAll(
-        '[role="menuitemradio"], [role="menuitem"]'
-      )
-    ]
+    this.menuItems = Array.prototype.slice.call(
+      this.menuRef.querySelectorAll('[role="menuitemradio"], [role="menuitem"]')
+    )
 
     if (this.menuItems.length === 0) {
       throw new Error('The menu has no menu items')

--- a/src/table/src/manageTableCellFocusInteraction.js
+++ b/src/table/src/manageTableCellFocusInteraction.js
@@ -4,9 +4,8 @@
  * @param {Element} ref - the cell to manage focus interaction for.
  */
 export default function manageTableCellFocusInteraction(key, ref) {
-  const tableRowChildren = Array.prototype.slice.call(
-    ref.parentElement.children
-  )
+  // eslint-disable-next-line unicorn/prefer-spread
+  const tableRowChildren = Array.from(ref.parentElement.children)
   const columnIndex = tableRowChildren.indexOf(ref)
 
   let nextItemToFocus
@@ -20,7 +19,8 @@ export default function manageTableCellFocusInteraction(key, ref) {
       nextItemToFocus = tableRowChildren[columnIndex + 1]
     }
   } else if (key === 'ArrowUp' || key === 'ArrowDown') {
-    const tableBodyChildren = Array.prototype.slice.call(
+    // eslint-disable-next-line unicorn/prefer-spread
+    const tableBodyChildren = Array.from(
       ref.parentElement.parentElement.children
     )
     const rowIndex = tableBodyChildren.indexOf(ref.parentElement)

--- a/src/table/src/manageTableCellFocusInteraction.js
+++ b/src/table/src/manageTableCellFocusInteraction.js
@@ -4,7 +4,9 @@
  * @param {Element} ref - the cell to manage focus interaction for.
  */
 export default function manageTableCellFocusInteraction(key, ref) {
-  const tableRowChildren = [...ref.parentElement.children]
+  const tableRowChildren = Array.prototype.slice.call(
+    ref.parentElement.children
+  )
   const columnIndex = tableRowChildren.indexOf(ref)
 
   let nextItemToFocus
@@ -18,7 +20,9 @@ export default function manageTableCellFocusInteraction(key, ref) {
       nextItemToFocus = tableRowChildren[columnIndex + 1]
     }
   } else if (key === 'ArrowUp' || key === 'ArrowDown') {
-    const tableBodyChildren = [...ref.parentElement.parentElement.children]
+    const tableBodyChildren = Array.prototype.slice.call(
+      ref.parentElement.parentElement.children
+    )
     const rowIndex = tableBodyChildren.indexOf(ref.parentElement)
 
     let nextRow

--- a/src/table/src/manageTableRowFocusInteraction.js
+++ b/src/table/src/manageTableRowFocusInteraction.js
@@ -5,7 +5,9 @@
  */
 export default function manageTableRowFocusInteraction(key, ref) {
   let nextItemToFocus
-  const tableBodyChildren = [...ref.parentElement.children]
+  const tableBodyChildren = Array.prototype.slice.call(
+    ref.parentElement.children
+  )
   const rowIndex = tableBodyChildren.indexOf(ref)
 
   if (key === 'ArrowUp' && rowIndex - 1 >= 0) {

--- a/src/table/src/manageTableRowFocusInteraction.js
+++ b/src/table/src/manageTableRowFocusInteraction.js
@@ -5,9 +5,8 @@
  */
 export default function manageTableRowFocusInteraction(key, ref) {
   let nextItemToFocus
-  const tableBodyChildren = Array.prototype.slice.call(
-    ref.parentElement.children
-  )
+  // eslint-disable-next-line unicorn/prefer-spread
+  const tableBodyChildren = Array.from(ref.parentElement.children)
   const rowIndex = tableBodyChildren.indexOf(ref)
 
   if (key === 'ArrowUp' && rowIndex - 1 >= 0) {


### PR DESCRIPTION
## Summary
* Switch to using the Array object to convert NodeList to an array. Reason being, the ES6 spread is being transpiled incorrectly. See the errors [here](https://evergreen.segment.com/components/menu) and [here](https://evergreen.segment.com/components/table) (try to sort the table in this case)

**Screenshot**

<img width="823" alt="screen shot 2018-10-17 at 9 33 40 pm" src="https://user-images.githubusercontent.com/12093664/47129890-72ce2b00-d254-11e8-8872-5d8028f30d44.png">
