### PR TITLE
Add overflow:hidden when overlay is shown

### DIFF
--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -162,6 +162,10 @@ class Overlay extends React.Component {
     }
   }
 
+  componentDidMount() {
+    document.body.style.overflow = 'hidden'
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.isShown && !this.props.isShown) {
       this.setState({
@@ -172,6 +176,7 @@ class Overlay extends React.Component {
 
   componentWillUnmount() {
     document.body.removeEventListener('keydown', this.onEsc, false)
+    document.body.style.overflow = 'visible'
   }
 
   /**


### PR DESCRIPTION
Targets https://github.com/segmentio/evergreen/issues/261

Rather than setting `overflow` to `null` on `componentWillUnmount`, I have set it to the default value of overflow. i.e. `visible`