### PR TITLE
migrate off deprecated lifecycle method to componentDidUpdate

### DIFF
--- a/src/table/src/ScrollbarSize.js
+++ b/src/table/src/ScrollbarSize.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unused-state */
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
@@ -28,10 +27,10 @@ export default class ScrollbarSize extends PureComponent {
     })
   }
 
-  componentWillUpdate(nextProps, nextState) {
-    if (nextState.innerWidth && nextState.outerWidth) {
+  componentDidUpdate() {
+    if (this.state.innerWidth && this.state.outerWidth) {
       this.props.handleScrollbarSize(
-        nextState.outerWidth - nextState.innerWidth
+        this.state.outerWidth - this.state.innerWidth
       )
     }
   }


### PR DESCRIPTION
This is the last lifecycle method we need to migrate off of per #386 .

Closes #386 