### PR TITLE
Runtime warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "react-tiny-virtual-list": "^2.1.4",
     "react-transition-group": "^2.5.0",
     "tinycolor2": "^1.4.1",
-    "ui-box": "^1.4.0"
+    "ui-box": "^1.4.0",
+    "warning": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.3.0",

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import warning from 'warning'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
 import { Icon } from '../../icon'
@@ -88,6 +89,13 @@ class MenuItem extends React.PureComponent {
       icon,
       ...passthroughProps
     } = this.props
+
+    if (process.env.NODE_ENV !== 'production') {
+      warning(
+        typeof this.props.onClick !== 'function',
+        '<Menu.Item> expects `onSelect` prop, but you passed `onClick`.'
+      )
+    }
 
     const themedClassName = theme.getMenuItemClassName(appearance, 'none')
 

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import warning from 'warning'
 import { Pane } from '../../layers'
 import { withTheme } from '../../theme'
 import safeInvoke from '../../lib/safe-invoke'
@@ -72,14 +73,16 @@ class TableRow extends PureComponent {
     intent: 'none',
     appearance: 'default',
     height: 48,
-    onClick: () => {},
     onSelect: () => {},
     onDeselect: () => {},
     onKeyPress: () => {}
   }
 
   handleClick = e => {
-    this.props.onClick(e)
+    if (typeof this.props.onClick === 'function') {
+      this.props.onClick(e)
+    }
+
     if (this.props.isSelectable) {
       if (this.props.isSelected) {
         this.props.onDeselect()
@@ -134,6 +137,13 @@ class TableRow extends PureComponent {
       isSelected,
       ...props
     } = this.props
+
+    if (process.env.NODE_ENV !== 'production') {
+      warning(
+        typeof onClick !== 'function',
+        '<Table.Row> expects `onSelect` prop, but you passed `onClick`.'
+      )
+    }
 
     const themedClassName = theme.getRowClassName(appearance, intent)
 

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
+import warning from 'warning'
 import { Text } from '../../typography'
 import { withTheme } from '../../theme'
 
@@ -33,7 +34,6 @@ class Tab extends PureComponent {
   }
 
   static defaultProps = {
-    onClick: () => {},
     onSelect: () => {},
     onKeyPress: () => {},
     is: 'span',
@@ -54,7 +54,10 @@ class Tab extends PureComponent {
   }
 
   handleClick = e => {
-    this.props.onClick(e)
+    if (typeof this.props.onClick === 'function') {
+      this.props.onClick(e)
+    }
+
     this.props.onSelect()
   }
 
@@ -76,6 +79,13 @@ class Tab extends PureComponent {
       appearance,
       ...props
     } = this.props
+
+    if (process.env.NODE_ENV !== 'production') {
+      warning(
+        typeof this.props.onClick !== 'function',
+        '<Tab> expects `onSelect` prop, but you passed `onClick`.'
+      )
+    }
 
     const textSize = theme.getTextSizeForControlHeight(height)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12049,6 +12049,13 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
+warning@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
+  dependencies:
+    loose-envify "^1.0.0"
+
 watchpack@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"


### PR DESCRIPTION
This PR starts an initiative to introduce runtime warnings in development to help developers notice and fix common mistakes. Being an active user of Evergreen, I still use onClick prop instead of onSelect sometimes. After this is merged, this is what I would see if I did it again:

<img width="516" alt="cleanshot 2018-10-31 at 21 24 36 2x" src="https://user-images.githubusercontent.com/697676/47832780-9fa23800-dd54-11e8-9e23-9ea9d8ba1c0f.png">

Happy to tweak error messages, if needed.