### PR TITLE
Add a better explanation of the validation message

### DIFF
--- a/docs/src/pages/components/select.mdx
+++ b/docs/src/pages/components/select.mdx
@@ -129,6 +129,21 @@ Anytime you would reach for a native select, use this.
 </SelectField>
 ```
 
+## Validation message without invalid input
+
+```jsx
+<SelectField
+  isInvalid={false}
+  required
+  label="A required text input field"
+  description="This is a description."
+  validationMessage="This field is required"
+>
+  <option value="foo" checked>Foo</option>
+  <option value="bar">Bar</option>
+</SelectField>
+```
+
 ## Controlled usage
 
 The `SelectField` component works the same as using `input` directly.

--- a/docs/src/pages/components/text-input.mdx
+++ b/docs/src/pages/components/text-input.mdx
@@ -121,6 +121,18 @@ The `TextInputField` component combines a `TextInput` with a label and optional
 />
 ```
 
+## Validation message without invalid input
+
+```jsx
+<TextInputField
+  isInvalid={false}
+  required
+  label="A required text input field"
+  description="This is a description."
+  validationMessage="This field is required"
+/>
+```
+
 ## Controlled usage
 
 The `TextInputField` component works the same as using `input` directly.

--- a/src/form-field/src/FormField.js
+++ b/src/form-field/src/FormField.js
@@ -35,7 +35,7 @@ export default class FormField extends PureComponent {
 
     /**
      * If a validation message is passed it is shown under the input element
-     * and above the hint. This is uneffected by `isInvalid`.
+     * and above the hint. This is unaffected by `isInvalid`.
      */
     validationMessage: PropTypes.node,
 

--- a/src/form-field/src/FormField.js
+++ b/src/form-field/src/FormField.js
@@ -35,7 +35,7 @@ export default class FormField extends PureComponent {
 
     /**
      * If a validation message is passed it is shown under the input element
-     * and above the hint.
+     * and above the hint. This is uneffected by `isInvalid`.
      */
     validationMessage: PropTypes.node,
 

--- a/src/select/src/SelectField.js
+++ b/src/select/src/SelectField.js
@@ -41,7 +41,7 @@ export default class TextInputField extends PureComponent {
 
     /**
      * If a validation message is passed it is shown under the input element
-     * and above the hint.
+     * and above the hint. This is uneffected by `isInvalid`.
      */
     validationMessage: PropTypes.node,
 

--- a/src/select/src/SelectField.js
+++ b/src/select/src/SelectField.js
@@ -41,7 +41,7 @@ export default class TextInputField extends PureComponent {
 
     /**
      * If a validation message is passed it is shown under the input element
-     * and above the hint. This is uneffected by `isInvalid`.
+     * and above the hint. This is unaffected by `isInvalid`.
      */
     validationMessage: PropTypes.node,
 

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -22,7 +22,8 @@ class TextInput extends PureComponent {
     disabled: PropTypes.bool,
 
     /**
-     * Sets visual styling to be invalid.
+     * Sets visual styling of _only_ the text input to be "invalid". 
+     * Note that this does not effect any `validationMessage`.
      */
     isInvalid: PropTypes.bool,
 

--- a/src/text-input/src/TextInputField.js
+++ b/src/text-input/src/TextInputField.js
@@ -41,7 +41,7 @@ export default class TextInputField extends PureComponent {
 
     /**
      * If a validation message is passed it is shown under the input element
-     * and above the hint.
+     * and above the hint. This is uneffected by `isInvalid`.
      */
     validationMessage: PropTypes.node,
 

--- a/src/text-input/src/TextInputField.js
+++ b/src/text-input/src/TextInputField.js
@@ -41,7 +41,7 @@ export default class TextInputField extends PureComponent {
 
     /**
      * If a validation message is passed it is shown under the input element
-     * and above the hint. This is uneffected by `isInvalid`.
+     * and above the hint. This is unaffected by `isInvalid`.
      */
     validationMessage: PropTypes.node,
 

--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -22,7 +22,8 @@ class Textarea extends PureComponent {
     disabled: PropTypes.bool,
 
     /**
-     * Sets visual styling to be invalid.
+     * Sets visual styling of _only_ the text area to be "invalid". 
+     * Note that this does not effect any `validationMessage`.
      */
     isInvalid: PropTypes.bool,
 


### PR DESCRIPTION
# Overview

The `isInvalid` and `validationMessage` is quite confusing and currently is shown in our docs and examples as if they were connected. 

To help resolve this confusion, this PR does two things:
* Adds examples of usage where `isInvalid={false}` and a validation message is shown.
* Adds explicit callouts and warnings in the descriptions of the props.