### PR TITLE
Upgrade @blueprintjs/icons to ^3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@blueprintjs/icons": "^3.2.0",
+    "@blueprintjs/icons": "^3.6.0",
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,10 +823,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@blueprintjs/icons@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@blueprintjs/icons/-/icons-3.2.0.tgz#d21cceebfac9c1bceded047e493ee1e180b86f11"
-  integrity sha512-MoI4TdZ2QMM9DEd+/vJOMSlhuvPID3Zip0TB/MB1J7p7GnUThIRq2FlETMUg6ig1GZweAWNl7cUtYFNHZ3EiUQ==
+"@blueprintjs/icons@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/icons/-/icons-3.6.0.tgz#af1d2de091d67927ed61671e6967c43620cb416d"
+  integrity sha512-sgB6rJtMjc2mS4aCS+65gK5DCr8fiWgOYi0buc0ODvGD2fwOtOFZuE4Duuj6/GZnCYj4s7E8NZgYK9Krd7G73Q==
   dependencies:
     classnames "^2.2"
     tslib "^1.9.0"


### PR DESCRIPTION
Hi,

This upgrade add new icons : inbox-filtered, inbox-geo, inbox-search, inbox-update, cube, cube-add, cube-remove, lifesaver, table-filtered and clean.

@blueprintjs/icons 3.6.0 : https://github.com/palantir/blueprint/pull/3335#issue-250243376
@blueprintjs/icons 3.4.0 : https://github.com/palantir/blueprint/pull/3222#issue-236917384
@blueprintjs/icons 3.3.0 : https://github.com/palantir/blueprint/pull/3052#issue-224304066