### PR TITLE
Add autoFocus prop for EditableCell

### DIFF
--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -54,7 +54,8 @@ class EditableCell extends React.PureComponent {
 
   static defaultProps = {
     size: 300,
-    isSelectable: true
+    isSelectable: true,
+    autoFocus: false
   }
 
   static getDerivedStateFromProps(props, state) {

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -44,7 +44,12 @@ class EditableCell extends React.PureComponent {
     /**
      * Function called when value changes. (value: string) => void.
      */
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+
+    /**
+     * When true, the cell will initialize in the editing state.
+     */
+    autoFocus: PropTypes.bool
   }
 
   static defaultProps = {
@@ -62,7 +67,8 @@ class EditableCell extends React.PureComponent {
   }
 
   state = {
-    value: this.props.children
+    value: this.props.children,
+    isEditing: this.props.autoFocus
   }
 
   onMainRef = ref => {

--- a/src/table/stories/EditableTable.js
+++ b/src/table/stories/EditableTable.js
@@ -131,6 +131,7 @@ export default class EditableTable extends React.PureComponent {
                           <Table.EditableCell
                             isSelectable={this.state.isSelectable}
                             borderRight="muted"
+                            autoFocus={user.id === 1} // Example condition
                             onChange={this.handleChange.bind(
                               null,
                               user.id,


### PR DESCRIPTION
# What's in this PR?

This PR adds an `autoFocus` prop to the EditableCell component. When `autoFocus` is true the EditableCell will initialize with it's `isEditing` state set to true. The purpose of this is to allow this component to initialize in an editable state, so the user can immediately start typing into the cell.

##### Example:
![2019-01-23 16 07 04](https://user-images.githubusercontent.com/8645285/51646064-e2c31000-1f2b-11e9-888b-8e9aee441d64.gif)


