### PR TITLE
Add emptyView to <SelectMenu>

### DIFF
--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -131,6 +131,41 @@ Available positions:
 </Component>
 ```
 
+## Empty view
+
+It's possible to display a custom empty view instead of options list via `emptyView`, when there are no properties supplied.
+Note that empty view won't be shown when options are being filtered and there are no search results.
+
+```jsx
+<SelectMenu
+  title="Empty view"
+  options={[]}
+  emptyView={(
+    <Pane height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Text size={300}>No options found</Text>
+    </Pane>
+  )}
+>
+  <Button>Select option...</Button>
+</SelectMenu>
+```
+
+It's also possible to close `<SelectMenu>` from within empty view:
+
+```jsx
+<SelectMenu
+  title="Empty view"
+  options={[]}
+  emptyView={({ close }) => (
+    <Pane height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Button onClick={close}>Close</Button>
+    </Pane>
+  )}
+>
+  <Button>Select option...</Button>
+</SelectMenu>
+```
+
 
 ## Multiselect with deselect example
 

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -77,7 +77,13 @@ export default class SelectMenu extends PureComponent {
      * rendered on the right side of the Select Menu to give additional
      * information when an option is selected.
      */
-    detailView: PropTypes.oneOfType([PropTypes.func, PropTypes.node])
+    detailView: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+
+    /**
+     * Can be a function that returns a node, or a node itself, that is
+     * rendered instead of the options list when there are no options.
+     */
+    emptyView: PropTypes.oneOfType([PropTypes.func, PropTypes.node])
   }
 
   static defaultProps = {
@@ -103,6 +109,20 @@ export default class SelectMenu extends PureComponent {
     return {}
   }
 
+  getEmptyView = (close, emptyView) => {
+    if (typeof emptyView === 'function') {
+      return {
+        emptyView: emptyView({ close })
+      }
+    }
+
+    if (emptyView) {
+      return { emptyView }
+    }
+
+    return {}
+  }
+
   render() {
     const {
       title,
@@ -114,6 +134,7 @@ export default class SelectMenu extends PureComponent {
       hasTitle,
       hasFilter,
       detailView,
+      emptyView,
       isMultiSelect,
       ...props
     } = this.props
@@ -143,6 +164,7 @@ export default class SelectMenu extends PureComponent {
             }}
             close={close}
             {...this.getDetailView(close, detailView)}
+            {...this.getEmptyView(close, emptyView)}
           />
         )}
         {...props}

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -25,7 +25,12 @@ export default class SelectMenuContent extends PureComponent {
     /**
      * Node that is placed right next to the options.
      */
-    detailView: PropTypes.node
+    detailView: PropTypes.node,
+
+    /**
+     * Node that is displayed instead of options list when there are no options.
+     */
+    emptyView: PropTypes.node
   }
 
   static defaultProps = {
@@ -45,12 +50,14 @@ export default class SelectMenuContent extends PureComponent {
       title,
       listProps,
       detailView,
+      emptyView,
       isMultiSelect
     } = this.props
 
     const headerHeight = 40
     const optionsListHeight = hasTitle ? height - headerHeight : height
     const hasDetailView = Boolean(detailView)
+    const hasEmptyView = Boolean(emptyView)
 
     return (
       <Pane display="flex" height={height}>
@@ -81,14 +88,19 @@ export default class SelectMenuContent extends PureComponent {
               />
             </Pane>
           )}
-          <OptionsList
-            height={optionsListHeight}
-            hasFilter={hasFilter}
-            options={options}
-            isMultiSelect={isMultiSelect}
-            close={close}
-            {...listProps}
-          />
+
+          {options.length === 0 && hasEmptyView ? (
+            <Pane height={optionsListHeight}>{emptyView}</Pane>
+          ) : (
+            <OptionsList
+              height={optionsListHeight}
+              hasFilter={hasFilter}
+              options={options}
+              isMultiSelect={isMultiSelect}
+              close={close}
+              {...listProps}
+            />
+          )}
         </Pane>
         {hasDetailView && detailView}
       </Pane>

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -4,6 +4,7 @@ import React from 'react'
 import Box from 'ui-box'
 import { SelectMenu } from '..'
 import { Button } from '../../buttons'
+import { Text } from '../../typography'
 import options from './starwars-options'
 import Manager from './Manager'
 
@@ -75,5 +76,20 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
         </SelectMenu>
       )}
     </Component>
+    <SelectMenu
+      title="Empty state"
+      emptyView={
+        <Box
+          height="100%"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Text size={300}>No options found</Text>
+        </Box>
+      }
+    >
+      <Button>Empty state</Button>
+    </SelectMenu>
   </Box>
 ))


### PR DESCRIPTION
Adds prop to display a custom empty view when there are no options passed to `<SelectMenu>`.

<img width="288" alt="cleanshot 2018-11-14 at 10 54 13 2x" src="https://user-images.githubusercontent.com/697676/48505318-a2dcff80-e7fb-11e8-974a-67125ef45d66.png">


```jsx
<SelectMenu
  title="Empty view"
  options={[]}
  emptyView={(
    <Pane height="100%" display="flex" alignItems="center" justifyContent="center">
      <Text size={300}>No options found</Text>
    </Pane>
  )}
>
  <Button>Select option...</Button>
</SelectMenu>
```