### PR TITLE
Remove extra label prop from Switch

### DIFF
--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -74,11 +74,6 @@ class Switch extends PureComponent {
     name: PropTypes.string,
 
     /**
-     * Label of the radio.
-     */
-    label: PropTypes.node,
-
-    /**
      * The value attribute of the radio.
      */
     value: PropTypes.string,


### PR DESCRIPTION
This PR targets issue https://github.com/segmentio/evergreen/issues/180.
I have removed the extra label prop from Switch component.
If there's a need to implement its use, we can implement it in another PR.