### PR TITLE
Extend SelectMenu

### DIFF
--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -263,7 +263,7 @@ This example shows basic usage with onFocusChange.
 
 ## Disabled option example
 
-This example shows basic usage for disabling some options. Options that are disabled cannot be clicked and its text is muted.
+This example shows basic usage for disabling some options. Options that are disabled cannot be clicked and their labels are muted.
 
 ```jsx
 <Component initialState={{ selected: null }}>

--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -261,4 +261,31 @@ This example shows basic usage with onFocusChange.
 </Component>
 ```
 
+## Disabled option example
+
+This example shows basic usage for disabling some options. Options that are disabled cannot be clicked and its text is muted.
+
+```jsx
+<Component initialState={{ selected: null }}>
+  {({ setState, state }) => (
+    <Pane>
+    <Pane marginBottom={8}>
+      <Text>Filter value: {state.filter}</Text>
+    </Pane>
+    <SelectMenu
+      title="Select Option"
+      options={
+        [{ label: "Disabled", value: "disabled", disabled: true }, { label: "Not Disabled", value: "not-disabled" }]
+      }
+      selected={state.selected}
+      onSelect={item => setState({ selected: item.value })}
+    >
+      <Button>{state.selected || 'Select name...'}</Button>
+    </SelectMenu>
+    </Pane>
+  )}
+  
+</Component>
+```
+
 <PropsTable of="SelectMenu" />

--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -232,4 +232,31 @@ As users click on selected values to remove them, you can update state.
 </Component>
 ```
 
+## onFocusChange example
+
+This example shows basic usage with onFocusChange. 
+
+```jsx
+<Component initialState={{ selected: null }}>
+  {({ setState, state }) => (
+    <Pane>
+    <SelectMenu
+      title="Select name"
+      onFocusChange={filter => setState({filter})}
+      options={
+        ['Apple', 'Apricot', 'Banana', 'Cherry', 'Cucumber']
+          .map(label => ({ label, value: label }))
+      }
+      selected={state.selected}
+      onSelect={item => setState({ selected: item.value })}
+    >
+      <Button>{state.selected || 'Select name...'}</Button>
+    </SelectMenu>
+    <Pane>{state.filter}</Pane>
+    </Pane>
+  )}
+  
+</Component>
+```
+
 <PropsTable of="SelectMenu" />

--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -232,7 +232,7 @@ As users click on selected values to remove them, you can update state.
 </Component>
 ```
 
-## onFocusChange example
+## onFilterChange example
 
 This example shows basic usage with onFocusChange. 
 
