### PR TITLE
Add key to VirtualBody items

### DIFF
--- a/src/table/src/TableVirtualBody.js
+++ b/src/table/src/TableVirtualBody.js
@@ -299,21 +299,28 @@ export default class TableVirtualBody extends PureComponent {
           scrollOffset={scrollOffset}
           scrollToAlignment={scrollToAlignment}
           renderItem={({ index, style }) => {
+            const child = children[index]
+            const key = child.key || index
+            const props = {
+              key,
+              style
+            }
+
             // If some children are strings by accident, support this gracefully.
-            if (!React.isValidElement(children[index])) {
-              if (typeof children[index] === 'string') {
-                return <div style={style}>{children[index]}</div>
+            if (!React.isValidElement(child)) {
+              if (typeof child === 'string') {
+                return <div {...props}>{child}</div>
               }
 
-              return <div style={style}>&nbsp;</div>
+              return <div {...props}>&nbsp;</div>
             }
 
             // When allowing height="auto" for rows, and a auto height item is
             // rendered for the first time...
             if (
               allowAutoHeight &&
-              React.isValidElement(children[index]) &&
-              children[index].props.height === 'auto' &&
+              React.isValidElement(child) &&
+              child.props.height === 'auto' &&
               // ... and only when the height is not already been calculated.
               !this.autoHeights[index]
             ) {
@@ -323,21 +330,20 @@ export default class TableVirtualBody extends PureComponent {
                 <div
                   ref={ref => this.onVirtualHelperRef(index, ref)}
                   data-virtual-index={index}
+                  {...props}
                   style={{
                     opacity: 0,
-                    ...style
+                    ...props.style
                   }}
                 >
-                  {children[index]}
+                  {child}
                 </div>
               )
             }
 
             // When allowAutoHeight is false, or when the height is known.
             // Simply render the item.
-            return React.cloneElement(children[index], {
-              style
-            })
+            return React.cloneElement(child, props)
           }}
         />
       </Pane>


### PR DESCRIPTION
Right now using `VirtualBody` results in
```
Warning: Each child in a list should have a unique "key" prop.
Check the render method of `VirtualList`.
```
even though every row is defined with a unique `key` prop.

I looked into it and found that a wrapper is created in `VirtualList`’s `renderItem` that does not have `key` prop. And according to [react-tiny-virtual-list]() `renderItem` docs:
> Responsible for rendering an item given it's index: `({index: number, style: Object}): React.PropTypes.node`. **The returned element must handle key and style.**

Evergreen is only handling `style` but not `key`.

This PR fixes that by using the child’s key if it has one or index as a fallback.