### PR TITLE
improve withTheme types

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,3 @@
 export { default as defaultTheme } from './src/default-theme'
-export { ThemeProvider, ThemeConsumer } from './src/ThemeContext'
-export { default as withTheme } from './src/withTheme'
+export { ThemeProvider, ThemeConsumer, Theme } from './src/ThemeContext'
+export { withTheme } from './src/withTheme'

--- a/src/theme/src/ThemeContext.ts
+++ b/src/theme/src/ThemeContext.ts
@@ -1,12 +1,22 @@
 import React from 'react'
 import defaultTheme from './default-theme'
 
+export interface Theme {
+  getCodeProps: (appearance: 'default' | 'minimal') => any
+  getFontFamily: (fontFamily?: string) => string
+  getHeadingStyle: (size?: number) => any
+  getLinkClassName: (color?: string) => string
+  getParagraphStyle: (size?: number) => any
+  getTextColor: (colorAlias?: string) => string
+  getTextStyle: (size?: number) => any
+}
+
 /**
  * Use React 16.3+ createContext API.
  */
 const {
   Provider: ThemeProvider,
   Consumer: ThemeConsumer
-} = React.createContext(defaultTheme)
+} = React.createContext<Theme>(defaultTheme)
 
 export { ThemeProvider, ThemeConsumer }

--- a/src/theme/src/withTheme.tsx
+++ b/src/theme/src/withTheme.tsx
@@ -1,21 +1,26 @@
 import React from 'react'
-import { ThemeConsumer } from './ThemeContext'
+import { ThemeConsumer, Theme } from './ThemeContext'
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+type Difference<T, K> = Pick<T, Exclude<keyof T, keyof K>>
 
 interface WithThemeProps {
-  // TODO: type this
-  theme: object
+  /**
+   * The theme context from the ThemeProvider
+   */
+  theme: Theme
 }
 
 /**
  * HOC that injects the `theme` from the ThemeConsumer into the wrapper component.
  */
-export default function withTheme<P extends WithThemeProps>(Component: React.ComponentType<P>) {
-  const displayName =
-    Component.displayName || Component.name || 'Component'
+export function withTheme<P extends WithThemeProps>(
+  Component: React.ComponentType<P>
+): React.ComponentClass<Difference<P, WithThemeProps>, {}> {
+  const displayName = Component.displayName || Component.name || 'Component'
 
-  return class WithTheme extends React.Component<Omit<P, keyof WithThemeProps>> {
+  return class WithTheme extends React.Component<
+    Difference<P, WithThemeProps>
+  > {
     static displayName = `withTheme(${displayName})`
 
     render() {

--- a/src/typography/src/Text.tsx
+++ b/src/typography/src/Text.tsx
@@ -1,21 +1,26 @@
 import React, { PureComponent } from 'react'
 import Box from 'ui-box'
-import { withTheme } from '../../theme'
-
-interface Theme {
-  getTextStyle: (size?: number) => any
-  getTextColor: (colorAlias?: string) => string
-  getFontFamily: (fontFamily?: string) => string
-}
+import { withTheme, Theme } from '../../theme'
 
 interface TextProps {
-  /** The color (alias or valid color) applied to the text */
+  /**
+   * The color (alias or valid color) applied to the text
+   */
   color?: string
-  /** The font family alias applied to the text */
+
+  /**
+   * The font family alias applied to the text
+   */
   fontFamily?: 'ui' | 'display' | 'mono'
-  /** The size of the text style */
+
+  /**
+   * The size of the text style
+   */
   size?: 300 | 400 | 500 | 600
-  /** Theme provided by ThemeProvider. */
+
+  /**
+   * Theme provided by ThemeProvider.
+   */
   theme: Theme
 }
 


### PR DESCRIPTION
This PR adds better types for `withTheme`. I think we should start with defining (and expanding on) the interface first, and then we can make sure that `defaultTheme` meets the requirements / mirrors it.

This will be a good exercise to figure out where the theme is pulling values directly from the defaultTheme object instead of from the theme provider.

Overall I think theming is a bit complex (hierarchical nested config, sometimes from the context sometimes not) and would love to simplify our approach, but we can save that for another time.

Related: #300 