### PR TITLE
Proposal: DatePicker component [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@blueprintjs/icons": "^3.2.0",
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
+    "date-fns": "^1.29.0",
     "dom-helpers": "^3.2.1",
     "downshift": "^1.31.16",
     "fuzzaldrin-plus": "^0.6.0",

--- a/src/date-picker/index.js
+++ b/src/date-picker/index.js
@@ -1,0 +1,1 @@
+export { default as DatePicker } from './src/DatePicker'

--- a/src/date-picker/index.js
+++ b/src/date-picker/index.js
@@ -1,1 +1,3 @@
+export { default as InlineDatePicker } from './src/InlineDatePicker'
+export { default as DateRangePicker } from './src/DateRangePicker'
 export { default as DatePicker } from './src/DatePicker'

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -54,7 +54,8 @@ function makeCalendarData(pivotDate) {
 
   const present = makeDaysArray(addDays(firstDay, -1), totalDays, {
     isCurrentMonth: true,
-    isToday: date => isSameDay(date, today)
+    isToday: date => isSameDay(date, today),
+    isSelected: date => isSameDay(date, pivotDate)
   })
 
   // Complement days from previous month
@@ -142,7 +143,7 @@ function Calendar({
         </DateBox>
       ))}
 
-      {dates.map(({ date, isCurrentMonth, isToday }) => (
+      {dates.map(({ date, isCurrentMonth, isToday, isSelected }) => (
         <ThemeConsumer key={date.toString()}>
           {theme => (
             <DateBox>
@@ -151,20 +152,22 @@ function Calendar({
                 display="block"
                 width="100%"
                 textAlign="center"
-                appearance="minimal"
+                appearance={isSelected ? 'primary' : 'minimal'}
                 position="relative"
                 onClick={() => onClick && onClick(date)}
                 color={
-                  isCurrentMonth
-                    ? theme.colors.text.dark
-                    : theme.scales.neutral.N5
+                  isSelected
+                    ? theme.scales.neutral.N1
+                    : isCurrentMonth
+                      ? theme.colors.text.dark
+                      : theme.scales.neutral.N5
                 }
               >
                 {dateFormatter.format(date)}
                 {isToday ? (
                   <Icon
                     icon="dot"
-                    color="info"
+                    color={isSelected ? theme.scales.neutral.N1 : 'info'}
                     position="absolute"
                     bottom={0}
                     right={0}

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -92,48 +92,6 @@ function DateBox({ children, ...props }) {
   )
 }
 
-function DateCell({ date, isCurrentMonth, isToday, onClick, formatter }) {
-  return (
-    <ThemeConsumer>
-      {theme => (
-        <DateBox>
-          <Button
-            padding={0}
-            display="block"
-            width="100%"
-            textAlign="center"
-            appearance="minimal"
-            position="relative"
-            onClick={() => onClick && onClick(date)}
-            color={
-              isCurrentMonth ? theme.colors.text.dark : theme.scales.neutral.N5
-            }
-          >
-            {formatter ? formatter.format(date) : date.getDay()}
-            {isToday ? (
-              <Icon
-                icon="dot"
-                color="info"
-                position="absolute"
-                bottom={0}
-                right={0}
-              />
-            ) : null}
-          </Button>
-        </DateBox>
-      )}
-    </ThemeConsumer>
-  )
-}
-
-DateCell.propTypes = {
-  date: PropTypes.instanceOf(Date).isRequired,
-  formatter: PropTypes.instanceOf(Intl.DateTimeFormat),
-  isCurrentMonth: PropTypes.bool,
-  isToday: PropTypes.bool,
-  onClick: PropTypes.func
-}
-
 function getWeekdayNames(dates, locale, { weekday }) {
   return dates.map(d => {
     const name = new Intl.DateTimeFormat(locale, { weekday }).format(d)
@@ -184,13 +142,38 @@ function Calendar({
         </DateBox>
       ))}
 
-      {dates.map(date => (
-        <DateCell
-          key={date.date.toString()}
-          {...date}
-          onClick={onClick}
-          formatter={dateFormatter}
-        />
+      {dates.map(({ date, isCurrentMonth, isToday }) => (
+        <ThemeConsumer key={date.toString()}>
+          {theme => (
+            <DateBox>
+              <Button
+                padding={0}
+                display="block"
+                width="100%"
+                textAlign="center"
+                appearance="minimal"
+                position="relative"
+                onClick={() => onClick && onClick(date)}
+                color={
+                  isCurrentMonth
+                    ? theme.colors.text.dark
+                    : theme.scales.neutral.N5
+                }
+              >
+                {dateFormatter.format(date)}
+                {isToday ? (
+                  <Icon
+                    icon="dot"
+                    color="info"
+                    position="absolute"
+                    bottom={0}
+                    right={0}
+                  />
+                ) : null}
+              </Button>
+            </DateBox>
+          )}
+        </ThemeConsumer>
       ))}
     </Box>
   )

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -70,15 +70,24 @@ function makeCalendarData(pivotDate, disableDates) {
     }
   )
 
-  const future = makeDaysArray(
-    addDays(lastDay, -1),
-    dayOfLastDay === SUN ? 0 : SAT - dayOfLastDay + 1,
-    {
-      increment: 1,
-      isCurrentMonth: false,
-      isDisabled: disableDates
-    }
-  )
+  // Calculate how many dates in the future we need to add to calendar
+  // Always show 6 weeks to avoid UI jumping
+  const MAX_DAYS_SHOWN = 42
+
+  // TODO: Add prop to start calendar on Monday
+  const preliminaryFutureDays =
+    dayOfLastDay === SUN ? 0 : SAT - dayOfLastDay + 1
+
+  const actualFutureDays =
+    past.length + present.length + preliminaryFutureDays === MAX_DAYS_SHOWN
+      ? preliminaryFutureDays
+      : MAX_DAYS_SHOWN - present.length - past.length
+
+  const future = makeDaysArray(addDays(lastDay, -1), actualFutureDays, {
+    increment: 1,
+    isCurrentMonth: false,
+    isDisabled: disableDates
+  })
 
   return [...past, ...present, ...future]
 }

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
+
 import getDaysInMonth from 'date-fns/get_days_in_month'
 import startOfMonth from 'date-fns/start_of_month'
 import addDays from 'date-fns/add_days'
 import getDay from 'date-fns/get_day'
+
 import { majorScale } from '../../scales'
 import { Text } from '../../typography'
 import { ThemeConsumer } from '../../theme'
+import { Button } from '../../buttons'
 
 export const SUN = 0
 export const MON = 1
@@ -65,16 +68,15 @@ function makeCalendarData(pivotDate) {
   return [...first, ...data, ...last]
 }
 
-function DateBox(props) {
+function DateBox({ children, ...props }) {
   return (
     <Box
       width={`${100 / 7}%`}
       height={majorScale(4)}
       textAlign="center"
-      cursor={props.onClick ? 'pointer' : 'default'}
       {...props}
     >
-      {props.children}
+      {children}
     </Box>
   )
 }
@@ -84,14 +86,15 @@ function DateCell({ date, currentMonth }) {
     <ThemeConsumer>
       {theme => (
         <DateBox onClick={() => console.log(date)}>
-          <Text
+          <Button
+            appearance="minimal"
             userSelect="none"
             color={
               currentMonth ? theme.colors.text.dark : theme.scales.neutral.N5
             }
           >
             {date.getDate()}
-          </Text>
+          </Button>
         </DateBox>
       )}
     </ThemeConsumer>

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -91,17 +91,18 @@ function DateBox({ children, ...props }) {
   )
 }
 
-function DateCell({ date, isCurrentMonth, isToday }) {
+function DateCell({ date, isCurrentMonth, isToday, onClick }) {
   return (
     <ThemeConsumer>
       {theme => (
-        <DateBox onClick={() => console.log(date)}>
+        <DateBox>
           <Button
             appearance="minimal"
+            position="relative"
+            onClick={() => onClick && onClick(date)}
             color={
               isCurrentMonth ? theme.colors.text.dark : theme.scales.neutral.N5
             }
-            position="relative"
           >
             {date.getDate()}
             {isToday ? (
@@ -121,13 +122,14 @@ function DateCell({ date, isCurrentMonth, isToday }) {
 }
 
 DateCell.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
   isCurrentMonth: PropTypes.bool,
   isToday: PropTypes.bool,
-  date: PropTypes.instanceOf(Date).isRequired
+  onClick: PropTypes.func
 }
 
-export default function Month({ now, ...rest }) {
-  const dates = makeCalendarData(now)
+function Calendar({ pivotDate, onClick, ...rest }) {
+  const dates = makeCalendarData(pivotDate)
   return (
     <Box
       display="flex"
@@ -158,8 +160,15 @@ export default function Month({ now, ...rest }) {
         <Text fontWeight={600}>Sat</Text>
       </DateBox>
       {dates.map(date => (
-        <DateCell key={date.date.toString()} {...date} />
+        <DateCell key={date.date.toString()} {...date} onClick={onClick} />
       ))}
     </Box>
   )
 }
+
+Calendar.propTypes = {
+  pivotDate: PropTypes.instanceOf(Date).isRequired,
+  onClick: PropTypes.func
+}
+
+export default Calendar

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -44,7 +44,7 @@ function makeDaysArray(pivot, length, { increment = 1, ...rest } = {}) {
   ).acc
 }
 
-function makeCalendarData(pivotDate, disableDates) {
+function makeCalendarData(pivotDate, selectedDate, disableDates) {
   const today = new Date()
   const totalDays = getDaysInMonth(pivotDate)
   const firstDay = startOfMonth(pivotDate)
@@ -55,7 +55,7 @@ function makeCalendarData(pivotDate, disableDates) {
   const present = makeDaysArray(addDays(firstDay, -1), totalDays, {
     isCurrentMonth: true,
     isToday: date => isSameDay(date, today),
-    isSelected: date => isSameDay(date, pivotDate),
+    isSelected: date => isSameDay(date, selectedDate),
     isDisabled: disableDates
   })
 
@@ -66,6 +66,7 @@ function makeCalendarData(pivotDate, disableDates) {
     {
       increment: -1,
       isCurrentMonth: false,
+      isSelected: date => isSameDay(date, selectedDate),
       isDisabled: disableDates
     }
   )
@@ -86,6 +87,7 @@ function makeCalendarData(pivotDate, disableDates) {
   const future = makeDaysArray(addDays(lastDay, -1), actualFutureDays, {
     increment: 1,
     isCurrentMonth: false,
+    isSelected: date => isSameDay(date, selectedDate),
     isDisabled: disableDates
   })
 
@@ -127,13 +129,14 @@ const DEFAULT = {
 
 function Calendar({
   pivotDate,
+  selectedDate,
   onClick,
   locale = DEFAULT.locale,
   localeOptions = DEFAULT.localeOptions,
   disableDates,
   ...rest
 }) {
-  const dates = makeCalendarData(pivotDate, disableDates)
+  const dates = makeCalendarData(pivotDate, selectedDate, disableDates)
   const weekdays = getWeekdayNames(
     dates.slice(0, 7).map(({ date }) => date),
     locale,
@@ -201,6 +204,7 @@ function Calendar({
 
 Calendar.propTypes = {
   pivotDate: PropTypes.instanceOf(Date).isRequired,
+  selectedDate: PropTypes.instanceOf(Date),
   onClick: PropTypes.func,
   locale: PropTypes.string,
   localeOptions: PropTypes.object,

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -44,7 +44,7 @@ function makeDaysArray(pivot, length, { increment = 1, ...rest } = {}) {
   ).acc
 }
 
-function makeCalendarData(pivotDate) {
+function makeCalendarData(pivotDate, disableDates) {
   const today = new Date()
   const totalDays = getDaysInMonth(pivotDate)
   const firstDay = startOfMonth(pivotDate)
@@ -55,7 +55,8 @@ function makeCalendarData(pivotDate) {
   const present = makeDaysArray(addDays(firstDay, -1), totalDays, {
     isCurrentMonth: true,
     isToday: date => isSameDay(date, today),
-    isSelected: date => isSameDay(date, pivotDate)
+    isSelected: date => isSameDay(date, pivotDate),
+    isDisabled: disableDates
   })
 
   // Complement days from previous month
@@ -64,15 +65,18 @@ function makeCalendarData(pivotDate) {
     dayOfFirstDay === SUN ? 0 : dayOfFirstDay,
     {
       increment: -1,
-      isCurrentMonth: false
+      isCurrentMonth: false,
+      isDisabled: disableDates
     }
   )
+
   const future = makeDaysArray(
     addDays(lastDay, -1),
     dayOfLastDay === SUN ? 0 : SAT - dayOfLastDay + 1,
     {
       increment: 1,
-      isCurrentMonth: false
+      isCurrentMonth: false,
+      isDisabled: disableDates
     }
   )
 
@@ -117,9 +121,10 @@ function Calendar({
   onClick,
   locale = DEFAULT.locale,
   localeOptions = DEFAULT.localeOptions,
+  disableDates,
   ...rest
 }) {
-  const dates = makeCalendarData(pivotDate)
+  const dates = makeCalendarData(pivotDate, disableDates)
   const weekdays = getWeekdayNames(
     dates.slice(0, 7).map(({ date }) => date),
     locale,
@@ -143,41 +148,44 @@ function Calendar({
         </DateBox>
       ))}
 
-      {dates.map(({ date, isCurrentMonth, isToday, isSelected }) => (
-        <ThemeConsumer key={date.toString()}>
-          {theme => (
-            <DateBox>
-              <Button
-                padding={0}
-                display="block"
-                width="100%"
-                textAlign="center"
-                appearance={isSelected ? 'primary' : 'minimal'}
-                position="relative"
-                onClick={() => onClick && onClick(date)}
-                color={
-                  isSelected
-                    ? theme.scales.neutral.N1
-                    : isCurrentMonth
-                      ? theme.colors.text.dark
-                      : theme.scales.neutral.N5
-                }
-              >
-                {dateFormatter.format(date)}
-                {isToday ? (
-                  <Icon
-                    icon="dot"
-                    color={isSelected ? theme.scales.neutral.N1 : 'info'}
-                    position="absolute"
-                    bottom={0}
-                    right={0}
-                  />
-                ) : null}
-              </Button>
-            </DateBox>
-          )}
-        </ThemeConsumer>
-      ))}
+      {dates.map(
+        ({ date, isCurrentMonth, isToday, isSelected, isDisabled }) => (
+          <ThemeConsumer key={date.toString()}>
+            {theme => (
+              <DateBox>
+                <Button
+                  padding={0}
+                  display="block"
+                  width="100%"
+                  textAlign="center"
+                  appearance={isSelected ? 'primary' : 'minimal'}
+                  position="relative"
+                  onClick={() => onClick && onClick(date)}
+                  disabled={isDisabled}
+                  color={
+                    isSelected
+                      ? theme.scales.neutral.N1
+                      : isCurrentMonth
+                        ? theme.colors.text.dark
+                        : theme.scales.neutral.N6
+                  }
+                >
+                  {dateFormatter.format(date)}
+                  {isToday ? (
+                    <Icon
+                      icon="dot"
+                      color={isSelected ? theme.scales.neutral.N1 : 'info'}
+                      position="absolute"
+                      bottom={0}
+                      right={0}
+                    />
+                  ) : null}
+                </Button>
+              </DateBox>
+            )}
+          </ThemeConsumer>
+        )
+      )}
     </Box>
   )
 }
@@ -186,7 +194,8 @@ Calendar.propTypes = {
   pivotDate: PropTypes.instanceOf(Date).isRequired,
   onClick: PropTypes.func,
   locale: PropTypes.string,
-  localeOptions: PropTypes.object
+  localeOptions: PropTypes.object,
+  disableDates: PropTypes.func
 }
 
 export default Calendar

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -1,0 +1,142 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+import getDaysInMonth from 'date-fns/get_days_in_month'
+import startOfMonth from 'date-fns/start_of_month'
+import addDays from 'date-fns/add_days'
+import getDay from 'date-fns/get_day'
+import { majorScale } from '../../scales'
+import { Text } from '../../typography'
+import { ThemeConsumer } from '../../theme'
+
+export const SUN = 0
+export const MON = 1
+export const TUE = 2
+export const WED = 3
+export const THU = 4
+export const FRI = 5
+export const SAT = 6
+
+function makeDaysArray(pivot, length, { increment = 1, ...props } = {}) {
+  return Array.from({ length }).reduce(
+    ({ acc, pivot }) => {
+      const date = addDays(pivot, increment)
+      return {
+        acc:
+          increment > 0
+            ? [...acc, { date, ...props }]
+            : [{ date, ...props }, ...acc],
+        pivot: date
+      }
+    },
+    { acc: [], pivot }
+  ).acc
+}
+
+function makeCalendarData(pivotDate) {
+  const totalDays = getDaysInMonth(pivotDate)
+  const firstDay = startOfMonth(pivotDate)
+  const lastDay = addDays(firstDay, totalDays)
+  const dayOfFirstDay = getDay(firstDay)
+  const dayOfLastDay = getDay(lastDay)
+
+  const data = makeDaysArray(addDays(firstDay, -1), totalDays, {
+    currentMonth: true
+  })
+
+  // Complement days from previous month
+  const first = makeDaysArray(
+    firstDay,
+    dayOfFirstDay === SUN ? 0 : dayOfFirstDay,
+    {
+      increment: -1,
+      currentMonth: false
+    }
+  )
+  const last = makeDaysArray(
+    addDays(lastDay, -1),
+    dayOfLastDay === SUN ? 0 : SAT - dayOfLastDay + 1,
+    {
+      increment: 1,
+      currentMonth: false
+    }
+  )
+
+  return [...first, ...data, ...last]
+}
+
+function DateBox(props) {
+  return (
+    <Box
+      width={`${100 / 7}%`}
+      height={majorScale(4)}
+      textAlign="center"
+      cursor={props.onClick ? 'pointer' : 'default'}
+      {...props}
+    >
+      {props.children}
+    </Box>
+  )
+}
+
+function DateCell({ date, currentMonth }) {
+  return (
+    <ThemeConsumer>
+      {theme => (
+        <DateBox onClick={() => console.log(date)}>
+          <Text
+            userSelect="none"
+            color={
+              currentMonth ? theme.colors.text.dark : theme.scales.neutral.N5
+            }
+          >
+            {date.getDate()}
+          </Text>
+        </DateBox>
+      )}
+    </ThemeConsumer>
+  )
+}
+
+DateCell.propTypes = {
+  currentMonth: PropTypes.bool,
+  date: PropTypes.instanceOf(Date).isRequired
+}
+
+export default function Month({ now, ...rest }) {
+  const dates = makeCalendarData(now)
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      flexWrap="wrap"
+      paddingTop={majorScale(2)}
+      {...rest}
+    >
+      <DateBox>
+        <Text fontWeight={600}>Sun</Text>
+      </DateBox>
+      <DateBox>
+        <Text fontWeight={600}>Mon</Text>
+      </DateBox>
+      <DateBox>
+        <Text fontWeight={600}>Tue</Text>
+      </DateBox>
+      <DateBox>
+        <Text fontWeight={600}>Wed</Text>
+      </DateBox>
+      <DateBox>
+        <Text fontWeight={600}>Thu</Text>
+      </DateBox>
+      <DateBox>
+        <Text fontWeight={600}>Fri</Text>
+      </DateBox>
+      <DateBox>
+        <Text fontWeight={600}>Sat</Text>
+      </DateBox>
+      {dates.map(date => (
+        <DateCell key={date.date.toString()} {...date} />
+      ))}
+    </Box>
+  )
+}

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -128,8 +128,17 @@ DateCell.propTypes = {
   onClick: PropTypes.func
 }
 
-function Calendar({ pivotDate, onClick, ...rest }) {
+function getWeekdayNames(dates, locale, { weekday }) {
+  return dates.map(d => new Intl.DateTimeFormat(locale, { weekday }).format(d))
+}
+
+function Calendar({ pivotDate, onClick, locale, localeOptions, ...rest }) {
   const dates = makeCalendarData(pivotDate)
+  const weekdays = getWeekdayNames(
+    dates.slice(0, 7).map(({ date }) => date),
+    locale,
+    localeOptions
+  )
   return (
     <Box
       display="flex"
@@ -138,27 +147,12 @@ function Calendar({ pivotDate, onClick, ...rest }) {
       paddingTop={majorScale(2)}
       {...rest}
     >
-      <DateBox>
-        <Text fontWeight={600}>Sun</Text>
-      </DateBox>
-      <DateBox>
-        <Text fontWeight={600}>Mon</Text>
-      </DateBox>
-      <DateBox>
-        <Text fontWeight={600}>Tue</Text>
-      </DateBox>
-      <DateBox>
-        <Text fontWeight={600}>Wed</Text>
-      </DateBox>
-      <DateBox>
-        <Text fontWeight={600}>Thu</Text>
-      </DateBox>
-      <DateBox>
-        <Text fontWeight={600}>Fri</Text>
-      </DateBox>
-      <DateBox>
-        <Text fontWeight={600}>Sat</Text>
-      </DateBox>
+      {weekdays.map(name => (
+        <DateBox key={name}>
+          <Text fontWeight={600}>{name}</Text>
+        </DateBox>
+      ))}
+
       {dates.map(date => (
         <DateCell key={date.date.toString()} {...date} onClick={onClick} />
       ))}

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -129,7 +129,12 @@ DateCell.propTypes = {
 }
 
 function getWeekdayNames(dates, locale, { weekday }) {
-  return dates.map(d => new Intl.DateTimeFormat(locale, { weekday }).format(d))
+  return dates.map(d => {
+    const name = new Intl.DateTimeFormat(locale, { weekday }).format(d)
+    // Some locales may have the same weekday name in narrow format
+    // e.g. T(iistai) and T(orstai) in Finnish
+    return { name, key: name + d }
+  })
 }
 
 function Calendar({ pivotDate, onClick, locale, localeOptions, ...rest }) {
@@ -147,8 +152,8 @@ function Calendar({ pivotDate, onClick, locale, localeOptions, ...rest }) {
       paddingTop={majorScale(2)}
       {...rest}
     >
-      {weekdays.map(name => (
-        <DateBox key={name}>
+      {weekdays.map(({ name, key }) => (
+        <DateBox key={key}>
           <Text fontWeight={600}>{name}</Text>
         </DateBox>
       ))}

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -81,6 +81,7 @@ function makeCalendarData(pivotDate) {
 function DateBox({ children, ...props }) {
   return (
     <Box
+      userSelect="none"
       width={`${100 / 7}%`}
       height={majorScale(4)}
       textAlign="center"
@@ -91,12 +92,16 @@ function DateBox({ children, ...props }) {
   )
 }
 
-function DateCell({ date, isCurrentMonth, isToday, onClick }) {
+function DateCell({ date, isCurrentMonth, isToday, onClick, formatter }) {
   return (
     <ThemeConsumer>
       {theme => (
         <DateBox>
           <Button
+            padding={0}
+            display="block"
+            width="100%"
+            textAlign="center"
             appearance="minimal"
             position="relative"
             onClick={() => onClick && onClick(date)}
@@ -104,7 +109,7 @@ function DateCell({ date, isCurrentMonth, isToday, onClick }) {
               isCurrentMonth ? theme.colors.text.dark : theme.scales.neutral.N5
             }
           >
-            {date.getDate()}
+            {formatter ? formatter.format(date) : date.getDay()}
             {isToday ? (
               <Icon
                 icon="dot"
@@ -123,6 +128,7 @@ function DateCell({ date, isCurrentMonth, isToday, onClick }) {
 
 DateCell.propTypes = {
   date: PropTypes.instanceOf(Date).isRequired,
+  formatter: PropTypes.instanceOf(Intl.DateTimeFormat),
   isCurrentMonth: PropTypes.bool,
   isToday: PropTypes.bool,
   onClick: PropTypes.func
@@ -137,13 +143,33 @@ function getWeekdayNames(dates, locale, { weekday }) {
   })
 }
 
-function Calendar({ pivotDate, onClick, locale, localeOptions, ...rest }) {
+const DEFAULT = {
+  locale: 'en-US',
+  localeOptions: {
+    weekday: 'short',
+    month: 'long',
+    year: 'numeric',
+    day: 'numeric'
+  }
+}
+
+function Calendar({
+  pivotDate,
+  onClick,
+  locale = DEFAULT.locale,
+  localeOptions = DEFAULT.localeOptions,
+  ...rest
+}) {
   const dates = makeCalendarData(pivotDate)
   const weekdays = getWeekdayNames(
     dates.slice(0, 7).map(({ date }) => date),
     locale,
     localeOptions
   )
+  const dateFormatter = new Intl.DateTimeFormat(locale, {
+    day: localeOptions.day || DEFAULT.localeOptions.day
+  })
+
   return (
     <Box
       display="flex"
@@ -159,7 +185,12 @@ function Calendar({ pivotDate, onClick, locale, localeOptions, ...rest }) {
       ))}
 
       {dates.map(date => (
-        <DateCell key={date.date.toString()} {...date} onClick={onClick} />
+        <DateCell
+          key={date.date.toString()}
+          {...date}
+          onClick={onClick}
+          formatter={dateFormatter}
+        />
       ))}
     </Box>
   )
@@ -167,7 +198,9 @@ function Calendar({ pivotDate, onClick, locale, localeOptions, ...rest }) {
 
 Calendar.propTypes = {
   pivotDate: PropTypes.instanceOf(Date).isRequired,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  locale: PropTypes.string,
+  localeOptions: PropTypes.object
 }
 
 export default Calendar

--- a/src/date-picker/src/Calendar.js
+++ b/src/date-picker/src/Calendar.js
@@ -2,25 +2,20 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 
-import getDaysInMonth from 'date-fns/get_days_in_month'
-import startOfMonth from 'date-fns/start_of_month'
 import addDays from 'date-fns/add_days'
 import getDay from 'date-fns/get_day'
+import getDaysInMonth from 'date-fns/get_days_in_month'
 import isSameDay from 'date-fns/is_same_day'
+import startOfMonth from 'date-fns/start_of_month'
 
 import { majorScale } from '../../scales'
-import { Text } from '../../typography'
-import { ThemeConsumer } from '../../theme'
 import { Button } from '../../buttons'
 import { Icon } from '../../icon'
+import { Text } from '../../typography'
+import { ThemeConsumer } from '../../theme'
 
-export const SUN = 0
-export const MON = 1
-export const TUE = 2
-export const WED = 3
-export const THU = 4
-export const FRI = 5
-export const SAT = 6
+const SUN = 0
+const SAT = 6
 
 function makeDaysArray(pivot, length, { increment = 1, ...rest } = {}) {
   return Array.from({ length }).reduce(
@@ -94,20 +89,6 @@ function makeCalendarData(pivotDate, selectedDate, disableDates) {
   return [...past, ...present, ...future]
 }
 
-function DateBox({ children, ...props }) {
-  return (
-    <Box
-      userSelect="none"
-      width={`${100 / 7}%`}
-      height={majorScale(4)}
-      textAlign="center"
-      {...props}
-    >
-      {children}
-    </Box>
-  )
-}
-
 function getWeekdayNames(dates, locale, { weekday }) {
   return dates.map(d => {
     const name = new Intl.DateTimeFormat(locale, { weekday }).format(d)
@@ -125,6 +106,20 @@ const DEFAULT = {
     year: 'numeric',
     day: 'numeric'
   }
+}
+
+function DateBox({ children, ...props }) {
+  return (
+    <Box
+      userSelect="none"
+      width={`${100 / 7}%`}
+      height={majorScale(4)}
+      textAlign="center"
+      {...props}
+    >
+      {children}
+    </Box>
+  )
 }
 
 function Calendar({

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -54,7 +54,10 @@ export default class DatePicker extends PureComponent {
     todayButtonLabel: 'Today',
     locale: 'en-US',
     localeOptions: {
-      weekday: 'short'
+      weekday: 'short',
+      month: 'long',
+      year: 'numeric',
+      day: 'numeric'
     }
   }
 
@@ -68,8 +71,12 @@ export default class DatePicker extends PureComponent {
 
   getCurrentMonthTitle = () =>
     new Intl.DateTimeFormat(this.props.locale, {
-      month: 'long',
-      year: 'numeric'
+      month:
+        this.props.localeOptions.month ||
+        DatePicker.defaultProps.localeOptions.month,
+      year:
+        this.props.localeOptions.year ||
+        DatePicker.defaultProps.localeOptions.year
     }).format(this.state.value)
 
   doGoToNextMonth = () => this.changeDate(addMonths(this.state.value, 1))
@@ -110,7 +117,9 @@ export default class DatePicker extends PureComponent {
             appearance="minimal"
             onClick={this.doGoToPrevMonth}
           />
-          <Text marginX="auto">{this.getCurrentMonthTitle()}</Text>
+          <Text marginX="auto" userSelect="none">
+            {this.getCurrentMonthTitle()}
+          </Text>
           <IconButton
             icon="chevron-right"
             appearance="minimal"

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -1,0 +1,100 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+import addMonths from 'date-fns/add_months'
+import addYears from 'date-fns/add_years'
+import format from 'date-fns/format'
+
+import { Popover } from '../../popover'
+import { TextInput } from '../../text-input'
+import { Text } from '../../typography'
+import { IconButton } from '../../buttons'
+import { majorScale } from '../../scales'
+
+import Calendar from './Calendar'
+
+class DatePickerPopover extends PureComponent {
+  static propTypes = {
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date)
+    ]).isRequired
+  }
+
+  static defaultProps = {
+    width: 280
+  }
+
+  state = { value: this.props.value }
+
+  changeCurrentDate = (fn, increment) => () =>
+    this.setState(prevState => ({ value: fn(prevState.value, increment) }))
+
+  doGoToNextMonth = this.changeCurrentDate(addMonths, 1)
+
+  doGoToPrevMonth = this.changeCurrentDate(addMonths, -1)
+
+  doGoToNextYear = this.changeCurrentDate(addYears, 1)
+
+  doGoToPrevYear = this.changeCurrentDate(addYears, -1)
+
+  render() {
+    const { value, ...props } = this.props
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        padding={majorScale(1)}
+        {...props}
+      >
+        <Box display="flex" alignItems="center">
+          <IconButton
+            icon="double-chevron-left"
+            appearance="minimal"
+            onClick={this.doGoToPrevYear}
+          />
+          <IconButton
+            icon="chevron-left"
+            appearance="minimal"
+            onClick={this.doGoToPrevMonth}
+          />
+          <Text marginX="auto">{format(this.state.value, 'MMMM YYYY')}</Text>
+          <IconButton
+            icon="chevron-right"
+            appearance="minimal"
+            onClick={this.doGoToNextMonth}
+          />
+          <IconButton
+            icon="double-chevron-right"
+            appearance="minimal"
+            onClick={this.doGoToNextYear}
+          />
+        </Box>
+        <Calendar now={this.state.value} />
+      </Box>
+    )
+  }
+}
+
+export default class DatePicker extends PureComponent {
+  static propTypes = {
+    value: PropTypes.oneOfType([
+      PropTypes.string, // A formatted string
+      PropTypes.number, // A timestamp
+      PropTypes.instanceOf(Date) // Or a Date object
+    ]).isRequired,
+    textInputProps: PropTypes.object,
+    dateFormat: PropTypes.string
+  }
+
+  render() {
+    const { value, textInputProps, ...rest } = this.props
+
+    return (
+      <Popover content={<DatePickerPopover value={value} />} {...rest}>
+        <TextInput placeholder="Pick a date" {...textInputProps} />
+      </Popover>
+    )
+  }
+}

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -22,9 +22,14 @@ export default class DatePicker extends PureComponent {
     ]).isRequired,
 
     /**
-     * Should if a button to quickly jump to today is shown
+     * Should if a button to quickly jump to the current date is shown
      */
     shouldShowTodayButton: PropTypes.bool,
+
+    /**
+     * Label of button to jump to the current date
+     */
+    todayButtonLabel: PropTypes.string,
 
     /**
      * The locale used to format date time in calendar
@@ -46,6 +51,7 @@ export default class DatePicker extends PureComponent {
   static defaultProps = {
     width: 280,
     shouldShowTodayButton: true,
+    todayButtonLabel: 'Today',
     locale: 'en-US',
     localeOptions: {
       weekday: 'short'
@@ -80,10 +86,12 @@ export default class DatePicker extends PureComponent {
     const {
       value,
       shouldShowTodayButton,
+      todayButtonLabel,
       locale,
       localeOptions,
       ...props
     } = this.props
+
     return (
       <Box
         display="flex"
@@ -126,7 +134,7 @@ export default class DatePicker extends PureComponent {
             justifyContent="center"
             onClick={this.doJumpToToday}
           >
-            Today
+            {todayButtonLabel}
           </Button>
         ) : null}
       </Box>

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -76,7 +76,6 @@ class DatePickerPopover extends PureComponent {
     )
   }
 }
-
 export default class DatePicker extends PureComponent {
   static propTypes = {
     value: PropTypes.oneOfType([

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
+
 import addMonths from 'date-fns/add_months'
 import addYears from 'date-fns/add_years'
 
 import { Text } from '../../typography'
-import { IconButton, Button } from '../../buttons'
+import { Button, IconButton } from '../../buttons'
 import { majorScale } from '../../scales'
 
 import Calendar from './Calendar'
@@ -13,7 +14,7 @@ import Calendar from './Calendar'
 export default class DatePicker extends PureComponent {
   static propTypes = {
     /**
-     * The date presentation of calendar
+     * The current selected date on calendar
      */
     value: PropTypes.oneOfType([
       PropTypes.string,
@@ -22,22 +23,22 @@ export default class DatePicker extends PureComponent {
     ]).isRequired,
 
     /**
-     * Should if a button to quickly jump to the current date is shown
+     * Should a button to quickly jump to the current date is shown
      */
     shouldShowTodayButton: PropTypes.bool,
 
     /**
-     * Label of button to jump to the current date
+     * Label of ShowToday button
      */
     todayButtonLabel: PropTypes.string,
 
     /**
-     * The locale used to format date time in calendar
+     * The locale used to format date in calendar
      */
     locale: PropTypes.string,
 
     /**
-     * Options used to format date time
+     * Options used to format
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
      */
     localeOptions: PropTypes.object,

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -5,29 +5,56 @@ import addMonths from 'date-fns/add_months'
 import addYears from 'date-fns/add_years'
 import format from 'date-fns/format'
 
-import { Popover } from '../../popover'
-import { TextInput } from '../../text-input'
 import { Text } from '../../typography'
 import { IconButton, Button } from '../../buttons'
 import { majorScale } from '../../scales'
 
 import Calendar from './Calendar'
 
-class DatePickerPopover extends PureComponent {
+export default class DatePicker extends PureComponent {
+  static propTypes = {
+    /**
+     * The date presentation of calendar
+     */
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date)
+    ]).isRequired,
+
+    /**
+     * Should if a button to quickly jump to today is shown
+     */
+    shouldShowTodayButton: PropTypes.bool,
+
+    /**
+     * Callback function to be invokved when users select a date
+     */
+    onChange: PropTypes.func
+  }
+
+  static defaultProps = {
+    width: 280,
+    shouldShowTodayButton: true
+  }
+
   state = { value: this.props.value }
 
-  changeCurrentDate = (fn, increment) => () =>
-    this.setState(prevState => ({ value: fn(prevState.value, increment) }))
+  changeDate = value =>
+    this.setState(
+      { value },
+      () => this.props.onChange && this.props.onChange(value)
+    )
 
-  doGoToNextMonth = this.changeCurrentDate(addMonths, 1)
+  doGoToNextMonth = () => this.changeDate(addMonths(this.state.value, 1))
 
-  doGoToPrevMonth = this.changeCurrentDate(addMonths, -1)
+  doGoToPrevMonth = () => this.changeDate(addMonths(this.state.value, -1))
 
-  doGoToNextYear = this.changeCurrentDate(addYears, 1)
+  doGoToNextYear = () => this.changeDate(addYears(this.state.value, 1))
 
-  doGoToPrevYear = this.changeCurrentDate(addYears, -1)
+  doGoToPrevYear = () => this.changeDate(addYears(this.state.value, -1))
 
-  doJumpToToday = () => this.setState({ value: new Date() })
+  doJumpToToday = () => this.changeDate(new Date())
 
   render() {
     const { value, shouldShowTodayButton, ...props } = this.props
@@ -61,7 +88,7 @@ class DatePickerPopover extends PureComponent {
             onClick={this.doGoToNextYear}
           />
         </Box>
-        <Calendar now={this.state.value} />
+        <Calendar pivotDate={this.state.value} onClick={this.changeDate} />
         {shouldShowTodayButton ? (
           <Button
             appearance="minimal"
@@ -72,43 +99,6 @@ class DatePickerPopover extends PureComponent {
           </Button>
         ) : null}
       </Box>
-    )
-  }
-}
-export default class DatePicker extends PureComponent {
-  static propTypes = {
-    /**
-     * The date presentation of calendar
-     */
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date)
-    ]).isRequired,
-
-    /**
-     * Should if a button to quickly jump to today is shown
-     */
-    shouldShowTodayButton: PropTypes.bool,
-
-    /**
-     * Props that are passed to text input field
-     */
-    textInputProps: PropTypes.object
-  }
-
-  static defaultProps = {
-    width: 280,
-    shouldShowTodayButton: true
-  }
-
-  render() {
-    const { textInputProps, ...rest } = this.props
-
-    return (
-      <Popover content={<DatePickerPopover {...rest} />}>
-        <TextInput placeholder="Pick a date" {...textInputProps} />
-      </Popover>
     )
   }
 }

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -43,6 +43,11 @@ export default class DatePicker extends PureComponent {
     localeOptions: PropTypes.object,
 
     /**
+     * Validation function to determine if a date is disabled
+     */
+    disableDates: PropTypes.func,
+
+    /**
      * Callback function to be invokved when users select a date
      */
     onChange: PropTypes.func
@@ -96,6 +101,7 @@ export default class DatePicker extends PureComponent {
       todayButtonLabel,
       locale,
       localeOptions,
+      disableDates,
       ...props
     } = this.props
 
@@ -136,6 +142,7 @@ export default class DatePicker extends PureComponent {
           onClick={this.changeDate}
           locale={locale}
           localeOptions={localeOptions}
+          disableDates={disableDates}
         />
         {shouldShowTodayButton ? (
           <Button

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -1,100 +1,18 @@
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
-import Box from 'ui-box'
+import React from 'react'
 
-import addMonths from 'date-fns/add_months'
-import addYears from 'date-fns/add_years'
+import { Popover } from '../../popover'
+import { TextInput } from '../../text-input'
+import InlineDatePicker from './InlineDatePicker'
+import defaultPropTypes from './propTypes'
 
-import { Text } from '../../typography'
-import { Button, IconButton } from '../../buttons'
-import { majorScale } from '../../scales'
+function defaultDateFormatter(date) {
+  return date instanceof Date ? date.toLocaleDateString() : date
+}
 
-import Calendar from './Calendar'
-
-export default class DatePicker extends PureComponent {
+export default class DatePicker extends React.Component {
   static propTypes = {
-    /**
-     * The current selected date on calendar
-     */
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date)
-    ]).isRequired,
-
-    /**
-     * Should a button to quickly jump to the current date is shown
-     */
-    shouldShowTodayButton: PropTypes.bool,
-
-    /**
-     * Label of ShowToday button
-     */
-    todayButtonLabel: PropTypes.string,
-
-    /**
-     * The locale used to format date in calendar
-     */
-    locale: PropTypes.string,
-
-    /**
-     * Options used to format
-     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
-     */
-    localeOptions: PropTypes.object,
-
-    /**
-     * Validation function to determine if a date is disabled
-     */
-    disableDates: PropTypes.func,
-
-    /**
-     * Callback function to be invokved when users select a date
-     */
-    onChange: PropTypes.func
+    ...defaultPropTypes
   }
-
-  static defaultProps = {
-    width: 280,
-    shouldShowTodayButton: true,
-    todayButtonLabel: 'Today',
-    locale: 'en-US',
-    localeOptions: {
-      weekday: 'short',
-      month: 'long',
-      year: 'numeric',
-      day: 'numeric'
-    }
-  }
-
-  state = { pivotDate: this.props.value }
-
-  changePivotDate = pivotDate => this.setState({ pivotDate })
-
-  getCurrentMonthTitle = () =>
-    new Intl.DateTimeFormat(this.props.locale, {
-      month:
-        this.props.localeOptions.month ||
-        DatePicker.defaultProps.localeOptions.month,
-      year:
-        this.props.localeOptions.year ||
-        DatePicker.defaultProps.localeOptions.year
-    }).format(this.state.pivotDate)
-
-  doGoToNextMonth = () =>
-    this.changePivotDate(addMonths(this.state.pivotDate, 1))
-
-  doGoToPrevMonth = () =>
-    this.changePivotDate(addMonths(this.state.pivotDate, -1))
-
-  doGoToNextYear = () => this.changePivotDate(addYears(this.state.pivotDate, 1))
-
-  doGoToPrevYear = () =>
-    this.changePivotDate(addYears(this.state.pivotDate, -1))
-
-  doJumpToToday = () => this.changePivotDate(new Date())
-
-  doCalendarClick = date => this.props.onChange && this.props.onChange(date)
 
   render() {
     const {
@@ -104,59 +22,27 @@ export default class DatePicker extends PureComponent {
       locale,
       localeOptions,
       disableDates,
+      onChange,
+      dateFormatter = defaultDateFormatter,
       ...props
     } = this.props
 
     return (
-      <Box
-        display="flex"
-        flexDirection="column"
-        padding={majorScale(1)}
-        {...props}
+      <Popover
+        content={
+          <InlineDatePicker
+            value={value}
+            shouldShowTodayButton={shouldShowTodayButton}
+            todayButtonLabel={todayButtonLabel}
+            locale={locale}
+            localeOptions={localeOptions}
+            disableDates={disableDates}
+            onChange={onChange}
+          />
+        }
       >
-        <Box display="flex" alignItems="center">
-          <IconButton
-            icon="double-chevron-left"
-            appearance="minimal"
-            onClick={this.doGoToPrevYear}
-          />
-          <IconButton
-            icon="chevron-left"
-            appearance="minimal"
-            onClick={this.doGoToPrevMonth}
-          />
-          <Text marginX="auto" userSelect="none">
-            {this.getCurrentMonthTitle()}
-          </Text>
-          <IconButton
-            icon="chevron-right"
-            appearance="minimal"
-            onClick={this.doGoToNextMonth}
-          />
-          <IconButton
-            icon="double-chevron-right"
-            appearance="minimal"
-            onClick={this.doGoToNextYear}
-          />
-        </Box>
-        <Calendar
-          pivotDate={this.state.pivotDate}
-          selectedDate={this.props.value}
-          onClick={this.doCalendarClick}
-          locale={locale}
-          localeOptions={localeOptions}
-          disableDates={disableDates}
-        />
-        {shouldShowTodayButton ? (
-          <Button
-            appearance="minimal"
-            justifyContent="center"
-            onClick={this.doJumpToToday}
-          >
-            {todayButtonLabel}
-          </Button>
-        ) : null}
-      </Box>
+        <TextInput value={dateFormatter(value)} {...props} />
+      </Popover>
     )
   }
 }

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import addMonths from 'date-fns/add_months'
 import addYears from 'date-fns/add_years'
-import format from 'date-fns/format'
 
 import { Text } from '../../typography'
 import { IconButton, Button } from '../../buttons'
@@ -28,6 +27,17 @@ export default class DatePicker extends PureComponent {
     shouldShowTodayButton: PropTypes.bool,
 
     /**
+     * The locale used to format date time in calendar
+     */
+    locale: PropTypes.string,
+
+    /**
+     * Options used to format date time
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+     */
+    localeOptions: PropTypes.object,
+
+    /**
      * Callback function to be invokved when users select a date
      */
     onChange: PropTypes.func
@@ -35,7 +45,11 @@ export default class DatePicker extends PureComponent {
 
   static defaultProps = {
     width: 280,
-    shouldShowTodayButton: true
+    shouldShowTodayButton: true,
+    locale: 'en-US',
+    localeOptions: {
+      weekday: 'short'
+    }
   }
 
   state = { value: this.props.value }
@@ -45,6 +59,12 @@ export default class DatePicker extends PureComponent {
       { value },
       () => this.props.onChange && this.props.onChange(value)
     )
+
+  getCurrentMonthTitle = () =>
+    new Intl.DateTimeFormat(this.props.locale, {
+      month: 'long',
+      year: 'numeric'
+    }).format(this.state.value)
 
   doGoToNextMonth = () => this.changeDate(addMonths(this.state.value, 1))
 
@@ -57,7 +77,13 @@ export default class DatePicker extends PureComponent {
   doJumpToToday = () => this.changeDate(new Date())
 
   render() {
-    const { value, shouldShowTodayButton, ...props } = this.props
+    const {
+      value,
+      shouldShowTodayButton,
+      locale,
+      localeOptions,
+      ...props
+    } = this.props
     return (
       <Box
         display="flex"
@@ -76,7 +102,7 @@ export default class DatePicker extends PureComponent {
             appearance="minimal"
             onClick={this.doGoToPrevMonth}
           />
-          <Text marginX="auto">{format(this.state.value, 'MMMM YYYY')}</Text>
+          <Text marginX="auto">{this.getCurrentMonthTitle()}</Text>
           <IconButton
             icon="chevron-right"
             appearance="minimal"
@@ -88,7 +114,12 @@ export default class DatePicker extends PureComponent {
             onClick={this.doGoToNextYear}
           />
         </Box>
-        <Calendar pivotDate={this.state.value} onClick={this.changeDate} />
+        <Calendar
+          pivotDate={this.state.value}
+          onClick={this.changeDate}
+          locale={locale}
+          localeOptions={localeOptions}
+        />
         {shouldShowTodayButton ? (
           <Button
             appearance="minimal"

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -8,24 +8,12 @@ import format from 'date-fns/format'
 import { Popover } from '../../popover'
 import { TextInput } from '../../text-input'
 import { Text } from '../../typography'
-import { IconButton } from '../../buttons'
+import { IconButton, Button } from '../../buttons'
 import { majorScale } from '../../scales'
 
 import Calendar from './Calendar'
 
 class DatePickerPopover extends PureComponent {
-  static propTypes = {
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date)
-    ]).isRequired
-  }
-
-  static defaultProps = {
-    width: 280
-  }
-
   state = { value: this.props.value }
 
   changeCurrentDate = (fn, increment) => () =>
@@ -39,8 +27,10 @@ class DatePickerPopover extends PureComponent {
 
   doGoToPrevYear = this.changeCurrentDate(addYears, -1)
 
+  doJumpToToday = () => this.setState({ value: new Date() })
+
   render() {
-    const { value, ...props } = this.props
+    const { value, shouldShowTodayButton, ...props } = this.props
     return (
       <Box
         display="flex"
@@ -72,26 +62,51 @@ class DatePickerPopover extends PureComponent {
           />
         </Box>
         <Calendar now={this.state.value} />
+        {shouldShowTodayButton ? (
+          <Button
+            appearance="minimal"
+            justifyContent="center"
+            onClick={this.doJumpToToday}
+          >
+            Today
+          </Button>
+        ) : null}
       </Box>
     )
   }
 }
 export default class DatePicker extends PureComponent {
   static propTypes = {
+    /**
+     * The date presentation of calendar
+     */
     value: PropTypes.oneOfType([
-      PropTypes.string, // A formatted string
-      PropTypes.number, // A timestamp
-      PropTypes.instanceOf(Date) // Or a Date object
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date)
     ]).isRequired,
-    textInputProps: PropTypes.object,
-    dateFormat: PropTypes.string
+
+    /**
+     * Should if a button to quickly jump to today is shown
+     */
+    shouldShowTodayButton: PropTypes.bool,
+
+    /**
+     * Props that are passed to text input field
+     */
+    textInputProps: PropTypes.object
+  }
+
+  static defaultProps = {
+    width: 280,
+    shouldShowTodayButton: true
   }
 
   render() {
-    const { value, textInputProps, ...rest } = this.props
+    const { textInputProps, ...rest } = this.props
 
     return (
-      <Popover content={<DatePickerPopover value={value} />} {...rest}>
+      <Popover content={<DatePickerPopover {...rest} />}>
         <TextInput placeholder="Pick a date" {...textInputProps} />
       </Popover>
     )

--- a/src/date-picker/src/DatePicker.js
+++ b/src/date-picker/src/DatePicker.js
@@ -66,13 +66,9 @@ export default class DatePicker extends PureComponent {
     }
   }
 
-  state = { value: this.props.value }
+  state = { pivotDate: this.props.value }
 
-  changeDate = value =>
-    this.setState(
-      { value },
-      () => this.props.onChange && this.props.onChange(value)
-    )
+  changePivotDate = pivotDate => this.setState({ pivotDate })
 
   getCurrentMonthTitle = () =>
     new Intl.DateTimeFormat(this.props.locale, {
@@ -82,17 +78,22 @@ export default class DatePicker extends PureComponent {
       year:
         this.props.localeOptions.year ||
         DatePicker.defaultProps.localeOptions.year
-    }).format(this.state.value)
+    }).format(this.state.pivotDate)
 
-  doGoToNextMonth = () => this.changeDate(addMonths(this.state.value, 1))
+  doGoToNextMonth = () =>
+    this.changePivotDate(addMonths(this.state.pivotDate, 1))
 
-  doGoToPrevMonth = () => this.changeDate(addMonths(this.state.value, -1))
+  doGoToPrevMonth = () =>
+    this.changePivotDate(addMonths(this.state.pivotDate, -1))
 
-  doGoToNextYear = () => this.changeDate(addYears(this.state.value, 1))
+  doGoToNextYear = () => this.changePivotDate(addYears(this.state.pivotDate, 1))
 
-  doGoToPrevYear = () => this.changeDate(addYears(this.state.value, -1))
+  doGoToPrevYear = () =>
+    this.changePivotDate(addYears(this.state.pivotDate, -1))
 
-  doJumpToToday = () => this.changeDate(new Date())
+  doJumpToToday = () => this.changePivotDate(new Date())
+
+  doCalendarClick = date => this.props.onChange && this.props.onChange(date)
 
   render() {
     const {
@@ -138,8 +139,9 @@ export default class DatePicker extends PureComponent {
           />
         </Box>
         <Calendar
-          pivotDate={this.state.value}
-          onClick={this.changeDate}
+          pivotDate={this.state.pivotDate}
+          selectedDate={this.props.value}
+          onClick={this.doCalendarClick}
           locale={locale}
           localeOptions={localeOptions}
           disableDates={disableDates}

--- a/src/date-picker/src/DateRangePicker.js
+++ b/src/date-picker/src/DateRangePicker.js
@@ -71,7 +71,7 @@ export default class DateRangePicker extends React.Component {
             locale={locale}
             localeOptions={localeOptions}
             disableDates={date =>
-              isBefore(date, startDate) || disableDates(date)
+              isBefore(date, startDate) || (disableDates && disableDates(date))
             }
             onChange={endDate => onChange && onChange(startDate, endDate)}
           />

--- a/src/date-picker/src/DateRangePicker.js
+++ b/src/date-picker/src/DateRangePicker.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import Box from 'ui-box'
+
+import isBefore from 'date-fns/is_before'
+import DatePicker from './DatePicker'
+import defaultPropTypes from './propTypes'
+
+// As DateRangePicker uses `startDate` and `endDate` as its values, let's remove
+// `value` prop types check
+const defaultPropTypesWithoutValue = Object.entries(defaultPropTypes).reduce(
+  (acc, [key, value]) => {
+    return key === 'value' ? acc : { ...acc, [key]: value }
+  },
+  {}
+)
+
+export default class DateRangePicker extends React.Component {
+  static propTypes = {
+    ...defaultPropTypesWithoutValue,
+
+    /**
+     * The starting date
+     */
+    startDate: defaultPropTypes.value,
+
+    /**
+     * The ending date
+     */
+    endDate: defaultPropTypes.value
+  }
+
+  render() {
+    const {
+      startDate,
+      endDate,
+      shouldShowTodayButton,
+      todayButtonLabel,
+      locale,
+      localeOptions,
+      disableDates,
+      onChange
+    } = this.props
+    return (
+      <Box display="flex">
+        <Box paddingRight={4}>
+          <DatePicker
+            width="100%"
+            value={startDate}
+            shouldShowTodayButton={shouldShowTodayButton}
+            todayButtonLabel={todayButtonLabel}
+            locale={locale}
+            localeOptions={localeOptions}
+            disableDates={disableDates}
+            onChange={startDate =>
+              onChange &&
+              onChange(
+                startDate,
+                isBefore(this.props.endDate, startDate)
+                  ? startDate
+                  : this.props.endDate
+              )
+            }
+          />
+        </Box>
+        <Box paddingLeft={4}>
+          <DatePicker
+            width="100%"
+            value={endDate}
+            shouldShowTodayButton={shouldShowTodayButton}
+            todayButtonLabel={todayButtonLabel}
+            locale={locale}
+            localeOptions={localeOptions}
+            disableDates={date =>
+              isBefore(date, startDate) || disableDates(date)
+            }
+            onChange={endDate => onChange && onChange(startDate, endDate)}
+          />
+        </Box>
+      </Box>
+    )
+  }
+}

--- a/src/date-picker/src/InlineDatePicker.js
+++ b/src/date-picker/src/InlineDatePicker.js
@@ -1,0 +1,124 @@
+import React, { PureComponent } from 'react'
+import Box from 'ui-box'
+
+import addMonths from 'date-fns/add_months'
+import addYears from 'date-fns/add_years'
+
+import { Text } from '../../typography'
+import { Button, IconButton } from '../../buttons'
+import { majorScale } from '../../scales'
+
+import Calendar from './Calendar'
+import defaultPropTypes from './propTypes'
+
+export default class InlineDatePicker extends PureComponent {
+  static propTypes = {
+    ...defaultPropTypes
+  }
+
+  static defaultProps = {
+    width: 280,
+    shouldShowTodayButton: true,
+    todayButtonLabel: 'Today',
+    locale: 'en-US',
+    localeOptions: {
+      weekday: 'short',
+      month: 'long',
+      year: 'numeric',
+      day: 'numeric'
+    }
+  }
+
+  state = { pivotDate: this.props.value }
+
+  changePivotDate = pivotDate => this.setState({ pivotDate })
+
+  getCurrentMonthTitle = () =>
+    new Intl.DateTimeFormat(this.props.locale, {
+      month:
+        this.props.localeOptions.month ||
+        InlineDatePicker.defaultProps.localeOptions.month,
+      year:
+        this.props.localeOptions.year ||
+        InlineDatePicker.defaultProps.localeOptions.year
+    }).format(this.state.pivotDate)
+
+  doGoToNextMonth = () =>
+    this.changePivotDate(addMonths(this.state.pivotDate, 1))
+
+  doGoToPrevMonth = () =>
+    this.changePivotDate(addMonths(this.state.pivotDate, -1))
+
+  doGoToNextYear = () => this.changePivotDate(addYears(this.state.pivotDate, 1))
+
+  doGoToPrevYear = () =>
+    this.changePivotDate(addYears(this.state.pivotDate, -1))
+
+  doJumpToToday = () => this.changePivotDate(new Date())
+
+  doCalendarClick = date => this.props.onChange && this.props.onChange(date)
+
+  render() {
+    const {
+      value,
+      shouldShowTodayButton,
+      todayButtonLabel,
+      locale,
+      localeOptions,
+      disableDates,
+      ...props
+    } = this.props
+
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        padding={majorScale(1)}
+        {...props}
+      >
+        <Box display="flex" alignItems="center">
+          <IconButton
+            icon="double-chevron-left"
+            appearance="minimal"
+            onClick={this.doGoToPrevYear}
+          />
+          <IconButton
+            icon="chevron-left"
+            appearance="minimal"
+            onClick={this.doGoToPrevMonth}
+          />
+          <Text marginX="auto" userSelect="none">
+            {this.getCurrentMonthTitle()}
+          </Text>
+          <IconButton
+            icon="chevron-right"
+            appearance="minimal"
+            onClick={this.doGoToNextMonth}
+          />
+          <IconButton
+            icon="double-chevron-right"
+            appearance="minimal"
+            onClick={this.doGoToNextYear}
+          />
+        </Box>
+        <Calendar
+          pivotDate={this.state.pivotDate}
+          selectedDate={this.props.value}
+          onClick={this.doCalendarClick}
+          locale={locale}
+          localeOptions={localeOptions}
+          disableDates={disableDates}
+        />
+        {shouldShowTodayButton ? (
+          <Button
+            appearance="minimal"
+            justifyContent="center"
+            onClick={this.doJumpToToday}
+          >
+            {todayButtonLabel}
+          </Button>
+        ) : null}
+      </Box>
+    )
+  }
+}

--- a/src/date-picker/src/propTypes.js
+++ b/src/date-picker/src/propTypes.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types'
+
+export default {
+  /**
+   * The current selected date on calendar
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date)
+  ]).isRequired,
+
+  /**
+   * Should a button to quickly jump to the current date is shown
+   */
+  shouldShowTodayButton: PropTypes.bool,
+
+  /**
+   * Label of ShowToday button
+   */
+  todayButtonLabel: PropTypes.string,
+
+  /**
+   * The locale used to format date in calendar
+   */
+  locale: PropTypes.string,
+
+  /**
+   * Options used to format
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+   */
+  localeOptions: PropTypes.object,
+
+  /**
+   * Validation function to determine if a date is disabled
+   */
+  disableDates: PropTypes.func,
+
+  /**
+   * Callback function to be invokved when users select a date
+   */
+  onChange: PropTypes.func
+}

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -7,7 +7,7 @@ import format from 'date-fns/format'
 import { Paragraph } from '../../typography'
 import { Popover } from '../../popover'
 import { TextInput } from '../../text-input'
-import { SegmentedControl } from '../../segmented-control'
+import { Combobox } from '../../combobox'
 
 storiesOf('date-picker', module)
   .add('DatePicker', () => (
@@ -58,57 +58,96 @@ storiesOf('date-picker', module)
         initialState={{
           date: new Date(),
           locale: 'fi-FI',
-          locales: [
-            { label: 'fi-FI', value: 'fi-FI' },
-            { label: 'vi-VN', value: 'vi-VN' },
-            { label: 'es-ES', value: 'es-ES' },
-            { label: 'en-GB', value: 'en-GB' },
-            { label: 'zh-CN', value: 'zh-CN' },
-            { label: 'ru-RU', value: 'ru-RU' }
-          ],
+          locales: ['fi-FI', 'vi-VN', 'es-ES', 'ar-AE', 'ru-RU', 'zh-CN'],
           localeOptions: {
-            weekday: 'narrow'
+            weekday: 'narrow',
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric'
           },
-          weekdayFormats: [
-            { label: 'narrow', value: 'narrow' },
-            { label: 'short', value: 'short' },
-            { label: 'long', value: 'long' }
-          ],
+          weekdayFormats: ['narrow', 'short', 'long'],
+          dayFormats: ['numeric', '2-digit'],
+          monthFormats: ['numeric', '2-digit', 'narrow', 'short', 'long'],
+          yearFormats: ['numeric', '2-digit'],
           todayButtonLabels: new Map([
             ['fi-FI', 'Tänään'],
             ['vi-VN', 'Hôm nay'],
             ['es-ES', 'Hoy'],
-            ['en-GB', 'Today'],
+            ['ar-AE', 'اليَوْم'],
             ['zh-CN', '今天'],
             ['ru-RU', 'сегодня']
           ])
         }}
       >
         {({ state, setState }) => (
-          <Box>
-            <Box display="flex" marginBottom={16} width="100%">
-              <Box width="50%" paddingX={16}>
-                <SegmentedControl
-                  options={state.locales}
-                  value={state.locale}
-                  onChange={locale => setState({ locale })}
-                />
-              </Box>
-              <Box width="50%" paddingX={16}>
-                <SegmentedControl
-                  options={state.weekdayFormats}
-                  value={state.localeOptions.weekday}
-                  onChange={weekday => setState({ localeOptions: { weekday } })}
-                />
-              </Box>
+          <Box display="flex">
+            <Box
+              width="50%"
+              display="flex"
+              flexDirection="column"
+              justifyContent="space-between"
+            >
+              <Combobox
+                selectedItem={state.locale}
+                items={state.locales}
+                onChange={locale => setState({ locale })}
+                autocompleteProps={{ title: 'Locale' }}
+              />
+              <Combobox
+                selectedItem={state.localeOptions.weekday}
+                items={state.weekdayFormats}
+                onChange={weekday =>
+                  setState({
+                    localeOptions: { ...state.localeOptions, weekday }
+                  })
+                }
+                autocompleteProps={{ title: 'Weekday' }}
+              />
+              <Combobox
+                selectedItem={state.localeOptions.day}
+                items={state.dayFormats}
+                onChange={day =>
+                  setState({
+                    localeOptions: { ...state.localeOptions, day }
+                  })
+                }
+                autocompleteProps={{ title: 'Day' }}
+              />
+              <Combobox
+                selectedItem={state.localeOptions.month}
+                items={state.monthFormats}
+                onChange={month =>
+                  setState({
+                    localeOptions: { ...state.localeOptions, month }
+                  })
+                }
+                autocompleteProps={{ title: 'Month' }}
+              />
+              <Combobox
+                selectedItem={state.localeOptions.year}
+                items={state.yearFormats}
+                onChange={year =>
+                  setState({
+                    localeOptions: { ...state.localeOptions, year }
+                  })
+                }
+                autocompleteProps={{ title: 'Year' }}
+              />
             </Box>
-            <DatePicker
-              width={320}
-              value={state.date}
-              locale={state.locale}
-              localeOptions={state.localeOptions}
-              todayButtonLabel={state.todayButtonLabels.get(state.locale)}
-            />
+            <div>
+              <DatePicker
+                width={320}
+                value={state.date}
+                locale={state.locale}
+                localeOptions={state.localeOptions}
+                todayButtonLabel={state.todayButtonLabels.get(state.locale)}
+                onChange={date => setState({ date })}
+              />
+              <Paragraph>
+                Selected date:{' '}
+                {new Intl.DateTimeFormat(state.locale).format(state.date)}
+              </Paragraph>
+            </div>
           </Box>
         )}
       </Component>

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -1,0 +1,14 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import Box from 'ui-box'
+import { DatePicker } from '..'
+
+storiesOf('date-picker', module).add('DatePicker', () => (
+  <Box padding={40}>
+    {(() => {
+      document.body.style.margin = '0'
+      document.body.style.height = '100vh'
+    })()}
+    <DatePicker value={new Date()} />
+  </Box>
+))

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import Box from 'ui-box'
 import { DatePicker } from '..'
+import { Paragraph } from '../../typography'
 
 storiesOf('date-picker', module).add('DatePicker', () => (
   <Box padding={40}>
@@ -9,6 +10,10 @@ storiesOf('date-picker', module).add('DatePicker', () => (
       document.body.style.margin = '0'
       document.body.style.height = '100vh'
     })()}
+    <Paragraph marginY={16}>Default date picker</Paragraph>
     <DatePicker value={new Date()} />
+
+    <Paragraph marginY={16}>Without Today button</Paragraph>
+    <DatePicker value={new Date()} shouldShowTodayButton={false} />
   </Box>
 ))

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -6,7 +6,6 @@ import { DatePicker } from '..'
 import format from 'date-fns/format'
 import isWeekend from 'date-fns/is_weekend'
 import isBefore from 'date-fns/is_before'
-import isSameDay from 'date-fns/is_same_day'
 import { Paragraph } from '../../typography'
 import { Popover } from '../../popover'
 import { TextInput } from '../../text-input'
@@ -60,7 +59,7 @@ storiesOf('date-picker', module)
         </Component>
       </Box>
 
-      <Box width="66.66%">
+      <Box width="33.33%">
         <Paragraph marginY={16}>As a date range picker</Paragraph>
         <Component
           initialState={{ startDate: new Date(), endDate: new Date() }}
@@ -72,15 +71,17 @@ storiesOf('date-picker', module)
                   content={
                     <DatePicker
                       value={state.startDate}
-                      disableDates={d =>
-                        !isSameDay(state.endDate, state.startDate) &&
-                        isBefore(state.endDate, d)
-                      }
-                      onChange={startDate => setState({ startDate })}
+                      onChange={startDate => {
+                        const endDate = isBefore(state.endDate, startDate)
+                          ? startDate
+                          : state.endDate
+                        setState({ startDate, endDate })
+                      }}
                     />
                   }
                 >
                   <TextInput
+                    width="95%"
                     value={format(state.startDate, 'DD/MM/YYYY')}
                     placeholder="Pick the start date"
                     readOnly
@@ -92,15 +93,13 @@ storiesOf('date-picker', module)
                   content={
                     <DatePicker
                       value={state.endDate}
-                      disableDates={d =>
-                        !isSameDay(state.endDate, state.startDate) &&
-                        !isBefore(state.startDate, d)
-                      }
+                      disableDates={d => isBefore(d, state.startDate)}
                       onChange={endDate => setState({ endDate })}
                     />
                   }
                 >
                   <TextInput
+                    width="95%"
                     value={format(state.endDate, 'DD/MM/YYYY')}
                     placeholder="Pick the end date"
                     readOnly

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -5,6 +5,8 @@ import Component from '@reactions/component'
 import { DatePicker } from '..'
 import format from 'date-fns/format'
 import isWeekend from 'date-fns/is_weekend'
+import isBefore from 'date-fns/is_before'
+import isSameDay from 'date-fns/is_same_day'
 import { Paragraph } from '../../typography'
 import { Popover } from '../../popover'
 import { TextInput } from '../../text-input'
@@ -12,49 +14,103 @@ import { Combobox } from '../../combobox'
 
 storiesOf('date-picker', module)
   .add('DatePicker', () => (
-    <Box padding={40}>
+    <Box padding={40} display="flex" flexWrap="wrap">
       {(() => {
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
 
-      <Box display="flex" flexWrap="wrap">
-        <Box width="33.33%">
-          <Paragraph marginY={16}>Default date picker</Paragraph>
-          <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
-        </Box>
-        <Box width="33.33%">
-          <Paragraph marginY={16}>Without Today button</Paragraph>
-          <DatePicker
-            value={new Date(2019, 6, 1)}
-            shouldShowTodayButton={false}
-          />
-        </Box>
-        <Box width="33.33%">
-          <Paragraph marginY={16}>Disable all weekends</Paragraph>
-          <DatePicker value={new Date(1989, 7, 1)} disableDates={isWeekend} />
-        </Box>
+      <Box width="33.33%">
+        <Paragraph marginY={16}>Default date picker</Paragraph>
+        <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
       </Box>
 
-      <Paragraph marginY={16}>Use with a popover</Paragraph>
-      <Component initialState={{ date: new Date() }}>
-        {({ state, setState }) => (
-          <Popover
-            content={
-              <DatePicker
-                value={state.date}
-                onChange={date => setState({ date })}
+      <Box width="33.33%">
+        <Paragraph marginY={16}>Without Today button</Paragraph>
+        <DatePicker
+          value={new Date(2019, 6, 1)}
+          shouldShowTodayButton={false}
+        />
+      </Box>
+
+      <Box width="33.33%">
+        <Paragraph marginY={16}>Disable all weekends</Paragraph>
+        <DatePicker value={new Date(1989, 7, 1)} disableDates={isWeekend} />
+      </Box>
+
+      <Box width="33.33%">
+        <Paragraph marginY={16}>Use with a popover</Paragraph>
+        <Component initialState={{ date: new Date() }}>
+          {({ state, setState }) => (
+            <Popover
+              content={
+                <DatePicker
+                  value={state.date}
+                  onChange={date => setState({ date })}
+                />
+              }
+            >
+              <TextInput
+                value={format(state.date, 'DD/MM/YYYY')}
+                placeholder="Pick a date"
+                readOnly
               />
-            }
-          >
-            <TextInput
-              value={format(state.date, 'DD/MM/YYYY')}
-              placeholder="Pick a date"
-              readOnly
-            />
-          </Popover>
-        )}
-      </Component>
+            </Popover>
+          )}
+        </Component>
+      </Box>
+
+      <Box width="66.66%">
+        <Paragraph marginY={16}>As a date range picker</Paragraph>
+        <Component
+          initialState={{ startDate: new Date(), endDate: new Date() }}
+        >
+          {({ state, setState }) => (
+            <Box display="flex">
+              <Box width="50%">
+                <Popover
+                  content={
+                    <DatePicker
+                      value={state.startDate}
+                      disableDates={d =>
+                        !isSameDay(state.endDate, state.startDate) &&
+                        isBefore(state.endDate, d)
+                      }
+                      onChange={startDate => setState({ startDate })}
+                    />
+                  }
+                >
+                  <TextInput
+                    value={format(state.startDate, 'DD/MM/YYYY')}
+                    placeholder="Pick the start date"
+                    readOnly
+                  />
+                </Popover>
+              </Box>
+              <Box width="50%">
+                <Popover
+                  content={
+                    <DatePicker
+                      value={state.endDate}
+                      disableDates={d =>
+                        !isSameDay(state.endDate, state.startDate) &&
+                        !isBefore(state.startDate, d)
+                      }
+                      onChange={endDate => setState({ endDate })}
+                    />
+                  }
+                >
+                  <TextInput
+                    value={format(state.endDate, 'DD/MM/YYYY')}
+                    placeholder="Pick the end date"
+                    readOnly
+                  />
+                </Popover>
+              </Box>
+            </Box>
+          )}
+        </Component>
+      </Box>
     </Box>
   ))
   .add('With different locales ', () => (

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -103,7 +103,7 @@ storiesOf('date-picker', module)
               </Box>
             </Box>
             <DatePicker
-              width={400}
+              width={320}
               value={state.date}
               locale={state.locale}
               localeOptions={state.localeOptions}

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -101,10 +101,9 @@ storiesOf('date-picker', module)
             <DateRangePicker
               startDate={state.startDate}
               endDate={state.endDate}
-              onChange={(startDate, endDate) => {
-                console.log(startDate, endDate)
+              onChange={(startDate, endDate) =>
                 setState({ startDate, endDate })
-              }}
+              }
               locale="fi-FI"
               disableDates={isWeekend}
             />

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -4,6 +4,7 @@ import Box from 'ui-box'
 import Component from '@reactions/component'
 import { DatePicker } from '..'
 import format from 'date-fns/format'
+import isWeekend from 'date-fns/is_weekend'
 import { Paragraph } from '../../typography'
 import { Popover } from '../../popover'
 import { TextInput } from '../../text-input'
@@ -17,17 +18,21 @@ storiesOf('date-picker', module)
         document.body.style.height = '100vh'
       })()}
 
-      <Box display="flex">
-        <Box width="50%">
+      <Box display="flex" flexWrap="wrap">
+        <Box width="33.33%">
           <Paragraph marginY={16}>Default date picker</Paragraph>
           <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
         </Box>
-        <Box width="50%">
+        <Box width="33.33%">
           <Paragraph marginY={16}>Without Today button</Paragraph>
           <DatePicker
             value={new Date(2019, 6, 1)}
             shouldShowTodayButton={false}
           />
+        </Box>
+        <Box width="33.33%">
+          <Paragraph marginY={16}>Disable all weekends</Paragraph>
+          <DatePicker value={new Date(1989, 7, 1)} disableDates={isWeekend} />
         </Box>
       </Box>
 

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -1,8 +1,12 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import Box from 'ui-box'
+import Component from '@reactions/component'
 import { DatePicker } from '..'
+import format from 'date-fns/format'
 import { Paragraph } from '../../typography'
+import { Popover } from '../../popover'
+import { TextInput } from '../../text-input'
 
 storiesOf('date-picker', module).add('DatePicker', () => (
   <Box padding={40}>
@@ -10,10 +14,39 @@ storiesOf('date-picker', module).add('DatePicker', () => (
       document.body.style.margin = '0'
       document.body.style.height = '100vh'
     })()}
-    <Paragraph marginY={16}>Default date picker</Paragraph>
-    <DatePicker value={new Date()} />
 
-    <Paragraph marginY={16}>Without Today button</Paragraph>
-    <DatePicker value={new Date()} shouldShowTodayButton={false} />
+    <Box display="flex">
+      <Box width="50%">
+        <Paragraph marginY={16}>Default date picker</Paragraph>
+        <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
+      </Box>
+      <Box width="50%">
+        <Paragraph marginY={16}>Without Today button</Paragraph>
+        <DatePicker
+          value={new Date(2019, 6, 1)}
+          shouldShowTodayButton={false}
+        />
+      </Box>
+    </Box>
+
+    <Paragraph marginY={16}>Use with a popover</Paragraph>
+    <Component initialState={{ date: new Date() }}>
+      {({ state, setState }) => (
+        <Popover
+          content={
+            <DatePicker
+              value={state.date}
+              onChange={date => setState({ date })}
+            />
+          }
+        >
+          <TextInput
+            value={format(state.date, 'DD/MM/YYYY')}
+            placeholder="Pick a date"
+            readOnly
+          />
+        </Popover>
+      )}
+    </Component>
   </Box>
 ))

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -7,46 +7,74 @@ import format from 'date-fns/format'
 import { Paragraph } from '../../typography'
 import { Popover } from '../../popover'
 import { TextInput } from '../../text-input'
+import { SegmentedControl } from '../../segmented-control'
 
-storiesOf('date-picker', module).add('DatePicker', () => (
-  <Box padding={40}>
-    {(() => {
-      document.body.style.margin = '0'
-      document.body.style.height = '100vh'
-    })()}
+storiesOf('date-picker', module)
+  .add('DatePicker', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
 
-    <Box display="flex">
-      <Box width="50%">
-        <Paragraph marginY={16}>Default date picker</Paragraph>
-        <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
-      </Box>
-      <Box width="50%">
-        <Paragraph marginY={16}>Without Today button</Paragraph>
-        <DatePicker
-          value={new Date(2019, 6, 1)}
-          shouldShowTodayButton={false}
-        />
-      </Box>
-    </Box>
-
-    <Paragraph marginY={16}>Use with a popover</Paragraph>
-    <Component initialState={{ date: new Date() }}>
-      {({ state, setState }) => (
-        <Popover
-          content={
-            <DatePicker
-              value={state.date}
-              onChange={date => setState({ date })}
-            />
-          }
-        >
-          <TextInput
-            value={format(state.date, 'DD/MM/YYYY')}
-            placeholder="Pick a date"
-            readOnly
+      <Box display="flex">
+        <Box width="50%">
+          <Paragraph marginY={16}>Default date picker</Paragraph>
+          <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
+        </Box>
+        <Box width="50%">
+          <Paragraph marginY={16}>Without Today button</Paragraph>
+          <DatePicker
+            value={new Date(2019, 6, 1)}
+            shouldShowTodayButton={false}
           />
-        </Popover>
+        </Box>
+      </Box>
+
+      <Paragraph marginY={16}>Use with a popover</Paragraph>
+      <Component initialState={{ date: new Date() }}>
+        {({ state, setState }) => (
+          <Popover
+            content={
+              <DatePicker
+                value={state.date}
+                onChange={date => setState({ date })}
+              />
+            }
+          >
+            <TextInput
+              value={format(state.date, 'DD/MM/YYYY')}
+              placeholder="Pick a date"
+              readOnly
+            />
+          </Popover>
+        )}
+      </Component>
+    </Box>
+  ))
+  .add('With different locales ', () => (
+    <Component
+      initialState={{
+        date: new Date(),
+        locale: 'fi-FI',
+        locales: [
+          { label: 'fi-FI', value: 'fi-FI' },
+          { label: 'vi-VN', value: 'vi-VN' },
+          { label: 'es-ES', value: 'es-ES' },
+          { label: 'en-GB', value: 'en-GB' },
+          { label: 'zh-CN', value: 'zh-CN' }
+        ]
+      }}
+    >
+      {({ state, setState }) => (
+        <Box padding={16}>
+          <SegmentedControl
+            options={state.locales}
+            value={state.value}
+            onChange={locale => setState({ locale })}
+          />
+          <DatePicker value={state.date} locale={state.locale} />
+        </Box>
       )}
     </Component>
-  </Box>
-))
+  ))

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -2,17 +2,14 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import Box from 'ui-box'
 import Component from '@reactions/component'
-import { DatePicker } from '..'
+import { DatePicker, InlineDatePicker, DateRangePicker } from '..'
 import format from 'date-fns/format'
 import isWeekend from 'date-fns/is_weekend'
-import isBefore from 'date-fns/is_before'
 import { Paragraph } from '../../typography'
-import { Popover } from '../../popover'
-import { TextInput } from '../../text-input'
 import { Combobox } from '../../combobox'
 
 storiesOf('date-picker', module)
-  .add('Inline DatePicker', () => (
+  .add('InlineDatePicker', () => (
     <Box padding={40} display="flex" flexWrap="wrap">
       {(() => {
         document.body.style.margin = '0'
@@ -21,12 +18,12 @@ storiesOf('date-picker', module)
 
       <Box width="33.33%">
         <Paragraph marginY={16}>Default date picker</Paragraph>
-        <DatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
+        <InlineDatePicker value={new Date(2018, 7, 1)} onChange={console.log} />
       </Box>
 
       <Box width="33.33%">
         <Paragraph marginY={16}>Without Today button</Paragraph>
-        <DatePicker
+        <InlineDatePicker
           value={new Date(2019, 6, 1)}
           shouldShowTodayButton={false}
         />
@@ -34,82 +31,83 @@ storiesOf('date-picker', module)
 
       <Box width="33.33%">
         <Paragraph marginY={16}>Disable all weekends</Paragraph>
-        <DatePicker value={new Date(1989, 7, 1)} disableDates={isWeekend} />
+        <InlineDatePicker
+          value={new Date(1989, 7, 1)}
+          disableDates={isWeekend}
+        />
       </Box>
     </Box>
   ))
-  .add('DatePicker inputs', () => (
+  .add('DatePicker', () => (
     <Box padding={40} display="flex" flexWrap="wrap">
       <Box width="33.33%">
-        <Paragraph marginY={16}>Use with a popover</Paragraph>
+        <Paragraph marginY={16}>Default date picker (uncontrolled)</Paragraph>
+        <DatePicker value={new Date()} />
+      </Box>
+
+      <Box width="33.33%">
+        <Paragraph marginY={16}>Default date picker (controlled)</Paragraph>
         <Component initialState={{ date: new Date() }}>
           {({ state, setState }) => (
-            <Popover
-              content={
-                <DatePicker
-                  value={state.date}
-                  onChange={date => setState({ date })}
-                />
-              }
-            >
-              <TextInput
-                value={format(state.date, 'DD/MM/YYYY')}
-                placeholder="Pick a date"
-                readOnly
-              />
-            </Popover>
+            <DatePicker
+              value={state.date}
+              onChange={date => setState({ date })}
+            />
           )}
         </Component>
       </Box>
 
       <Box width="33.33%">
-        <Paragraph marginY={16}>As a date range picker</Paragraph>
+        <Paragraph marginY={16}>With different format</Paragraph>
+        <Component initialState={{ date: new Date() }}>
+          {({ state, setState }) => (
+            <DatePicker
+              value={state.date}
+              dateFormatter={d => format(d, 'YYYY-MM-DD')}
+              onChange={date => setState({ date })}
+            />
+          )}
+        </Component>
+      </Box>
+    </Box>
+  ))
+  .add('DateRangePicker', () => (
+    <Box padding={16} display="flex">
+      <Box width="50%">
+        <Paragraph marginY={16}>Default date range picker</Paragraph>
         <Component
           initialState={{ startDate: new Date(), endDate: new Date() }}
         >
           {({ state, setState }) => (
-            <Box display="flex">
-              <Box width="50%">
-                <Popover
-                  content={
-                    <DatePicker
-                      value={state.startDate}
-                      onChange={startDate => {
-                        const endDate = isBefore(state.endDate, startDate)
-                          ? startDate
-                          : state.endDate
-                        setState({ startDate, endDate })
-                      }}
-                    />
-                  }
-                >
-                  <TextInput
-                    width="95%"
-                    value={format(state.startDate, 'DD/MM/YYYY')}
-                    placeholder="Pick the start date"
-                    readOnly
-                  />
-                </Popover>
-              </Box>
-              <Box width="50%">
-                <Popover
-                  content={
-                    <DatePicker
-                      value={state.endDate}
-                      disableDates={d => isBefore(d, state.startDate)}
-                      onChange={endDate => setState({ endDate })}
-                    />
-                  }
-                >
-                  <TextInput
-                    width="95%"
-                    value={format(state.endDate, 'DD/MM/YYYY')}
-                    placeholder="Pick the end date"
-                    readOnly
-                  />
-                </Popover>
-              </Box>
-            </Box>
+            <DateRangePicker
+              startDate={state.startDate}
+              endDate={state.endDate}
+              onChange={(startDate, endDate) => {
+                console.log(startDate, endDate)
+                setState({ startDate, endDate })
+              }}
+            />
+          )}
+        </Component>
+      </Box>
+      <Box width="50%">
+        <Paragraph marginY={16}>
+          Both inputs share common datepicker props
+        </Paragraph>
+        <Component
+          initialState={{ startDate: new Date(), endDate: new Date() }}
+        >
+          {({ state, setState }) => (
+            <DateRangePicker
+              startDate={state.startDate}
+              endDate={state.endDate}
+              onChange={(startDate, endDate) => {
+                console.log(startDate, endDate)
+                setState({ startDate, endDate })
+              }}
+              locale="fi-FI"
+              disableDates={isWeekend}
+            />
           )}
         </Component>
       </Box>
@@ -150,12 +148,14 @@ storiesOf('date-picker', module)
               justifyContent="space-between"
             >
               <Combobox
+                marginBottom={16}
                 selectedItem={state.locale}
                 items={state.locales}
                 onChange={locale => setState({ locale })}
                 autocompleteProps={{ title: 'Locale' }}
               />
               <Combobox
+                marginBottom={16}
                 selectedItem={state.localeOptions.weekday}
                 items={state.weekdayFormats}
                 onChange={weekday =>
@@ -166,6 +166,7 @@ storiesOf('date-picker', module)
                 autocompleteProps={{ title: 'Weekday' }}
               />
               <Combobox
+                marginBottom={16}
                 selectedItem={state.localeOptions.day}
                 items={state.dayFormats}
                 onChange={day =>
@@ -176,6 +177,7 @@ storiesOf('date-picker', module)
                 autocompleteProps={{ title: 'Day' }}
               />
               <Combobox
+                marginBottom={16}
                 selectedItem={state.localeOptions.month}
                 items={state.monthFormats}
                 onChange={month =>
@@ -186,6 +188,7 @@ storiesOf('date-picker', module)
                 autocompleteProps={{ title: 'Month' }}
               />
               <Combobox
+                marginBottom={16}
                 selectedItem={state.localeOptions.year}
                 items={state.yearFormats}
                 onChange={year =>
@@ -197,7 +200,7 @@ storiesOf('date-picker', module)
               />
             </Box>
             <Box marginLeft={32}>
-              <DatePicker
+              <InlineDatePicker
                 width={320}
                 value={state.date}
                 locale={state.locale}

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -53,28 +53,64 @@ storiesOf('date-picker', module)
     </Box>
   ))
   .add('With different locales ', () => (
-    <Component
-      initialState={{
-        date: new Date(),
-        locale: 'fi-FI',
-        locales: [
-          { label: 'fi-FI', value: 'fi-FI' },
-          { label: 'vi-VN', value: 'vi-VN' },
-          { label: 'es-ES', value: 'es-ES' },
-          { label: 'en-GB', value: 'en-GB' },
-          { label: 'zh-CN', value: 'zh-CN' }
-        ]
-      }}
-    >
-      {({ state, setState }) => (
-        <Box padding={16}>
-          <SegmentedControl
-            options={state.locales}
-            value={state.value}
-            onChange={locale => setState({ locale })}
-          />
-          <DatePicker value={state.date} locale={state.locale} />
-        </Box>
-      )}
-    </Component>
+    <Box padding={16}>
+      <Component
+        initialState={{
+          date: new Date(),
+          locale: 'fi-FI',
+          locales: [
+            { label: 'fi-FI', value: 'fi-FI' },
+            { label: 'vi-VN', value: 'vi-VN' },
+            { label: 'es-ES', value: 'es-ES' },
+            { label: 'en-GB', value: 'en-GB' },
+            { label: 'zh-CN', value: 'zh-CN' },
+            { label: 'ru-RU', value: 'ru-RU' }
+          ],
+          localeOptions: {
+            weekday: 'narrow'
+          },
+          weekdayFormats: [
+            { label: 'narrow', value: 'narrow' },
+            { label: 'short', value: 'short' },
+            { label: 'long', value: 'long' }
+          ],
+          todayButtonLabels: new Map([
+            ['fi-FI', 'Tänään'],
+            ['vi-VN', 'Hôm nay'],
+            ['es-ES', 'Hoy'],
+            ['en-GB', 'Today'],
+            ['zh-CN', '今天'],
+            ['ru-RU', 'сегодня']
+          ])
+        }}
+      >
+        {({ state, setState }) => (
+          <Box>
+            <Box display="flex" marginBottom={16} width="100%">
+              <Box width="50%" paddingX={16}>
+                <SegmentedControl
+                  options={state.locales}
+                  value={state.locale}
+                  onChange={locale => setState({ locale })}
+                />
+              </Box>
+              <Box width="50%" paddingX={16}>
+                <SegmentedControl
+                  options={state.weekdayFormats}
+                  value={state.localeOptions.weekday}
+                  onChange={weekday => setState({ localeOptions: { weekday } })}
+                />
+              </Box>
+            </Box>
+            <DatePicker
+              width={400}
+              value={state.date}
+              locale={state.locale}
+              localeOptions={state.localeOptions}
+              todayButtonLabel={state.todayButtonLabels.get(state.locale)}
+            />
+          </Box>
+        )}
+      </Component>
+    </Box>
   ))

--- a/src/date-picker/stories/index.stories.js
+++ b/src/date-picker/stories/index.stories.js
@@ -12,7 +12,7 @@ import { TextInput } from '../../text-input'
 import { Combobox } from '../../combobox'
 
 storiesOf('date-picker', module)
-  .add('DatePicker', () => (
+  .add('Inline DatePicker', () => (
     <Box padding={40} display="flex" flexWrap="wrap">
       {(() => {
         document.body.style.margin = '0'
@@ -36,7 +36,10 @@ storiesOf('date-picker', module)
         <Paragraph marginY={16}>Disable all weekends</Paragraph>
         <DatePicker value={new Date(1989, 7, 1)} disableDates={isWeekend} />
       </Box>
-
+    </Box>
+  ))
+  .add('DatePicker inputs', () => (
+    <Box padding={40} display="flex" flexWrap="wrap">
       <Box width="33.33%">
         <Paragraph marginY={16}>Use with a popover</Paragraph>
         <Component initialState={{ date: new Date() }}>
@@ -142,7 +145,6 @@ storiesOf('date-picker', module)
         {({ state, setState }) => (
           <Box display="flex">
             <Box
-              width="50%"
               display="flex"
               flexDirection="column"
               justifyContent="space-between"
@@ -194,7 +196,7 @@ storiesOf('date-picker', module)
                 autocompleteProps={{ title: 'Year' }}
               />
             </Box>
-            <div>
+            <Box marginLeft={32}>
               <DatePicker
                 width={320}
                 value={state.date}
@@ -203,11 +205,11 @@ storiesOf('date-picker', module)
                 todayButtonLabel={state.todayButtonLabels.get(state.locale)}
                 onChange={date => setState({ date })}
               />
-              <Paragraph>
+              <Paragraph textAlign="center">
                 Selected date:{' '}
                 {new Intl.DateTimeFormat(state.locale).format(state.date)}
               </Paragraph>
-            </div>
+            </Box>
           </Box>
         )}
       </Component>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,7 +4115,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.23.0, date-fns@^1.27.2:
+date-fns@^1.23.0, date-fns@^1.27.2, date-fns@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
   integrity sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==


### PR DESCRIPTION
I built a date picker for my project and thought it would be useful for other Evergreen's users. If the team already has a plan to build this component in future versions, please let me know 🙂

Lots of inspiration come from Antd and Atlaskit.

### Functionalities

The DatePicker itself does not expose any input, but just a calendar where users can select a date. By doing this way it's possible to show DatePicker inline, or customize to use with `TextInput`, `Button` or any other controls.

![image](https://user-images.githubusercontent.com/172503/48730474-21460100-ec43-11e8-9d72-4c83ca6a8882.png)
_Inline date pickers, with Today button and dates being disabled on demand_

![image](https://user-images.githubusercontent.com/172503/48730521-4cc8eb80-ec43-11e8-9ce1-083ba02288cc.png)
_Date input using `Popover` and `TextInput`_

![image](https://user-images.githubusercontent.com/172503/48730595-9285b400-ec43-11e8-9365-c0cccc3e0e0c.png)
_Can be used to make a date range input_

![image](https://user-images.githubusercontent.com/172503/48731191-273ce180-ec45-11e8-811a-82d6be8b2ac6.png)
![image](https://user-images.githubusercontent.com/172503/48731147-0b394000-ec45-11e8-972a-95b59a60d335.png)
_Supports l10n_

### Props

- `value {string|number|Date}`: (required) the initial date or value of DatePicker
- `shouldShowTodayButton {boolean}`: if a button is displayed to jump to the current date
- `todayButtonLabel {string}`: label for ShowToday button
- `locale {string}`: locale to format dates, as defined in `Intl.DateTimeFormat`
- `localeOptions {object}`: options to format dates and weekdays' name, as defined in `Intl.DateTimeFormat`
- `disableDates {Date -> boolean}`: function to determine if a date should be disabled
- `onChange {Date -> void}`: callback function when a date is selected

### Todos

- [ ] Allow to show weeks starting from Mondays
- [ ] Support a11y via ARIA attributes (don't have much experience about this)
- [ ] Most likely support keyboard usage
- [ ] Add unit tests for date calculating

### Final thoughts

**Should we make `DateInput` and `DateRangeInput`?** It's up to consumers to customize the UI of their date pickers, but I guess we can export ready-made controls for most common use-cases.

**Do we need a time picker too?** It could mimic the one in Atlaskit.

**Look and feel** I'm not a designer so pretty much unsure if the UI matched with Evergreen design guideline. Please have comments for this.

All feedback are pretty much appreciated.