### PR TITLE
Add documentation for using buttons as links

### DIFF
--- a/docs/src/pages/components/button.mdx
+++ b/docs/src/pages/components/button.mdx
@@ -398,6 +398,14 @@ The `BackButton` component is a preset based on the `Button` component.
 
 <PropsTable of="BackButton" />
 
+# Buttons as links
+
+Buttons can be used as links by using the optional `is` property with a value such as `ReactRouterLink` from [react-router](https://github.com/ReactTraining/react-router), or `a`.
+
+```jsx
+<Button is="a" href="#">Link</Button>
+```
+
 # TextDropdownButton component
 
 The `TextDropdownButton` is different from the other types of buttons.

--- a/docs/src/pages/components/button.mdx
+++ b/docs/src/pages/components/button.mdx
@@ -400,7 +400,7 @@ The `BackButton` component is a preset based on the `Button` component.
 
 # Buttons as links
 
-Buttons can be used as links by using the optional `is` property with a value such as `ReactRouterLink` from [react-router](https://github.com/ReactTraining/react-router), or `a`.
+Buttons can be used as links by using the optional `is` property with a value such as `Link` from [react-router](https://github.com/ReactTraining/react-router), or an `a` tag.
 
 ```jsx
 <Button is="a" href="#">Link</Button>


### PR DESCRIPTION
# What's in this PR? 

This PR adds a small section to the Evergreen button documentation page: https://evergreen.segment.com/components/button explaining best practices for using the Button component as a link.

Open to feedback on phrasing, or whether to go into more or less depth.

<img width="809" alt="Screen Shot 2019-03-11 at 5 45 58 PM" src="https://user-images.githubusercontent.com/8645285/54167160-9b360c00-4425-11e9-99a3-6ff3665f5007.png">
