### PR TITLE
Feat/body scroll

### DIFF
--- a/docs/src/pages/components/dialog.mdx
+++ b/docs/src/pages/components/dialog.mdx
@@ -55,7 +55,7 @@ This is normally the button that triggered the `Dialog`.
 
 ## Default with a danger intent
 
-The `intent` prop determines the appearance of the confirm button, `danger` is red. 
+The `intent` prop determines the appearance of the confirm button, `danger` is red.
 
 ```jsx
 <Component initialState={{ isShown: false }}>
@@ -220,12 +220,34 @@ Use the `hasFooter`, `hasHeader` props to show or hide the footer and header.
   {({ state, setState }) => (
     <Pane>
       <Dialog
-        isShown={state.isShown}      
+        isShown={state.isShown}
         onCloseComplete={() => setState({ isShown: false })}
         hasFooter={false}
         hasHeader={false}
       >
         Completely custom dialog
+      </Dialog>
+
+      <Button onClick={() => setState({ isShown: true })}>Show Dialog</Button>
+    </Pane>
+  )}
+</Component>
+```
+
+## Preserve scroll position and prevent body scrolling
+
+Use the `preventBodyScrolling` prop to disable scrolling outside the dialog.
+
+```jsx
+<Component initialState={{ isShown: false }}>
+  {({ state, setState }) => (
+    <Pane paddingY='40vh'>
+      <Dialog
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+        preventBodyScrolling
+      >
+        Scroll-locked body
       </Dialog>
 
       <Button onClick={() => setState({ isShown: true })}>Show Dialog</Button>

--- a/docs/src/pages/components/side-sheet.mdx
+++ b/docs/src/pages/components/side-sheet.mdx
@@ -125,7 +125,7 @@ Content is a simple card.
                     </Tab>
                   )
                 )}
-              
+
             </Tablist>
           </Pane>
         </Pane>
@@ -233,6 +233,29 @@ Example with a header with a title and title. Content is a simple card.
       </SideSheet>
       <Button onClick={() => setState({ isShown: true })}>
         Show Basic Side Sheet
+      </Button>
+    </React.Fragment>
+  )}
+</Component>
+```
+
+## Preserve scroll position and prevent body scrolling
+
+Use the `preventBodyScrolling` prop to disable scrolling outside the side sheet.
+
+```jsx collapse
+<Component initialState={{ isShown: false }}>
+  {({ state, setState }) => (
+    <React.Fragment>
+      <SideSheet
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+        preventBodyScrolling
+      >
+        <Paragraph margin={40}>Basic Example</Paragraph>
+      </SideSheet>
+      <Button onClick={() => setState({ isShown: true })}>
+        Show Side Sheet
       </Button>
     </React.Fragment>
   )}

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -177,7 +177,12 @@ class Dialog extends React.Component {
     /**
      * Props that are passed to the content container.
      */
-    contentContainerProps: PropTypes.object
+    contentContainerProps: PropTypes.object,
+
+    /**
+     * Whether or not to prevent scrolling in the outer body
+     */
+    preventBodyScrolling: PropTypes.bool
   }
 
   static defaultProps = {
@@ -197,7 +202,8 @@ class Dialog extends React.Component {
     shouldCloseOnOverlayClick: true,
     shouldCloseOnEscapePress: true,
     onCancel: close => close(),
-    onConfirm: close => close()
+    onConfirm: close => close(),
+    preventBodyScrolling: false
   }
 
   renderChildren = close => {
@@ -235,7 +241,8 @@ class Dialog extends React.Component {
       shouldCloseOnEscapePress,
       containerProps,
       contentContainerProps,
-      minHeightContent
+      minHeightContent,
+      preventBodyScrolling
     } = this.props
 
     const sideOffsetWithUnit = Number.isInteger(sideOffset)
@@ -260,6 +267,7 @@ class Dialog extends React.Component {
           alignItems: 'flex-start',
           justifyContent: 'center'
         }}
+        preventBodyScrolling={preventBodyScrolling}
       >
         {({ state, close }) => (
           <Pane

--- a/src/lib/prevent-body-scroll.js
+++ b/src/lib/prevent-body-scroll.js
@@ -1,0 +1,31 @@
+let previousOverflow
+
+/**
+ * Toggle the body scroll / overflow and additional styling
+ * necessary to preserve scroll position and body width (scrollbar replacement)
+ *
+ * @param {boolean} preventScroll - whether or not to prevent body scrolling
+ */
+export default function preventBodyScroll(preventScroll) {
+  /** Get the width before toggling the style so we can calculate the scrollbar width for a smooth, jankless style change */
+  const { width } = document.body.getBoundingClientRect()
+
+  /** Apply or remove overflow style */
+  if (preventScroll) {
+    previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+  } else {
+    document.body.style.overflow = previousOverflow || ''
+  }
+
+  /** Get the _new width_ of the body (this will tell us the scrollbar width) */
+  const newWidth = document.body.getBoundingClientRect().width
+  const scrollBarWidth = newWidth - width
+
+  /** If there's a diff due to scrollbars, then account for it with padding */
+  if (preventScroll) {
+    document.body.style.paddingRight = Math.max(0, scrollBarWidth || 0) + 'px'
+  } else {
+    document.body.style.paddingRight = ''
+  }
+}

--- a/src/lib/prevent-body-scroll.js
+++ b/src/lib/prevent-body-scroll.js
@@ -1,4 +1,5 @@
 let previousOverflow
+let previousPaddingRight
 
 /**
  * Toggle the body scroll / overflow and additional styling
@@ -24,8 +25,9 @@ export default function preventBodyScroll(preventScroll) {
 
   /** If there's a diff due to scrollbars, then account for it with padding */
   if (preventScroll) {
+    previousPaddingRight = document.body.style.paddingRight
     document.body.style.paddingRight = Math.max(0, scrollBarWidth || 0) + 'px'
   } else {
-    document.body.style.paddingRight = ''
+    document.body.style.paddingRight = previousPaddingRight || ''
   }
 }

--- a/src/overlay/stories/index.stories.js
+++ b/src/overlay/stories/index.stories.js
@@ -29,21 +29,41 @@ class OverlayManager extends PureComponent {
   }
 }
 
-storiesOf('overlay', module).add('Overlay', () => (
-  <Box padding={40}>
-    {(() => {
-      document.body.style.margin = '0'
-      document.body.style.height = '100vh'
-    })()}
-    <OverlayManager>
-      {({ hide, show, isShown }) => (
-        <Box>
-          <Overlay isShown={isShown} onExited={hide}>
-            Overlay children
-          </Overlay>
-          <Button onClick={show}>Show Overlay</Button>
-        </Box>
-      )}
-    </OverlayManager>
-  </Box>
-))
+storiesOf('overlay', module)
+  .add('Overlay', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <OverlayManager>
+        {({ hide, show, isShown }) => (
+          <Box>
+            <Overlay isShown={isShown} onExited={hide}>
+              Overlay children
+            </Overlay>
+            <Button onClick={show}>Show Overlay</Button>
+          </Box>
+        )}
+      </OverlayManager>
+    </Box>
+  ))
+  .add('Prevent Body Scroll', () => (
+    <Box padding={40} paddingTop="50vh">
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '200vh'
+        document.body.style.background = 'gray'
+      })()}
+      <OverlayManager>
+        {({ hide, show, isShown }) => (
+          <Box>
+            <Overlay isShown={isShown} onExited={hide} preventBodyScrolling>
+              Overlay children
+            </Overlay>
+            <Button onClick={show}>Show Overlay</Button>
+          </Box>
+        )}
+      </OverlayManager>
+    </Box>
+  ))

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -186,7 +186,12 @@ class SideSheet extends React.Component {
       Position.BOTTOM,
       Position.LEFT,
       Position.RIGHT
-    ]).isRequired
+    ]).isRequired,
+
+    /**
+     * Whether or not to prevent scrolling in the outer body
+     */
+    preventBodyScrolling: PropTypes.bool
   }
 
   static defaultProps = {
@@ -209,7 +214,8 @@ class SideSheet extends React.Component {
       onBeforeClose,
       shouldCloseOnOverlayClick,
       shouldCloseOnEscapePress,
-      position
+      position,
+      preventBodyScrolling
     } = this.props
 
     return (
@@ -220,6 +226,7 @@ class SideSheet extends React.Component {
         onBeforeClose={onBeforeClose}
         onExited={onCloseComplete}
         onEntered={onOpenComplete}
+        preventBodyScrolling={preventBodyScrolling}
       >
         {({ state, close }) => (
           <Pane


### PR DESCRIPTION
This introduces scroll-locking support for anything consuming Overlay. It's opt-in, which makes this a non-breaking change.

When you pass `preventBodyScrolling` to Overlay, Dialog, or SideSheet the body content will no longer be scrollable (opposite the default behavior of these components). When the component unmounts or `isShown={false}` then the scroll behavior will return.

I've also updated the docs and stories.

Replaces #385 and closes #261 

cc @jeroenransijn @prateekgoel @kcjpop 