### PR TITLE
Fix AdvancedTable string-type column sorting.

### DIFF
--- a/docs/src/components/examples/AdvancedTable.js
+++ b/docs/src/components/examples/AdvancedTable.js
@@ -61,13 +61,16 @@ export default class AdvancedTable extends React.Component {
         bValue = Number(bValue.substr(1))
       }
 
+      // Support string comparison
+      const sortTable = { true: 1, false: -1 }
+
       // Order ascending (Order.ASC)
       if (this.state.ordering === Order.ASC) {
-        return aValue - bValue
+        return aValue === bValue ? 0 : sortTable[aValue > bValue]
       }
 
       // Order descending (Order.DESC)
-      return bValue - aValue
+      return bValue === aValue ? 0 : sortTable[bValue > aValue]
     })
   }
 

--- a/src/table/stories/AdvancedTable.js
+++ b/src/table/stories/AdvancedTable.js
@@ -56,13 +56,16 @@ export default class AdvancedTable extends React.Component {
         bValue = Number(bValue.substr(1))
       }
 
+      // Support string comparison
+      const sortTable = { true: 1, false: -1 }
+
       // Order ascending (Order.ASC)
       if (this.state.ordering === Order.ASC) {
-        return aValue - bValue
+        return aValue === bValue ? 0 : sortTable[aValue > bValue]
       }
 
       // Order descending (Order.DESC)
-      return bValue - aValue
+      return bValue === aValue ? 0 : sortTable[bValue > aValue]
     })
   }
 


### PR DESCRIPTION
Previously, sorting by `email` in [AdvancedTable](https://evergreen.segment.com/components/table/) was not supported. This commit enables string-type and number-type comparison.