### PR TITLE
Show runtime warnings only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "react-tiny-virtual-list": "^2.1.4",
     "react-transition-group": "^2.5.0",
     "tinycolor2": "^1.4.1",
-    "ui-box": "^1.4.0",
-    "warning": "^4.0.2"
+    "ui-box": "^1.4.0"
   },
   "peerDependencies": {
     "react": "^16.3.0",

--- a/src/lib/warning.js
+++ b/src/lib/warning.js
@@ -1,0 +1,8 @@
+const shownWarnings = []
+
+export default (condition, warning) => {
+  if (condition && !shownWarnings.includes(warning)) {
+    console.error(`Warning: ${warning}`)
+    shownWarnings.push(warning)
+  }
+}

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import warning from 'warning'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
 import { Icon } from '../../icon'
 import { withTheme } from '../../theme'
 import safeInvoke from '../../lib/safe-invoke'
+import warning from '../../lib/warning'
 
 class MenuItem extends React.PureComponent {
   static propTypes = {
@@ -92,7 +92,7 @@ class MenuItem extends React.PureComponent {
 
     if (process.env.NODE_ENV !== 'production') {
       warning(
-        typeof this.props.onClick !== 'function',
+        typeof this.props.onClick === 'function',
         '<Menu.Item> expects `onSelect` prop, but you passed `onClick`.'
       )
     }

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -1,10 +1,10 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import warning from 'warning'
 import { Pane } from '../../layers'
 import { withTheme } from '../../theme'
 import safeInvoke from '../../lib/safe-invoke'
+import warning from '../../lib/warning'
 import { TableRowProvider } from './TableRowContext'
 import manageTableRowFocusInteraction from './manageTableRowFocusInteraction'
 
@@ -140,7 +140,7 @@ class TableRow extends PureComponent {
 
     if (process.env.NODE_ENV !== 'production') {
       warning(
-        typeof onClick !== 'function',
+        typeof onClick === 'function',
         '<Table.Row> expects `onSelect` prop, but you passed `onClick`.'
       )
     }

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import warning from 'warning'
 import { Text } from '../../typography'
 import { withTheme } from '../../theme'
+import warning from '../../lib/warning'
 
 class Tab extends PureComponent {
   static propTypes = {
@@ -82,7 +82,7 @@ class Tab extends PureComponent {
 
     if (process.env.NODE_ENV !== 'production') {
       warning(
-        typeof this.props.onClick !== 'function',
+        typeof this.props.onClick === 'function',
         '<Tab> expects `onSelect` prop, but you passed `onClick`.'
       )
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12049,13 +12049,6 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
-  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
-  dependencies:
-    loose-envify "^1.0.0"
-
 watchpack@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"


### PR DESCRIPTION
Follow up to https://github.com/segmentio/evergreen/pull/415.

Turns out `warning` package didn't have functionality to show same warning only once. And turns out it's much easier to just write our own implementation which does that.