### PR TITLE
Add ability to show only one toaster with the same ID at a time

### DIFF
--- a/docs/src/pages/components/toaster.mdx
+++ b/docs/src/pages/components/toaster.mdx
@@ -150,3 +150,21 @@ The `duration` property is in seconds — not milliseconds.
   10 Seconds
 </Button>
 ```
+
+## Unique toasts
+
+There are cases when it's only one toast with the same content can be shown at a time.
+Passing a unique ID via `id` property allows Evergreen to close all previous toasts with the same ID, before showing a new one.
+
+
+```jsx
+<Button
+  onClick={() =>
+    toaster.warning('Only one toaster will be shown', {
+      id: 'forbidden-action'
+    })
+  }
+>
+  Show only one toaster
+</Button>
+```

--- a/src/toaster/src/ToastManager.js
+++ b/src/toaster/src/ToastManager.js
@@ -15,6 +15,8 @@ const wrapperClass = css({
   pointerEvents: 'none'
 })
 
+const hasCustomId = settings => Object.hasOwnProperty.call(settings, 'id')
+
 export default class ToastManager extends React.PureComponent {
   static propTypes = {
     /**
@@ -56,6 +58,16 @@ export default class ToastManager extends React.PureComponent {
   }
 
   notify = (title, settings) => {
+    // If there's a custom toast ID passed, close existing toasts with the same custom ID
+    if (hasCustomId(settings)) {
+      for (const toast of this.state.toasts) {
+        // Since unique ID is still appended to a custom ID, skip the unique ID and check only prefix
+        if (String(toast.id).startsWith(settings.id)) {
+          this.closeToast(toast.id)
+        }
+      }
+    }
+
     const instance = this.createToastInstance(title, settings)
 
     this.setState(previousState => {
@@ -68,7 +80,8 @@ export default class ToastManager extends React.PureComponent {
   }
 
   createToastInstance = (title, settings) => {
-    const id = ++ToastManager.idCounter
+    const uniqueId = ++ToastManager.idCounter
+    const id = hasCustomId(settings) ? `${settings.id}-${uniqueId}` : uniqueId
 
     return {
       id,

--- a/src/toaster/stories/index.stories.js
+++ b/src/toaster/stories/index.stories.js
@@ -46,6 +46,16 @@ storiesOf('toaster', module).add('examples', () => (
         >
           Notify with Text
         </Button>
+        <Button
+          marginRight={8}
+          onClick={() =>
+            toaster.notify('A simple general message', {
+              id: 'general-message'
+            })
+          }
+        >
+          Notify once
+        </Button>
       </Box>
       <Box marginBottom={12}>
         <Button


### PR DESCRIPTION
There are cases when it's only one toast with the same content can be shown at a time. Passing a unique ID via id property allows Evergreen to close all previous toasts with the same ID, before showing a new one.

```js
toaster.warning('Only one toaster will be shown', {
  id: 'forbidden-action'
})
```