### PR TITLE
docs(Typography): Corrected definition for list style components

### DIFF
--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -15,9 +15,9 @@ import { ThemeConsumer, Pane, Heading, Text, Paragraph } from 'evergreen-ui'
 
 ## List components
 
-* **OrderedList**: used for headings. A `ol` element.
-* **UnorderedList**: used for headings. A `ul` element.
-* **ListItem**: used for headings. A `li` element.
+* **OrderedList**: used for ordered lists. A `ol` element.
+* **UnorderedList**: used for unordered lists. A `ul` element.
+* **ListItem**: used as the list item in either an unordered list, or ordered list. A `li` element.
 
 ## Font families
 


### PR DESCRIPTION
With this PR I aim to correct some definition depicted for the List style components in your documentation. 
