### PR TITLE
Revert "Scroll combobox to highlighted item (#499)"

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -212,8 +212,8 @@ export default class Autocomplete extends PureComponent {
           inputValue,
           getItemProps,
           selectedItem,
-          selectItemAtIndex,
           highlightedIndex,
+          selectItemAtIndex,
           getRootProps,
           ...restDownshiftProps
         }) => (
@@ -234,9 +234,7 @@ export default class Autocomplete extends PureComponent {
                   inputValue,
                   getItemProps,
                   selectedItem,
-                  highlightedIndex: this.props.items.includes(selectedItem)
-                    ? this.props.items.indexOf(selectedItem)
-                    : 0,
+                  highlightedIndex,
                   selectItemAtIndex
                 })
               }}
@@ -254,9 +252,7 @@ export default class Autocomplete extends PureComponent {
                   },
                   inputValue,
                   selectedItem,
-                  highlightedIndex: this.props.items.includes(selectedItem)
-                    ? this.props.items.indexOf(selectedItem)
-                    : 0,
+                  highlightedIndex,
                   selectItemAtIndex,
                   ...restDownshiftProps
                 })


### PR DESCRIPTION
This reverts commit 38be9cc6e95342c57ea7803f666f8a13f33ce441 from #499.

highlightedIndex is a controlled prop, you cannot force it to be `0`.

This will revert the intended feature by @jongsue (scrolling to the selected item when opening the combo box), but this fixes all the broken highlights (and keyboard navigation) for all components depending on downshift.

I will open a PR that upgrades downshift and fixes this.