### PR TITLE
Tiny typo fix

### DIFF
--- a/docs/src/pages/components/positioner.mdx
+++ b/docs/src/pages/components/positioner.mdx
@@ -2,7 +2,7 @@ import PropsTable from 'components/PropsTable'
 
 ## Introduction
 
-The `Positioner` component is a utility component to help with positioning an element to a anchor.
+The `Positioner` component is a utility component to help with positioning an element to an anchor.
 It is used as a helper component throughout Evergreen in components such as `Tooltip` and `Popover`.
 
 <PropsTable of="Positioner" />


### PR DESCRIPTION
Possibly the most underwhelming PR ever :grin:

Replaces _a anchor_ with _an anchor_.