### PR TITLE
Fix error when no onCloseComplete is passed to CornerDialog

### DIFF
--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -142,7 +142,8 @@ export default class CornerDialog extends PureComponent {
     hasClose: true,
     cancelLabel: 'Close',
     onCancel: close => close(),
-    onConfirm: close => close()
+    onConfirm: close => close(),
+    onCloseComplete: () => {}
   }
 
   constructor(props) {


### PR DESCRIPTION
Closes #296 

This issue was marked as stale, but I bumped into it today.
`CornerDialog` accepts an `onCloseComplete` prop that is not required, but will throw an error if it's not provided. 
I added a no-op function as a default prop, which solves the problem.

I also checked if `Dialog` has the same problem, but that component just passes the `onCloseComplete` prop on to `Overlay`, which does have a default prop.
I think it makes sense to set it on `Dialog` too, but I'll let you decide that.

 