### PR TITLE
Add delay to <Spinner>

### DIFF
--- a/docs/src/pages/components/spinner.mdx
+++ b/docs/src/pages/components/spinner.mdx
@@ -47,4 +47,15 @@ Alternatively you can center a `Spinner` with margins.
 </Pane>
 ```
 
+## Showing after delay
+
+Add `delay` prop (in milliseconds) to show spinner only after this time is passed.
+Hide and then show code below to see this behavior in action.
+
+```jsx
+<Pane height={40}>
+  <Spinner delay={300} />
+</Pane>
+```
+
 <PropsTable of="Spinner" />

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -44,6 +44,11 @@ class Spinner extends PureComponent {
     ...Box.propTypes,
 
     /**
+     * Delay after which spinner should be visible.
+     */
+    delay: PropTypes.number,
+
+    /**
      * The size of the spinner.
      */
     size: PropTypes.number.isRequired,
@@ -55,10 +60,23 @@ class Spinner extends PureComponent {
   }
 
   static defaultProps = {
-    size: 40
+    size: 40,
+    delay: 0
+  }
+
+  constructor({ delay }) {
+    super()
+
+    this.state = {
+      isVisible: delay === 0
+    }
   }
 
   render() {
+    if (!this.state.isVisible) {
+      return null
+    }
+
     const { theme, size, ...props } = this.props
     return (
       <Box width={size} height={size} lineHeight={0} {...props}>
@@ -73,6 +91,22 @@ class Spinner extends PureComponent {
         </Box>
       </Box>
     )
+  }
+
+  componentDidMount() {
+    const { delay } = this.props
+
+    if (delay > 0) {
+      this.delayTimer = setTimeout(() => {
+        this.setState({
+          isVisible: true
+        })
+      }, delay)
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.delayTimer)
   }
 }
 

--- a/src/spinner/stories/index.stories.js
+++ b/src/spinner/stories/index.stories.js
@@ -3,12 +3,18 @@ import React from 'react'
 import Box from 'ui-box'
 import { Spinner } from '..'
 
-storiesOf('spinner', module).add('Spinner', () => (
-  <Box padding={40}>
-    {(() => {
-      document.body.style.margin = '0'
-      document.body.style.height = '100vh'
-    })()}
-    <Spinner />
-  </Box>
-))
+storiesOf('spinner', module)
+  .add('Spinner', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <Spinner />
+    </Box>
+  ))
+  .add('Spinner with 300ms delay', () => (
+    <Box padding={40}>
+      <Spinner delay={300} />
+    </Box>
+  ))


### PR DESCRIPTION
Adds a `delay` prop (in milliseconds) which, if set, results in <Spinner> being shown after that delay is passed. Useful to avoid showing spinner for a fraction of second.