### PR TITLE
Fix initial rendering of nodes via Portal

### DIFF
--- a/src/portal/src/Portal.js
+++ b/src/portal/src/Portal.js
@@ -19,9 +19,6 @@ export default class Portal extends Component {
     }
 
     this.el = document.createElement('div')
-  }
-
-  componentDidMount() {
     portalContainer.appendChild(this.el)
   }
 


### PR DESCRIPTION
I stumbled upon an issue where I couldn't get correct height of elements inside `<Popover>`'s content, even when height was hard-coded via style. Here's a demo that consistently reproduces this issue: https://codesandbox.io/s/v1mzl5lxz3.

It's happening, because `<Popover>` uses `<Portal>` to render the popover content (actual popover) and first render of `<Portal>` doesn't actually end up in the DOM. Because at the time of first render, `componentDidMount()` wasn't executed yet, so `this.el` node is not a child of any node yet (not in the DOM). Adding `this.el` to `portalContainer`'s node in constructor solves this issue and first render of Portal correctly renders children in the DOM.