### PR TITLE
Allow SelectMenuContent to have editable placeholder icon & value

### DIFF
--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -334,4 +334,31 @@ This example shows how one should use titleView to pass in a custom title.
 </Component>
 ```
 
+## Custom Filter PlaceHolder and Icon Example
+
+It's possible to change the filter placeholder and filter icon through the `filterPlaceholder` and `filterIcon` props.
+
+Note that the icon can be one found in Segment's various [icons](https://evergreen.segment.com/components/icons), or `none`.
+
+
+```jsx
+<Component initialState={{ selected: null }}>
+  {({ setState, state }) => (
+    <SelectMenu
+      title="Select name"
+      options={
+        ['Comedy', 'Drama', 'Fantasy', 'Family', 'Action']
+          .map(label => ({ label, value: label }))
+      }
+      selected={state.selected}
+      onSelect={item => setState({ selected: item.value })}
+      filterPlaceholder={"Choose a genre"}
+      filterIcon={"film"}
+    >
+      <Button>{state.selected || 'Select name...'}</Button>
+    </SelectMenu>
+  )}
+</Component>
+```
+
 <PropsTable of="SelectMenu" />

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -43,7 +43,8 @@ export default class OptionsList extends PureComponent {
     hasFilter: PropTypes.bool,
     optionSize: PropTypes.number,
     renderItem: PropTypes.func,
-    placeholder: PropTypes.string,
+    filterPlaceholder: PropTypes.string,
+    filterIcon: PropTypes.string,
     optionsFilter: PropTypes.func,
     defaultSearchValue: PropTypes.string
   }
@@ -62,7 +63,8 @@ export default class OptionsList extends PureComponent {
     selected: [],
     renderItem: itemRenderer,
     optionsFilter: fuzzyFilter,
-    placeholder: 'Filter...',
+    filterPlaceholder: 'Filter...',
+    filterIcon: 'search',
     defaultSearchValue: ''
   }
 
@@ -215,6 +217,8 @@ export default class OptionsList extends PureComponent {
       onFilterChange,
       selected,
       hasFilter,
+      filterPlaceholder,
+      filterIcon,
       optionSize,
       renderItem,
       placeholder,
@@ -243,6 +247,8 @@ export default class OptionsList extends PureComponent {
               innerRef={this.assignSearchRef}
               borderRight={null}
               height={32}
+              placeholder={filterPlaceholder}
+              icon={filterIcon}
             />
           </TableHead>
         )}

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -221,7 +221,6 @@ export default class OptionsList extends PureComponent {
       filterIcon,
       optionSize,
       renderItem,
-      placeholder,
       optionsFilter,
       isMultiSelect,
       defaultSearchValue,

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -114,7 +114,9 @@ export default class SelectMenu extends PureComponent {
     width: 240,
     height: 248,
     position: Position.BOTTOM_LEFT,
-    isMultiSelect: false
+    isMultiSelect: false,
+    filterPlaceholder: 'Filter...',
+    filterIcon: 'search'
   }
 
   getDetailView = (close, detailView) => {

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -61,6 +61,16 @@ export default class SelectMenu extends PureComponent {
     hasFilter: PropTypes.bool,
 
     /**
+     * When true, show the filter.
+     */
+    filterPlaceholder: PropTypes.string,
+
+    /**
+     * When true, show the filter.
+     */
+    filterIcon: PropTypes.string,
+
+    /**
      * Function that is called as the onChange() event for the filter.
      */
     onFilterChange: PropTypes.func,
@@ -145,6 +155,8 @@ export default class SelectMenu extends PureComponent {
       position,
       hasTitle,
       hasFilter,
+      filterPlaceholder,
+      filterIcon,
       detailView,
       emptyView,
       titleView,
@@ -164,6 +176,8 @@ export default class SelectMenu extends PureComponent {
             options={options}
             title={title}
             hasFilter={hasFilter}
+            filterPlaceholder={filterPlaceholder}
+            filterIcon={filterIcon}
             hasTitle={hasTitle}
             isMultiSelect={isMultiSelect}
             titleView={titleView}

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -61,12 +61,12 @@ export default class SelectMenu extends PureComponent {
     hasFilter: PropTypes.bool,
 
     /**
-     * When true, show the filter.
+     * The placeholder of the search filter.
      */
     filterPlaceholder: PropTypes.string,
 
     /**
-     * When true, show the filter.
+     * The icon of the search filter.
      */
     filterIcon: PropTypes.string,
 

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -77,6 +77,8 @@ export default class SelectMenuContent extends PureComponent {
       options,
       hasTitle,
       hasFilter,
+      filterPlaceholder,
+      filterIcon,
       close,
       listProps,
       titleView,
@@ -107,6 +109,8 @@ export default class SelectMenuContent extends PureComponent {
             <OptionsList
               height={optionsListHeight}
               hasFilter={hasFilter}
+              filterPlaceholder={filterPlaceholder}
+              filterIcon={filterIcon}
               options={options}
               isMultiSelect={isMultiSelect}
               close={close}

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -37,6 +37,8 @@ export default class SelectMenuContent extends PureComponent {
     options: PropTypes.arrayOf(OptionShapePropType),
     hasTitle: PropTypes.bool,
     hasFilter: PropTypes.bool,
+    filterPlaceholder: PropTypes.string,
+    filterIcon: PropTypes.string,
     listProps: PropTypes.shape(OptionsList.propTypes),
 
     /**

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -6,6 +6,7 @@ import { SelectMenu } from '..'
 import { Button } from '../../buttons'
 import { Text } from '../../typography'
 import { Pane } from '../../layers'
+import { TextInput } from '../../text-input'
 import options from './starwars-options'
 import Manager from './Manager'
 
@@ -39,6 +40,39 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
             onSelect={item => setState({ selected: item.value })}
           >
             <Button>Select w/ onFilterChange</Button>
+          </SelectMenu>
+        </Pane>
+      )}
+    </Manager>
+    <Manager>
+      {({ setState, state }) => (
+        <Pane display="block">
+          Filter Placeholder:{' '}
+          <TextInput
+            onChange={event =>
+              setState({ placeholderText: event.target.value })
+            }
+            width={100}
+            display="inline-block"
+          />
+          Icon:{' '}
+          <TextInput
+            onChange={event =>
+              setState({ placeholderIcon: event.target.value })
+            }
+            width={100}
+            display="inline-block"
+          />
+          <SelectMenu
+            title="Select w/ changeable filter placeholder and icon"
+            options={options}
+            selected={state.selected}
+            filterPlaceholder={state.placeholderText}
+            filterIcon={state.placeholderIcon}
+            onFilterChange={filterText => setState({ filterText })}
+            onSelect={item => setState({ selected: item.value })}
+          >
+            <Button>Select w/ changeable filter placeholder and icon</Button>
           </SelectMenu>
         </Pane>
       )}

--- a/src/table/src/SearchTableHeaderCell.js
+++ b/src/table/src/SearchTableHeaderCell.js
@@ -50,7 +50,12 @@ export default class SearchTableHeaderCell extends PureComponent {
     /**
      * Text to display in the input if the input is empty.
      */
-    placeholder: PropTypes.string
+    placeholder: PropTypes.string,
+
+    /**
+     * Icon to display in the input.
+     */
+    icon: PropTypes.string
   }
 
   static defaultProps = {

--- a/src/table/src/SearchTableHeaderCell.js
+++ b/src/table/src/SearchTableHeaderCell.js
@@ -56,7 +56,8 @@ export default class SearchTableHeaderCell extends PureComponent {
   static defaultProps = {
     onChange: () => {},
     spellCheck: true,
-    placeholder: 'Filter...'
+    placeholder: 'Filter...',
+    icon: 'search'
   }
 
   render() {
@@ -67,13 +68,14 @@ export default class SearchTableHeaderCell extends PureComponent {
       autoFocus,
       spellCheck,
       placeholder,
+      icon,
       ...props
     } = this.props
 
     return (
       <TableHeaderCell {...props}>
         <Icon
-          icon="search"
+          icon={icon}
           color="muted"
           marginLeft={2}
           marginRight={10}


### PR DESCRIPTION
Previously, the `SelectMenuContent` component had a placeholder that could not be accessed through its props This change proposes to allow the filter placeholder to be editable through props. 

This feature is also added to the Storybook so users can actively edit the new props being passed in.

**Default values are still the same:**
<img width="693" alt="screen shot 2019-02-07 at 5 07 39 pm" src="https://user-images.githubusercontent.com/34897995/52453185-088b1000-2afb-11e9-8a9c-364c0231b8ff.png">


**With the placeholder text changed:**
<img width="692" alt="screen shot 2019-02-07 at 5 07 55 pm" src="https://user-images.githubusercontent.com/34897995/52453209-2193c100-2afb-11e9-9245-a553792d15f2.png">


**With the placeholder icon gone:**
<img width="692" alt="screen shot 2019-02-07 at 5 08 08 pm" src="https://user-images.githubusercontent.com/34897995/52453217-28bacf00-2afb-11e9-93c0-f7f89524509b.png">


**With the placeholder icon changed:**
<img width="694" alt="screen shot 2019-02-07 at 5 08 28 pm" src="https://user-images.githubusercontent.com/34897995/52453222-2fe1dd00-2afb-11e9-91bf-64f5d026bd5d.png">

**Documentation:**
<img width="820" alt="screen shot 2019-02-12 at 2 15 04 pm" src="https://user-images.githubusercontent.com/34897995/52671712-a8b4b080-2ed0-11e9-9cd5-2fbde4dc052b.png">
<img width="476" alt="screen shot 2019-02-12 at 2 20 00 pm" src="https://user-images.githubusercontent.com/34897995/52672002-62138600-2ed1-11e9-944f-4e8fd93d8d56.png">
