### PR TITLE
Fixed Menu error 'querySelectorAll of null'.

### DIFF
--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -32,7 +32,8 @@ export default class Menu extends React.PureComponent {
     children: PropTypes.node
   }
 
-  componentDidMount() {
+  onRefReady() {
+    console.log(this.menuRef)
     // Get the menu item buttons
     // eslint-disable-next-line unicorn/prefer-spread
     this.menuItems = Array.from(
@@ -112,6 +113,7 @@ export default class Menu extends React.PureComponent {
 
   onMenuRef = ref => {
     this.menuRef = ref
+    if (ref) this.onRefReady()
   }
 
   render() {

--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -33,7 +33,6 @@ export default class Menu extends React.PureComponent {
   }
 
   onRefReady() {
-    console.log(this.menuRef)
     // Get the menu item buttons
     // eslint-disable-next-line unicorn/prefer-spread
     this.menuItems = Array.from(

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -131,7 +131,10 @@ export default class Positioner extends PureComponent {
 
   getRef = ref => {
     this.positionerRef = ref
-    this.props.innerRef(ref)
+
+    if (typeof this.props.innerRef === 'function') {
+      this.props.innerRef(ref)
+    }
   }
 
   handleEnter = () => {


### PR DESCRIPTION
While browsing the docs, I found an error on the Menu component. I set out to fix the error, and this PR is the solution I came up with.

<img width="855" alt="screen shot 2018-10-20 at 6 13 15 pm" src="https://user-images.githubusercontent.com/19484365/47261390-dd20de80-d493-11e8-9632-803cecc5f137.png">

This is the piece of problematic code:

```js
onMenuRef = ref => {
  this.menuRef = ref
}
```

I believe `componentDidMount` was invoking before the `onMenuRef` method was invoked by the ancestral child. So my solution was to change `componentDidMount` to `onRefReady`, which now gets invoked whenever the `onMenuRef` method is invoked.

```js
  onMenuRef = ref => {
    this.menuRef = ref
    if (ref) this.onRefReady()
  }
```

Also, every _other_ time `onMenuRef` was called, `ref` was `null`, so I added the condition to make sure that `ref` existed before trying to invoke `onRefReady`.

One other change I made was to `Positioner.js`, in which I updated to follow the same defensive pattern for invoking `this.props.innerRef`. 

**I am not sure if this is the right fix.** I do not yet fully understand the logic in the `componentDidMount` or what made it necessary to happen only on mount. **But this is the solution that worked for me** in the few minutes I had before having to take the misses out for dinner. :)