### PR TITLE
Fix `statelessProps` propTypes

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -57,7 +57,7 @@ export default class Popover extends Component {
     /**
      * Properties passed through to the Popover card.
      */
-    statelessProps: PropTypes.objectOf(PopoverStateless.propTypes),
+    statelessProps: PropTypes.shape(PopoverStateless.propTypes),
 
     /**
      * Duration of the animation.


### PR DESCRIPTION
This fixes #510 and #497, enabling passing properties to the popover container.

I wonder though, why `statelessProps` property has different name than Dialog's `containerProps`. The `containerProps` seems to be more natural/intuitive.

@rywall @mshwery @Flaque 