### PR TITLE
docs(Typography): Paragraph components scale 300 to 500

### DIFF
--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -70,7 +70,7 @@ There is not need for you to override this on a component level.
         <h2 className="heading h2">Paragraph Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {Object.keys(theme.typography.text).map(size => {
+        {[300, 400, 500].map(size => {
           return (
             <TextStylePreview
               key={size}


### PR DESCRIPTION
With this PR I aim to fix the paragraph component docs, where the scale being displayed runs through the keys `theme.typography.text`, whereas the text scale only runs 300 _to_ 500. As the paragraph style for 600 depicts 20px whereas this should be 16px.

Stretch question, should you guys expose the scale for this component outside the realm of propTypes? So if future scales get implemented for `Paragraph`, it'll be reflected in the docs?