@@ -240,9 +240,12 @@ This example shows basic usage with onFocusChange.
 <Component initialState={{ selected: null }}>
   {({ setState, state }) => (
     <Pane>
+    <Pane marginBottom={8}>
+      <Text>Filter value: {state.filter}</Text>
+    </Pane>
     <SelectMenu
       title="Select name"
-      onFocusChange={filter => setState({filter})}
+      onFilterChange={filter => setState({filter})}
       options={
         ['Apple', 'Apricot', 'Banana', 'Cherry', 'Cucumber']
           .map(label => ({ label, value: label }))
@@ -252,7 +255,6 @@ This example shows basic usage with onFocusChange.
     >
       <Button>{state.selected || 'Select name...'}</Button>
     </SelectMenu>
-    <Pane>{state.filter}</Pane>
     </Pane>
   )}
   

--- a/src/select-menu/src/Option.js
+++ b/src/select-menu/src/Option.js
@@ -13,7 +13,8 @@ export default class Option extends PureComponent {
     onDeselect: PropTypes.func,
     isHighlighted: PropTypes.bool,
     isSelected: PropTypes.bool,
-    isSelectable: PropTypes.bool
+    isSelectable: PropTypes.bool,
+    disabled: PropTypes.bool
   }
 
   render() {
@@ -24,14 +25,23 @@ export default class Option extends PureComponent {
       isHighlighted,
       isSelected,
       isSelectable,
+      disabled,
       style,
       height,
       ...props
     } = this.props
 
+    const textProps = {}
+    if (disabled) {
+      textProps.color = 'muted'
+    }
+    if (isSelected) {
+      textProps.color = 'selected'
+    }
+
     return (
       <TableRow
-        isSelectable={isSelectable}
+        isSelectable={isSelectable && !disabled}
         isHighlighted={isHighlighted}
         onSelect={onSelect}
         onDeselect={onDeselect}
@@ -54,11 +64,12 @@ export default class Option extends PureComponent {
         <TextTableCell
           height={height}
           borderBottom="muted"
-          textProps={isSelected ? { color: 'selected' } : {}}
+          textProps={textProps}
           paddingLeft={0}
           borderRight={null}
           flex={1}
           alignSelf="stretch"
+          cursor={disabled ? 'default' : 'pointer'}
         >
           {label}
         </TextTableCell>

--- a/src/select-menu/src/OptionShapePropType.js
+++ b/src/select-menu/src/OptionShapePropType.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 const OptionShapePropType = PropTypes.shape({
   label: PropTypes.string,
   labelInList: PropTypes.string, // Optional
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  disabled: PropTypes.bool // Optional
 })
 
 export default OptionShapePropType

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -269,7 +269,8 @@ export default class OptionsList extends PureComponent {
                 onSelect: () => this.handleSelect(item),
                 onDeselect: () => this.handleDeselect(item),
                 isSelectable: !isSelected || isMultiSelect,
-                isSelected
+                isSelected,
+                disabled: item.disabled
               })
             }}
           />

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -39,6 +39,7 @@ export default class OptionsList extends PureComponent {
     selected: PropTypes.arrayOf(PropTypes.string),
     onSelect: PropTypes.func,
     onDeselect: PropTypes.func,
+    onFilterChange: PropTypes.func,
     hasFilter: PropTypes.bool,
     optionSize: PropTypes.number,
     renderItem: PropTypes.func,
@@ -57,6 +58,7 @@ export default class OptionsList extends PureComponent {
     optionSize: 33,
     onSelect: () => {},
     onDeselect: () => {},
+    onFilterChange: () => {},
     selected: [],
     renderItem: itemRenderer,
     optionsFilter: fuzzyFilter,
@@ -187,6 +189,7 @@ export default class OptionsList extends PureComponent {
     this.setState({
       searchValue
     })
+    this.props.onFilterChange(searchValue)
   }
 
   handleSelect = item => {

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -61,6 +61,11 @@ export default class SelectMenu extends PureComponent {
     hasFilter: PropTypes.bool,
 
     /**
+     * Function that is called as the onChange() event for the filter.
+     */
+    onFilterChange: PropTypes.func,
+
+    /**
      * The position of the Select Menu.
      */
     position: PropTypes.oneOf([
@@ -160,6 +165,7 @@ export default class SelectMenu extends PureComponent {
               onDeselect: item => {
                 this.props.onDeselect(item)
               },
+              onFilterChange: this.props.onFilterChange,
               selected: arrify(selected)
             }}
             close={close}

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -5,6 +5,7 @@ import Box from 'ui-box'
 import { SelectMenu } from '..'
 import { Button } from '../../buttons'
 import { Text } from '../../typography'
+import { Pane } from '../../layers'
 import options from './starwars-options'
 import Manager from './Manager'
 
@@ -24,6 +25,22 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
         >
           <Button>{state.selected || 'Select name...'}</Button>
         </SelectMenu>
+      )}
+    </Manager>
+    <Manager>
+      {({ setState, state }) => (
+        <Pane display="inline-block">
+          <Text display="block">Filter Text: {state.filterText}</Text>
+          <SelectMenu
+            title="Select name"
+            options={options}
+            selected={state.selected}
+            onFilterChange={filterText => setState({ filterText })}
+            onSelect={item => setState({ selected: item.value })}
+          >
+            <Button>Select w/ onFilterChange</Button>
+          </SelectMenu>
+        </Pane>
       )}
     </Manager>
     <Component


### PR DESCRIPTION
This PR:
- Adds `onFilterChange` to the `SelectMenu` component so users can access the filter value. 
- Adds a `disabled` prop to options for disabling certain options in the `SelectMenu`

Example of disabled option:
![disabled](https://user-images.githubusercontent.com/31225471/50864628-7f47b880-1357-11e9-95c9-f54f1010072e.gif)

