### PR TITLE
Task/include default checked

### DIFF
--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -79,6 +79,12 @@ class Checkbox extends PureComponent {
     onChange: PropTypes.func,
 
     /**
+     * When true, the checkbox is true initially.
+     * This is for uncontrolled usage.
+     */
+    defaultChecked: PropTypes.bool,
+
+    /**
      * When true, the radio is disabled.
      */
     disabled: PropTypes.bool,
@@ -102,8 +108,6 @@ class Checkbox extends PureComponent {
   }
 
   static defaultProps = {
-    checked: false,
-    indeterminate: false,
     onChange: () => {},
     appearance: 'default'
   }
@@ -121,6 +125,7 @@ class Checkbox extends PureComponent {
       name,
       label,
       appearance,
+      defaultChecked,
       disabled,
       isInvalid,
       checked,
@@ -150,6 +155,7 @@ class Checkbox extends PureComponent {
           value={value}
           checked={checked || indeterminate}
           onChange={onChange}
+          defaultChecked={defaultChecked}
           disabled={disabled}
           aria-invalid={isInvalid}
           innerRef={this.setIndeterminate}

--- a/src/checkbox/stories/index.stories.js
+++ b/src/checkbox/stories/index.stories.js
@@ -11,5 +11,6 @@ storiesOf('checkbox', module).add('Checkbox', () => (
     <Checkbox disabled checked label="Checkbox checked disabled" />
     <Checkbox indeterminate label="Checkbox indeterminate" />
     <Checkbox checked indeterminate label="Checkbox checked indeterminate" />
+    <Checkbox defaultChecked label="Checkbox defaultChecked" />
   </Box>
 ))

--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -55,6 +55,12 @@ class Radio extends PureComponent {
     onChange: PropTypes.func,
 
     /**
+     * This sets the initial `checked` state of a radio.
+     * This is for uncontrolled usage.
+     */
+    defaultChecked: PropTypes.bool,
+
+    /**
      * When true, the radio is disabled.
      */
     disabled: PropTypes.bool,
@@ -111,6 +117,7 @@ class Radio extends PureComponent {
       id,
       name,
       label,
+      defaultChecked,
       disabled,
       isInvalid,
       checked,
@@ -141,6 +148,7 @@ class Radio extends PureComponent {
           value={value}
           checked={checked}
           onChange={this.handleChange}
+          defaultChecked={defaultChecked}
           disabled={disabled}
           aria-invalid={isInvalid}
           required={isRequired}

--- a/src/radio/stories/index.stories.js
+++ b/src/radio/stories/index.stories.js
@@ -89,5 +89,14 @@ storiesOf('radio', module)
           label="Radio checked disabled"
         />
       </Box>
+      <Heading marginTop={40}>DefaultChecked usage</Heading>
+      <Box aria-label="Radio Group Label 12" role="group">
+        <Radio
+          defaultChecked
+          name="default-checked-group"
+          label="Radio 1 (defaultChecked)"
+        />
+        <Radio name="default-checked-group" label="Radio 2" />
+      </Box>
     </Box>
   ))


### PR DESCRIPTION
This PR introduces support for `defaultChecked` for people who want to use `Checkbox` or `Radio` as uncontrolled components. While this is a non-breaking change, previously `Checkbox` was written in a way that prevented you from using it as an uncontrolled component (due to `defaultProps`).