### PR TITLE
Update disabled props on Search Input

### DIFF
--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -51,7 +51,7 @@ class SearchInput extends PureComponent {
           height={height}
           paddingLeft={height}
           appearance={appearance}
-          disable={disabled}
+          disabled={disabled}
           width={width}
           {...remainingProps}
         />


### PR DESCRIPTION
Hi !

Great project ! Thank you for it !

I was browsing the doc/demo website and by checking the search-input, I saw that the disable search-input wasn't disabled. I check on multiple browser (Firefox / Chrome) and after checking the React devtools and the source code I saw the little typo on `disable` on the TextInput Component props sent.

Just a small PR to fix this typo from `disable` to `disabled`

