### PR TITLE
Make disabled EditableCells selectable

### DIFF
--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -151,7 +151,7 @@ class EditableCell extends React.PureComponent {
       <React.Fragment>
         <TextTableCell
           innerRef={this.onMainRef}
-          isSelectable={isSelectable && !disabled}
+          isSelectable={isSelectable}
           onClick={this.handleClick}
           onDoubleClick={this.handleDoubleClick}
           onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
# What's in this PR?

This PR removes the disabled check in the isSelectable conditional for `EditableCell`, making it optional for a disabled `EditableCell` to be selectable or not.