### PR TITLE
Fix onChange in SearchHeaderCell Docs

### DIFF
--- a/docs/src/pages/components/table.mdx
+++ b/docs/src/pages/components/table.mdx
@@ -212,7 +212,7 @@ This can be used as a base to build more complex table cells.
 ```jsx
 <Table.Head>
   <Table.SearchHeaderCell
-    onChange={e => console.log(e.target.value)}
+    onChange={value => console.log(value)}
     placeholder='Search by email...'
   />
 </Table.Head>


### PR DESCRIPTION
`Table.SearchHeaderCell`'s `onChange` handler provides the raw value, rather than the event: https://github.com/segmentio/evergreen/blob/93ae937ff275690bab9641f92a4c4f806ed92a79/src/table/src/SearchTableHeaderCell.js#L88