### PR TITLE
Fix Button whitespace so text does not wrap

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -177,6 +177,7 @@ class Button extends PureComponent {
         color={null} // Prevent the Text color overriding the glamor appearanceStyle color
         height={height}
         lineHeight={`${height}px`}
+        whiteSpace="nowrap"
         {...(isActive ? { 'data-active': true } : {})}
         {...Button.styles}
         {...props}


### PR DESCRIPTION
I'm not sure if there are any current use-cases where you'd want wrapping but figured I'd send over a PR if it was an oversight! Easy enough to add in any case.

<img width="161" alt="screen shot 2019-02-06 at 6 43 28 pm" src="https://user-images.githubusercontent.com/25254/52365673-eb453b80-2a3f-11e9-9f8f-88ed93381f71.png">
