### PR TITLE
Fix TextTableHeaderCell textProps PropType

### DIFF
--- a/src/table/src/TextTableHeaderCell.js
+++ b/src/table/src/TextTableHeaderCell.js
@@ -13,7 +13,7 @@ export default class TextTableHeaderCell extends PureComponent {
     /**
      * Pass additional props to the Text component.
      */
-    textProps: PropTypes.objectOf(PropTypes.object)
+    textProps: PropTypes.objectOf(PropTypes.string)
   }
 
   render() {


### PR DESCRIPTION
From the PropTypes docs:

```
// An object with property values of a certain type
optionalObjectOf: PropTypes.objectOf(PropTypes.number),
```