### PR TITLE
Fix search in <SelectMenu> when there are duplicate labels

### DIFF
--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -24,7 +24,6 @@ Pass an array to the `selected` prop to select more items.
 const options = [
   {
     label: 'String',
-    labelInList: 'Optional label to appear in list',
     value: 'String or Number'
   }
 ]
@@ -234,7 +233,7 @@ As users click on selected values to remove them, you can update state.
 
 ## onFilterChange example
 
-This example shows basic usage with onFocusChange. 
+This example shows basic usage with onFocusChange.
 
 ```jsx
 <Component initialState={{ selected: null }}>
@@ -257,7 +256,7 @@ This example shows basic usage with onFocusChange.
     </SelectMenu>
     </Pane>
   )}
-  
+
 </Component>
 ```
 
@@ -281,7 +280,7 @@ This example shows basic usage for disabling some options. Options that are disa
     </SelectMenu>
     </Pane>
   )}
-  
+
 </Component>
 ```
 ## Custom Title Example
@@ -317,7 +316,7 @@ This example shows how one should use titleView to pass in a custom title.
               height={24}
               onClick={close}
             />
-          </Pane>             
+          </Pane>
         )
       }}
       options={
@@ -330,7 +329,7 @@ This example shows how one should use titleView to pass in a custom title.
     </SelectMenu>
     </Pane>
   )}
-  
+
 </Component>
 ```
 

--- a/src/select-menu/src/OptionShapePropType.js
+++ b/src/select-menu/src/OptionShapePropType.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 
 const OptionShapePropType = PropTypes.shape({
   label: PropTypes.string,
-  labelInList: PropTypes.string, // Optional
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   disabled: PropTypes.bool // Optional
 })

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -13,7 +13,9 @@ import Option from './Option'
  * @param options <Array[String]> - ['label', 'label2', ...]
  * @param input <String>
  */
-const fuzzyFilter = (options, input) => fuzzaldrin.filter(options, input)
+const fuzzyFilter = (options, input, { key }) => {
+  return fuzzaldrin.filter(options, input, { key })
+}
 
 /**
  * This is the default item renderer of options
@@ -62,7 +64,6 @@ export default class OptionsList extends PureComponent {
     onFilterChange: () => {},
     selected: [],
     renderItem: itemRenderer,
-    optionsFilter: fuzzyFilter,
     filterPlaceholder: 'Filter...',
     filterIcon: 'search',
     defaultSearchValue: ''
@@ -114,14 +115,18 @@ export default class OptionsList extends PureComponent {
     const { optionsFilter } = this.props
     const { searchValue } = this.state
 
-    return searchValue.trim() === ''
-      ? options // Return if no search query
-      : optionsFilter(
-          options.map(item => item.labelInList || item.label),
-          searchValue
-        ).map(name =>
-          options.find(item => item.labelInList === name || item.label === name)
-        )
+    if (searchValue.trim() === '') {
+      return options
+    }
+
+    // Preserve backwards compatibility with allowing custom filters, which accept array of strings
+    if (typeof optionsFilter === 'function') {
+      return optionsFilter(options.map(item => item.label), searchValue).map(
+        name => options.find(item => item.label === name)
+      )
+    }
+
+    return fuzzyFilter(options, searchValue, { key: 'label' })
   }
 
   getCurrentIndex = () => {

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -26,7 +26,7 @@ export default class SelectMenu extends PureComponent {
 
     /**
      * The options to show in the menu.
-     * [{ label: String, value: String | Number, labelInList?: String }]
+     * [{ label: String, value: String | Number }]
      */
     options: PropTypes.arrayOf(OptionShapePropType),
 


### PR DESCRIPTION
Previously if there were multiple options with the same `label`, search would return only the first item with that `label`, because `<SelectMenu>` performed a search on strings, not on objects - https://github.com/segmentio/evergreen/blob/master/src/select-menu/src/OptionsList.js#L120. It would result in a messed up option list:

<img width="257" alt="CleanShot 2019-03-19 at 16 39 04@2x" src="https://user-images.githubusercontent.com/697676/54648973-87ae2500-4a65-11e9-8a52-ba916cb2377a.png">

This PR also removes `labelInList`, which never actually did anything. Since there's only one key to search in (`label`), this PR uses fuzzaldrin's `key` feature: `fuzzaldrin.filter(options, searchValue, { key: 'label' })`, which ensures duplicate labels will be handled correctly.

It also maintains backwards compatibility with `optionsFilter` prop by resorting to old behavior on searching `label` strings only.