### PR TITLE
Docs(Badge): remove prop description about automatic color

### DIFF
--- a/src/badges/src/Badge.js
+++ b/src/badges/src/Badge.js
@@ -10,7 +10,6 @@ class Badge extends PureComponent {
 
     /**
      * The color used for the badge.
-     * When the value is `automatic`, use the hash function to determine the color.
      */
     color: PropTypes.string.isRequired,
 


### PR DESCRIPTION
Addresses issue: #476 

Description: 
Badge doesn't have hashValue or fallback to default value to use in hash function like Avatar component when prop `color='automatic'` is set. It might be good to remove it from documentation for now so it doesn't confuse anyone.
