### PR TITLE
Add tab handling to EditableCell

### DIFF
--- a/src/table/src/EditableCellField.js
+++ b/src/table/src/EditableCellField.js
@@ -140,12 +140,20 @@ export default class EditableCellField extends React.PureComponent {
   }
 
   handleKeyDown = e => {
-    const { key } = e
-    if (key === 'Escape') {
-      this.props.onCancel()
-    } else if (key === 'Enter') {
-      this.textareaRef.blur()
-      e.preventDefault()
+    switch (e.key) {
+      case 'Escape':
+        this.props.onCancel()
+        this.textareaRef.blur()
+        break
+      case 'Enter':
+        this.textareaRef.blur()
+        e.preventDefault()
+        break
+      case 'Tab':
+        this.textareaRef.blur()
+        break
+      default:
+        break
     }
   }
 


### PR DESCRIPTION
# What's in this PR?

This PR adds handling for a Tab key down event for the EditableCell component. It also blurs the EditableCell when an Escape key down event occurs (previously focus was being lost when an Escape key down occurred)

This is a fix for [SCH-1491 - Hitting tab from cell edit field bumps user to URL bar](https://segment.atlassian.net/browse/SCH-1491)

Example of Tab when EditableCell is active:
![2019-01-28 12 16 56](https://user-images.githubusercontent.com/8645285/51863740-aceca580-22f6-11e9-8cb8-fa215ae3f1ea.gif)

Example of Escape when EditableCell is active:
![2019-01-28 12 22 10](https://user-images.githubusercontent.com/8645285/51864063-8aa75780-22f7-11e9-89ac-f5312db0780e.gif)

