### PR TITLE
Register first keydown on the editableCell component

### DIFF
--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -60,8 +60,13 @@ class EditableCell extends React.PureComponent {
 
   static getDerivedStateFromProps(props, state) {
     if (props.children !== state.value) {
+      if (state.value !== '') {
+        return {
+          value: props.children
+        }
+      }
       return {
-        value: props.children
+        value: state.value
       }
     }
     return null

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -59,14 +59,15 @@ class EditableCell extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
+    console.log(props.children)
     if (props.children !== state.value) {
-      if (state.value !== '') {
+      if (state.value !== '' && props.children === '') {
         return {
-          value: props.children
+          value: state.value
         }
       }
       return {
-        value: state.value
+        value: props.children
       }
     }
     return null
@@ -106,7 +107,7 @@ class EditableCell extends React.PureComponent {
         isEditing: true,
         value: key
       })
-    } else if (key === 'Enter') {
+    } else if (key === 'Enter' || key === 'Shift') {
       this.setState({
         isEditing: true
       })

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -58,20 +58,6 @@ class EditableCell extends React.PureComponent {
     autoFocus: false
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (props.children !== state.value) {
-      if (state.value !== '' && props.children === '') {
-        return {
-          value: state.value
-        }
-      }
-      return {
-        value: props.children
-      }
-    }
-    return null
-  }
-
   state = {
     value: this.props.children,
     isEditing: this.props.autoFocus
@@ -102,10 +88,10 @@ class EditableCell extends React.PureComponent {
      * as the value in the text field.
      */
     if (key.match(/^[a-z]{0,10}$/) && !e.metaKey && !e.ctrlKey && !e.altKey) {
-      this.setState({
+      this.setState(prevState => ({
         isEditing: true,
-        value: key
-      })
+        value: prevState.value + key
+      }))
     } else if (key === 'Enter' || key === 'Shift') {
       this.setState({
         isEditing: true
@@ -115,16 +101,13 @@ class EditableCell extends React.PureComponent {
 
   handleFieldChangeComplete = value => {
     const { onChange, isSelectable } = this.props
-    const currentValue = this.state.value
 
     this.setState({
       isEditing: false,
       value
     })
 
-    if (currentValue !== value) {
-      safeInvoke(onChange, value)
-    }
+    safeInvoke(onChange, value)
 
     if (this.mainRef && isSelectable) {
       this.mainRef.focus()

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -87,15 +87,20 @@ class EditableCell extends React.PureComponent {
      * When the user presses a character on the keyboard, use that character
      * as the value in the text field.
      */
-    if (key.match(/^[a-z]{0,10}$/) && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    if (key === 'Enter' || key === 'Shift' || this.state.value !== '') {
+      this.setState({
+        isEditing: true
+      })
+    } else if (
+      key.match(/^[a-z]{0,10}$/) &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey
+    ) {
       this.setState(prevState => ({
         isEditing: true,
         value: prevState.value + key
       }))
-    } else if (key === 'Enter' || key === 'Shift') {
-      this.setState({
-        isEditing: true
-      })
     }
   }
 

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -87,7 +87,7 @@ class EditableCell extends React.PureComponent {
      * When the user presses a character on the keyboard, use that character
      * as the value in the text field.
      */
-    if (key === 'Enter' || key === 'Shift' || this.state.value !== '') {
+    if (key === 'Enter' || key === 'Shift') {
       this.setState({
         isEditing: true
       })

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -59,7 +59,6 @@ class EditableCell extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
-    console.log(props.children)
     if (props.children !== state.value) {
       if (state.value !== '' && props.children === '') {
         return {


### PR DESCRIPTION
When using the `editableCell`, on the first keydown the key value isn’t being set to state, and so requires 2 key presses to register the key value:
![master](https://user-images.githubusercontent.com/34897995/52293876-c0b68e00-292c-11e9-9e6a-32868aa2a551.gif)

Functionality changes made in this PR:
- The first keydown value is registered, value is appended to cell
- Capital letters are registered on keydown

![feb-11-2019 13-38-12](https://user-images.githubusercontent.com/34897995/52595268-54db9600-2e02-11e9-9ca3-f301ed3141ef.gif)
