### PR TITLE
Fix empty title view in <SelectMenu> when it should be hidden

### DIFF
--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -98,7 +98,7 @@ export default class SelectMenuContent extends PureComponent {
           flexDirection="column"
           borderRight={hasDetailView ? 'muted' : null}
         >
-          {titleView({ close, title, headerHeight })}
+          {hasTitle && titleView({ close, title, headerHeight })}
           {options.length === 0 && hasEmptyView ? (
             <Pane height={optionsListHeight}>{emptyView}</Pane>
           ) : (


### PR DESCRIPTION
Fixes regression after recent <SelectMenu> changes, which could cause this empty title view and hide part of the options, when `hasTitle={false}`.
<img width="264" alt="cleanshot 2019-01-29 at 11 02 55 2x" src="https://user-images.githubusercontent.com/697676/51933122-76299480-23b5-11e9-8675-9fadf7669524.png">