### PR TITLE
fix `appearance` warnings

### DIFF
--- a/src/theme/src/default-theme/component-specific/getTextInputClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTextInputClassName.js
@@ -55,7 +55,8 @@ InputAppearances.neutral = Themer.createInputAppearance({
 
 InputAppearances.none = Themer.createInputAppearance({
   base: {
-    appearance: 'none',
+    WebkitAppearance: 'none',
+    MozAppearance: 'none',
     backgroundColor: 'white'
   },
   invalid: {},


### PR DESCRIPTION
Fixes warnings like:
```
createAppearance() only accepts whitelisted properties, key 'appearance' is not whitelisted in whitelist:  
```