### PR TITLE
Add a disabled and isLoading state to ComboBox

### DIFF
--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -64,12 +64,24 @@ export default class Combobox extends PureComponent {
     /**
      * Properties forwarded to the autocomplete component. Use with caution.
      */
-    autocompleteProps: PropTypes.object
+    autocompleteProps: PropTypes.object,
+
+    /**
+     * Makes the input element disabled.
+     */
+    disabled: PropTypes.bool,
+
+    /**
+     * When true, show a loading spinner. This also disables the button.
+     */
+    isLoading: PropTypes.bool
   }
 
   static defaultProps = {
     width: 240,
-    openOnFocus: false
+    openOnFocus: false,
+    disabled: false,
+    isLoading: false
   }
 
   constructor(props, context) {
@@ -101,8 +113,11 @@ export default class Combobox extends PureComponent {
       buttonProps,
       openOnFocus,
       autocompleteProps,
+      isLoading,
       ...props
     } = this.props
+
+    const disabled = props.disabled || isLoading
 
     return (
       <Autocomplete
@@ -137,6 +152,7 @@ export default class Combobox extends PureComponent {
               value={inputValue}
               borderTopRightRadius={0}
               borderBottomRightRadius={0}
+              disabled={disabled}
               {...getInputProps({
                 ...inputProps,
                 placeholder,
@@ -159,14 +175,16 @@ export default class Combobox extends PureComponent {
             <IconButton
               iconAim="down"
               color="muted"
-              icon="caret-down"
+              icon={isLoading ? '' : 'caret-down'}
               appearance="default"
               height={height}
               marginLeft={-1}
-              paddingLeft={0}
+              paddingLeft={isLoading ? 12 : 0}
               paddingRight={0}
               borderTopLeftRadius={0}
               borderBottomLeftRadius={0}
+              disabled={disabled}
+              isLoading={isLoading}
               {...getButtonProps({
                 ...buttonProps,
                 onClick: () => {

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -65,6 +65,14 @@ storiesOf('combobox', module).add('Combobox', () => (
         onChange={handleChange}
       />
     </Box>
+    <Box marginBottom={16}>
+      <Heading>Disabled usage</Heading>
+      <Combobox items={items} onChange={handleChange} disabled />
+    </Box>
+    <Box marginBottom={16}>
+      <Heading>Loading usage</Heading>
+      <Combobox items={items} onChange={handleChange} isLoading />
+    </Box>
 
     <Box marginBottom={16}>
       <Heading>Full width combobox</Heading>


### PR DESCRIPTION
This PR adds a `disabled` and `isLoading` state to `ComboBox`. This is useful when items must be fetched to display in a `ComboBox`, or when a user cannot yet select a value from the `ComboBox`.

| Default | Disabled | Loading |
| ------- | -------- | ------- |
| ![Default](https://user-images.githubusercontent.com/2907397/51444586-227cc400-1cae-11e9-9bf7-11b76c1d614b.png) | ![Disabled](https://user-images.githubusercontent.com/2907397/51444591-345e6700-1cae-11e9-828b-9b89e145895a.png) | ![image](https://user-images.githubusercontent.com/2907397/51444598-50fa9f00-1cae-11e9-8aee-b812e0ac9bae.png) |

