### PR TITLE
Upgrade downshift to 3.2.10 & highlight autocomplete’s selected item by default

### DIFF
--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -99,7 +99,7 @@ Get the `openMenu` prop to manually open the menu on certain events such as `onF
 >
   {({
     getInputProps,
-    getButtonProps,
+    getToggleButtonProps,
     getRef,
     inputValue,
     toggleMenu
@@ -110,7 +110,7 @@ Get the `openMenu` prop to manually open the menu on certain events such as `onF
         value={inputValue}
         {...getInputProps()}
       />
-      <Button onClick={toggleMenu} {...getButtonProps()}>
+      <Button onClick={toggleMenu} {...getToggleButtonProps()}>
         Trigger
       </Button>
     </Pane>
@@ -133,7 +133,7 @@ Consider using that component before using the `Autocomplete` component directly
   {({
     key,
     getInputProps,
-    getButtonProps,
+    getToggleButtonProps,
     getRef,
     inputValue,
     openMenu,
@@ -151,7 +151,7 @@ Consider using that component before using the `Autocomplete` component directly
         onFocus={openMenu}
         {...getInputProps()}
       />
-      <Button onClick={toggleMenu} {...getButtonProps()}>
+      <Button onClick={toggleMenu} {...getToggleButtonProps()}>
         Trigger
       </Button>
     </Pane>

--- a/docs/src/pages/components/combobox.mdx
+++ b/docs/src/pages/components/combobox.mdx
@@ -72,7 +72,7 @@ Typing in the text input will filter the list.
 
 ```jsx
 <Combobox
-  defaultSelectedItem={{ label: 'Banana' }}
+  initialSelectedItem={{ label: 'Banana' }}
   items={[{ label: 'Banana' }, { label: 'Pear' }, { label: 'Kiwi' }]}
   itemToString={item => item ? item.label : ''}
   onChange={selected => console.log(selected)}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.2.1",
-    "downshift": "^1.31.16",
+    "downshift": "^3.2.10",
     "fuzzaldrin-plus": "^0.6.0",
     "glamor": "^2.20.40",
     "lodash.debounce": "^4.0.8",

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -125,6 +125,22 @@ export default class Autocomplete extends PureComponent {
     })
   }
 
+  stateReducer = (state, changes) => {
+    const { items } = this.props
+
+    if (
+      Object.prototype.hasOwnProperty.call(changes, 'isOpen') &&
+      changes.isOpen
+    ) {
+      return {
+        ...changes,
+        highlightedIndex: items.indexOf(state.selectedItem)
+      }
+    }
+
+    return changes
+  }
+
   renderResults = ({
     width,
     inputValue,
@@ -206,7 +222,11 @@ export default class Autocomplete extends PureComponent {
     } = this.props
 
     return (
-      <Downshift initialSelectedItem={initialSelectedItem} {...props}>
+      <Downshift
+        initialSelectedItem={initialSelectedItem}
+        stateReducer={this.stateReducer}
+        {...props}
+      >
         {({
           isOpen: isShown,
           inputValue,

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -50,7 +50,7 @@ export default class Autocomplete extends PureComponent {
     /**
      * The selected item to be selected & shown by default on the autocomplete
      */
-    defaultSelectedItem: PropTypes.any,
+    initialSelectedItem: PropTypes.any,
 
     /**
      * In case the array of items is not an array of strings,
@@ -201,12 +201,12 @@ export default class Autocomplete extends PureComponent {
       itemsFilter,
       popoverMaxHeight,
       popoverMinWidth,
-      defaultSelectedItem,
+      initialSelectedItem,
       ...props
     } = this.props
 
     return (
-      <Downshift defaultSelectedItem={defaultSelectedItem} {...props}>
+      <Downshift initialSelectedItem={initialSelectedItem} {...props}>
         {({
           isOpen: isShown,
           inputValue,

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -53,6 +53,14 @@ export default class Autocomplete extends PureComponent {
     initialSelectedItem: PropTypes.any,
 
     /**
+     * The selected item to be selected & shown by default on the autocomplete (deprecated)
+     */
+    defaultSelectedItem: () =>
+      new Error(
+        `The 'defaultSelectedItem' prop is deprecated, use 'initialSelectedItem' instead`
+      ),
+
+    /**
      * In case the array of items is not an array of strings,
      * this function is used on each item to return the string that will be shown on the filter
      */
@@ -218,12 +226,13 @@ export default class Autocomplete extends PureComponent {
       popoverMaxHeight,
       popoverMinWidth,
       initialSelectedItem,
+      defaultSelectedItem,
       ...props
     } = this.props
 
     return (
       <Downshift
-        initialSelectedItem={initialSelectedItem}
+        initialSelectedItem={initialSelectedItem || defaultSelectedItem}
         stateReducer={this.stateReducer}
         {...props}
       >

--- a/src/autocomplete/stories/index.stories.js
+++ b/src/autocomplete/stories/index.stories.js
@@ -129,7 +129,7 @@ storiesOf('autocomplete', module).add('Autocomplete', () => (
       <Autocomplete onChange={handleChange} items={items}>
         {({
           getInputProps,
-          getButtonProps,
+          getToggleButtonProps,
           getRef,
           inputValue,
           toggleMenu
@@ -140,7 +140,7 @@ storiesOf('autocomplete', module).add('Autocomplete', () => (
               value={inputValue}
               {...getInputProps()}
             />
-            <Button onClick={toggleMenu} {...getButtonProps()}>
+            <Button onClick={toggleMenu} {...getToggleButtonProps()}>
               Trigger
             </Button>
           </Box>

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -41,6 +41,14 @@ export default class Combobox extends PureComponent {
     initialSelectedItem: PropTypes.any,
 
     /**
+     * Default selected item when uncontrolled (deprecated)
+     */
+    defaultSelectedItem: () =>
+      new Error(
+        `The 'defaultSelectedItem' prop is deprecated, use 'initialSelectedItem' instead`
+      ),
+
+    /**
      * The placeholder text when there is no value present.
      */
     placeholder: PropTypes.string,
@@ -104,6 +112,7 @@ export default class Combobox extends PureComponent {
       items,
       selectedItem,
       initialSelectedItem,
+      defaultSelectedItem,
       itemToString,
       width,
       height,
@@ -123,7 +132,7 @@ export default class Combobox extends PureComponent {
       <Autocomplete
         items={items}
         selectedItem={selectedItem}
-        initialSelectedItem={initialSelectedItem}
+        initialSelectedItem={initialSelectedItem || defaultSelectedItem}
         itemToString={itemToString}
         onChange={onChange}
         onStateChange={this.handleStateChange}

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -38,7 +38,7 @@ export default class Combobox extends PureComponent {
     /**
      * Default selected item when uncontrolled.
      */
-    defaultSelectedItem: PropTypes.any,
+    initialSelectedItem: PropTypes.any,
 
     /**
      * The placeholder text when there is no value present.
@@ -103,7 +103,7 @@ export default class Combobox extends PureComponent {
     const {
       items,
       selectedItem,
-      defaultSelectedItem,
+      initialSelectedItem,
       itemToString,
       width,
       height,
@@ -123,7 +123,7 @@ export default class Combobox extends PureComponent {
       <Autocomplete
         items={items}
         selectedItem={selectedItem}
-        defaultSelectedItem={defaultSelectedItem}
+        initialSelectedItem={initialSelectedItem}
         itemToString={itemToString}
         onChange={onChange}
         onStateChange={this.handleStateChange}
@@ -136,7 +136,7 @@ export default class Combobox extends PureComponent {
           openMenu,
           inputValue,
           getInputProps,
-          getButtonProps,
+          getToggleButtonProps,
           clearSelection
         }) => (
           <Box
@@ -186,7 +186,7 @@ export default class Combobox extends PureComponent {
               borderBottomLeftRadius={0}
               disabled={disabled}
               isLoading={isLoading}
-              {...getButtonProps({
+              {...getToggleButtonProps({
                 ...buttonProps,
                 onClick: () => {
                   if (!isShown) {

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -52,7 +52,7 @@ storiesOf('combobox', module).add('Combobox', () => (
     <Box marginBottom={16}>
       <Heading>Default value</Heading>
       <Combobox
-        defaultSelectedItem="Yoda"
+        initialSelectedItem="Yoda"
         items={items}
         onChange={handleChange}
       />
@@ -60,7 +60,7 @@ storiesOf('combobox', module).add('Combobox', () => (
     <Box marginBottom={16}>
       <Heading>Custom item objects</Heading>
       <Combobox
-        defaultSelectedItem={customItems[0]}
+        initialSelectedItem={customItems[0]}
         items={customItems}
         itemToString={i => (i ? i.label : '')}
         onChange={handleChange}
@@ -81,7 +81,7 @@ storiesOf('combobox', module).add('Combobox', () => (
       <Pane display="flex" background="tint1" padding={16}>
         <Combobox
           width="100%"
-          defaultSelectedItem={customItems[0]}
+          initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}
@@ -92,7 +92,7 @@ storiesOf('combobox', module).add('Combobox', () => (
       <Pane display="flex" background="tint2" width="75%" padding={16}>
         <Combobox
           width="100%"
-          defaultSelectedItem={customItems[0]}
+          initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}
@@ -110,7 +110,7 @@ storiesOf('combobox', module).add('Combobox', () => (
       >
         <Combobox
           width="100%"
-          defaultSelectedItem={customItems[0]}
+          initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,6 +3969,11 @@ compression-webpack-plugin@^2.0.0:
     serialize-javascript "^1.4.0"
     webpack-sources "^1.0.1"
 
+compute-scroll-into-view@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
+  integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4979,10 +4984,15 @@ dotenv@^5.0.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
 
-downshift@^1.31.16:
-  version "1.31.16"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
-  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
+downshift@^3.2.10:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.2.10.tgz#00f8e50383199c3f07ce63b575a840e2918b7b9f"
+  integrity sha512-fEYNbV/qDLUHTxF9wALNe51Xe5zauUhy2sqgYG1CtmAfUFMI30UuSaisU8CD0DEsFSIsaEvsVgtabb6nTEhtaA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    compute-scroll-into-view "^1.0.9"
+    prop-types "^15.6.0"
+    react-is "^16.5.2"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -11242,7 +11252,7 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.5.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==


### PR DESCRIPTION
This fixes #450 by creating a `stateReducer` that will set the `highlightedItem` to the selected item when opening the autocomplete – as suggested by @kentcdodds here: https://github.com/downshift-js/downshift/issues/645#issuecomment-451805753.

I wish this could be done without upgrading downshift but it doesn’t seem to work properly with the version evergreen is using (it highlights and scrolls to the selected element by default in Autocomplete but not in Combobox)

So this is breaking because Downshift renamed the following properties:

| Previous name | New name | |
|-|-|-|
| `getButtonProps` | `getToggleButtonProps` | _not used directly_ |
| `defaultSelectedItem` | `initialSelectedItem` | |
| `defaultInputValue` | `initialInputValue` | _unused_ |

If you don’t want to do a major release, we could alias and deprecated those properties first.
