### PR TITLE
Minor bugfixes for TagInput: shouldClearInput, prop warning, preventDefault

### DIFF
--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -51,10 +51,10 @@ class TagInput extends React.Component {
      */
     onRemove: PropTypes.func,
     /** Value or RegExp to split on pasted text or on enter keypress */
-    separator: PropTypes.oneOf([
+    separator: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.instanceOf(RegExp),
-      false
+      PropTypes.oneOf([false])
     ]),
     /** Provide props to tag component (actually `Badge`, for now). */
     tagProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -128,6 +128,8 @@ class TagInput extends React.Component {
     const { selectionEnd, value } = event.target
 
     if (event.key === 'Enter') {
+      // Prevent Enter keypresses from submitting forms since they have special powers inside TagInput
+      event.preventDefault()
       this.addTags(value)
     } else if (event.key === 'Backspace' && selectionEnd === 0) {
       this.handleBackspaceToRemove(event)

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -80,9 +80,11 @@ class TagInput extends React.Component {
   addTags = (value = '') => {
     const { onAdd, onChange, values } = this.props
     const newValues = this.getValues(value)
-    const shouldClearInput =
-      safeInvoke(onAdd, newValues) ||
-      safeInvoke(onChange, values.concat(newValues))
+    let shouldClearInput = safeInvoke(onAdd, newValues)
+
+    if (typeof onChange === 'function') {
+      shouldClearInput = shouldClearInput || onChange(values.concat(newValues))
+    }
 
     if (shouldClearInput !== false) {
       this.setState({ inputValue: '' })
@@ -188,6 +190,8 @@ class TagInput extends React.Component {
       onChange,
       onInputChange,
       onRemove,
+      separator,
+      tagProps,
       theme,
       values,
       ...props

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -16,6 +16,8 @@ let inputId = 1
 
 class TagInput extends React.Component {
   static propTypes = {
+    /** Whether or not the inputValue should be added to the tags when the input blurs. */
+    addOnBlur: PropTypes.bool,
     /** The class name to apply to the container component. */
     className: PropTypes.string,
     /** Whether or not the input should be disabled. */
@@ -63,6 +65,7 @@ class TagInput extends React.Component {
   }
 
   static defaultProps = {
+    addOnBlur: false,
     disabled: false,
     height: 32,
     separator: /[,\n\r]/,
@@ -109,8 +112,19 @@ class TagInput extends React.Component {
     this.removeTagAtIndex(values.length - 1)
   }
 
-  handleInputBlur = event => {
-    this.setState({ isFocused: false })
+  handleBlur = event => {
+    const container = event.target
+
+    // Use raf so that the dom has time to update `activeElement`
+    requestAnimationFrame(() => {
+      if (!container.contains(document.activeElement)) {
+        if (this.props.addOnBlur && this.state.inputValue) {
+          this.addTags(this.state.inputValue)
+        }
+        this.setState({ isFocused: false })
+      }
+    })
+
     safeInvoke(this.props.onBlur, event)
   }
 
@@ -183,6 +197,7 @@ class TagInput extends React.Component {
 
   render() {
     const {
+      addOnBlur,
       className,
       disabled,
       height,
@@ -216,6 +231,7 @@ class TagInput extends React.Component {
         paddingRight={Math.round(height / 3.2)}
         paddingY="2px"
         {...props}
+        onBlur={this.handleBlur}
       >
         {values.map(this.maybeRenderTag)}
         <Text
@@ -232,7 +248,6 @@ class TagInput extends React.Component {
           className={themedInputClassName}
           ref={this.setRef}
           onChange={this.handleInputChange}
-          onBlur={this.handleInputBlur}
           onFocus={this.handleInputFocus}
           onKeyDown={this.handleKeyDown}
         />

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -132,6 +132,7 @@ storiesOf('tag-input', module).add('TagInput', () => (
           <TagInput
             inputProps={{ placeholder: 'Enter something...' }}
             values={values}
+            separator={false}
             onAdd={addValues}
             onChange={handleChange}
             onRemove={removeValue}

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -26,6 +26,12 @@ class StateManager extends React.PureComponent {
     }))
   }
 
+  handleChange = values => {
+    if (values.length % 2 === 0) {
+      return false
+    }
+  }
+
   removeValue = (_value, index) => {
     this.setState(state => ({
       values: state.values.filter((_, i) => i !== index)
@@ -43,7 +49,8 @@ class StateManager extends React.PureComponent {
       values: this.state.values,
       addValues: this.addValues,
       removeValue: this.removeValue,
-      tagProps: this.tagProps
+      tagProps: this.tagProps,
+      handleChange: this.handleChange
     })
   }
 }
@@ -112,6 +119,22 @@ storiesOf('tag-input', module).add('TagInput', () => (
             onAdd={addValues}
             onRemove={removeValue}
             tagProps={tagProps}
+          />
+        )}
+      </StateManager>
+    </StorySection>
+    <StorySection>
+      <StoryHeader>
+        <StoryHeading>Prevent input clearing on even values</StoryHeading>
+      </StoryHeader>
+      <StateManager values={initialValues}>
+        {({ values, addValues, removeValue, handleChange }) => (
+          <TagInput
+            inputProps={{ placeholder: 'Enter something...' }}
+            values={values}
+            onAdd={addValues}
+            onChange={handleChange}
+            onRemove={removeValue}
           />
         )}
       </StateManager>

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -130,6 +130,7 @@ storiesOf('tag-input', module).add('TagInput', () => (
       <StateManager values={initialValues}>
         {({ values, addValues, removeValue, handleChange }) => (
           <TagInput
+            addOnBlur
             inputProps={{ placeholder: 'Enter something...' }}
             values={values}
             separator={false}

--- a/src/theme/src/default-theme/component-specific/getTextInputClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTextInputClassName.js
@@ -55,8 +55,6 @@ InputAppearances.neutral = Themer.createInputAppearance({
 
 InputAppearances.none = Themer.createInputAppearance({
   base: {
-    WebkitAppearance: 'none',
-    MozAppearance: 'none',
     backgroundColor: 'white'
   },
   invalid: {},


### PR DESCRIPTION
## What's in this PR?

This fixes `shouldClearInput` so that if _either_ `onAdd` or `onChange` explicitly `return false` the input will not be cleared.

This behavior allows consumers to do validation and reject changes while allowing the user a change to fix their input (not have to re-type stuff)

It also introduces `event.preventDefault()` when pressing enter because we do not want it to submit forms. It has special powers inside `TagInput` and we should preserve them.