### PR TITLE
Fix manual control over <Popover> visibility

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -92,7 +92,6 @@ export default class Popover extends Component {
 
   static defaultProps = {
     position: Position.BOTTOM,
-    isShown: false,
     minWidth: 200,
     minHeight: 40,
     animationDuration: 300,
@@ -316,7 +315,8 @@ export default class Popover extends Component {
     } = this.props
     const { isShown: stateIsShown } = this.state
 
-    const shown = isShown || stateIsShown
+    // If `isShown` is a boolean, popover is controlled manually, not via mouse events
+    const shown = typeof isShown === 'boolean' ? isShown : stateIsShown
 
     return (
       <Positioner

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -119,13 +119,6 @@ export default class Positioner extends PureComponent {
     this.state = initialState()
   }
 
-  componentDidMount() {
-    // If `isShown` is `true` on first render, <Transition> won't emit any enter/entered events
-    // because there was no transition from `false` to `true`
-    // In order to still display and position the content properly, `update()` must be fired after first render
-    this.update()
-  }
-
   componentWillUnmount() {
     if (this.latestAnimationFrame) {
       cancelAnimationFrame(this.latestAnimationFrame)
@@ -237,6 +230,7 @@ export default class Positioner extends PureComponent {
               {target({ getRef: this.getTargetRef, isShown })}
 
               <Transition
+                appear
                 in={isShown}
                 timeout={animationDuration}
                 onEnter={this.handleEnter}

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -119,6 +119,13 @@ export default class Positioner extends PureComponent {
     this.state = initialState()
   }
 
+  componentDidMount() {
+    // If `isShown` is `true` on first render, <Transition> won't emit any enter/entered events
+    // because there was no transition from `false` to `true`
+    // In order to still display and position the content properly, `update()` must be fired after first render
+    this.update()
+  }
+
   componentWillUnmount() {
     if (this.latestAnimationFrame) {
       cancelAnimationFrame(this.latestAnimationFrame)


### PR DESCRIPTION
Explicitly passing `isShown = true/false` didn't affect `<Popover>`'s behavior and didn't show/hide the popover correctly. This PR fixes it.