### PR TITLE
Add missing letterSpacing prop to 200 heading

### DIFF
--- a/src/theme/src/default-theme/typography/headings.js
+++ b/src/theme/src/default-theme/typography/headings.js
@@ -81,6 +81,7 @@ export default {
     fontSize: '12px',
     fontWeight: 600,
     lineHeight: '16px',
+    letterSpacing: '0',
     marginTop: 16,
     fontFamily: fontFamilies.ui,
     color: colors.text.muted


### PR DESCRIPTION
This PR Fixes _#479 Heading 200 doesn't have Letter spacing_

This is my first PR. I finished this PR in the following order.

1. fork it
2. create a new branch named "fix-heading-200-style"
3. change the heading 200 theme
4. run the doc to see if it is correct

I think the missing value is letterSpacing: '0'. It is different from the heading 300 just in color.

### before change
![image](https://user-images.githubusercontent.com/10218146/51450106-48679e80-1d6a-11e9-8925-4941d25c21f3.png)

### after change
![image](https://user-images.githubusercontent.com/10218146/51658792-3002b880-1fe4-11e9-8e52-cfeacb9832a6.png)

