### PR TITLE
feat(popover): add prop to disable close on body click

### DIFF
--- a/docs/src/pages/components/popover.mdx
+++ b/docs/src/pages/components/popover.mdx
@@ -260,6 +260,27 @@ The Popover can be positioned on the following positions using the `position` pr
   </Pane>
 </Pane>
 ```
+## Disable Close on Body Click
 
+```jsx
+<Popover
+  content={({ close }) => (
+    <Pane
+      width={320}
+      height={320}
+      paddingX={40}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      flexDirection="column"
+    >
+      <Button onClick={close}>Close</Button>
+    </Pane>
+  )}
+  shouldNotCloseOnBodyClick
+>
+  <Button>Trigger Popover</Button>
+</Popover>
+```
 
 <PropsTable of="Popover" />

--- a/docs/src/pages/components/popover.mdx
+++ b/docs/src/pages/components/popover.mdx
@@ -277,7 +277,7 @@ The Popover can be positioned on the following positions using the `position` pr
       <Button onClick={close}>Close</Button>
     </Pane>
   )}
-  shouldNotCloseOnBodyClick
+  shouldCloseOnExternalClick={false}
 >
   <Button>Trigger Popover</Button>
 </Popover>

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -92,7 +92,7 @@ export default class Popover extends Component {
     /**
      * Boolean indicating if clicking outside the dialog should close the dialog.
      */
-    shouldNotCloseOnBodyClick: PropTypes.bool
+    shouldCloseOnExternalClick: PropTypes.bool
   }
 
   static defaultProps = {
@@ -105,7 +105,7 @@ export default class Popover extends Component {
     onOpenComplete: () => {},
     onCloseComplete: () => {},
     bringFocusInside: false,
-    shouldNotCloseOnBodyClick: false
+    shouldCloseOnExternalClick: true
   }
 
   constructor(props) {
@@ -192,7 +192,7 @@ export default class Popover extends Component {
       return
     }
 
-    if (this.props.shouldNotCloseOnBodyClick) {
+    if (this.props.shouldCloseOnExternalClick === false) {
       return
     }
 

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -92,7 +92,7 @@ export default class Popover extends Component {
     /**
      * Boolean indicating if clicking outside the dialog should close the dialog.
      */
-    shouldNotCloseOnOutsideClick: PropTypes.bool
+    shouldNotCloseOnBodyClick: PropTypes.bool
   }
 
   static defaultProps = {
@@ -105,7 +105,7 @@ export default class Popover extends Component {
     onOpenComplete: () => {},
     onCloseComplete: () => {},
     bringFocusInside: false,
-    shouldNotCloseOnOutsideClick: false
+    shouldNotCloseOnBodyClick: false
   }
 
   constructor(props) {
@@ -192,7 +192,7 @@ export default class Popover extends Component {
       return
     }
 
-    if (this.props.shouldNotCloseOnOutsideClick) {
+    if (this.props.shouldNotCloseOnBodyClick) {
       return
     }
 

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -87,7 +87,12 @@ export default class Popover extends Component {
     /**
      * When true, bring focus inside of the Popover on open.
      */
-    bringFocusInside: PropTypes.bool
+    bringFocusInside: PropTypes.bool,
+
+    /**
+     * Boolean indicating if clicking outside the dialog should close the dialog.
+     */
+    shouldNotCloseOnOutsideClick: PropTypes.bool
   }
 
   static defaultProps = {
@@ -99,7 +104,8 @@ export default class Popover extends Component {
     onClose: () => {},
     onOpenComplete: () => {},
     onCloseComplete: () => {},
-    bringFocusInside: false
+    bringFocusInside: false,
+    shouldNotCloseOnOutsideClick: false
   }
 
   constructor(props) {
@@ -183,6 +189,10 @@ export default class Popover extends Component {
     }
 
     if (this.popoverNode && this.popoverNode.contains(e.target)) {
+      return
+    }
+
+    if (this.props.shouldNotCloseOnOutsideClick) {
       return
     }
 

--- a/src/popover/stories/index.stories.js
+++ b/src/popover/stories/index.stories.js
@@ -147,6 +147,9 @@ storiesOf('popover', module)
       >
         <Button marginRight={20}>Trigger Closable Popover</Button>
       </Popover>
+      <Popover content={<PopoverContent />} shouldNotCloseOnOutsideClick>
+        <Button marginRight={20}>No Close on Body Click</Button>
+      </Popover>
       <Popover
         useSmartPositioning={false}
         content={({ close }) => <ClosablePopoverContent close={close} />}

--- a/src/popover/stories/index.stories.js
+++ b/src/popover/stories/index.stories.js
@@ -147,7 +147,7 @@ storiesOf('popover', module)
       >
         <Button marginRight={20}>Trigger Closable Popover</Button>
       </Popover>
-      <Popover content={<PopoverContent />} shouldNotCloseOnBodyClick>
+      <Popover content={<PopoverContent />} shouldCloseOnExternalClick={false}>
         <Button marginRight={20}>No Close on Body Click</Button>
       </Popover>
       <Popover

--- a/src/popover/stories/index.stories.js
+++ b/src/popover/stories/index.stories.js
@@ -147,7 +147,7 @@ storiesOf('popover', module)
       >
         <Button marginRight={20}>Trigger Closable Popover</Button>
       </Popover>
-      <Popover content={<PopoverContent />} shouldNotCloseOnOutsideClick>
+      <Popover content={<PopoverContent />} shouldNotCloseOnBodyClick>
         <Button marginRight={20}>No Close on Body Click</Button>
       </Popover>
       <Popover


### PR DESCRIPTION
Gives users the ability to disable the popover closing when clicking outside the popover on the body.

Fixes #544 