### PR TITLE
#534:open popover on hover also shown in menuhover in storybook

### DIFF
--- a/src/menu/stories/index.stories.js
+++ b/src/menu/stories/index.stories.js
@@ -151,7 +151,26 @@ storiesOf('menu', module)
           </Menu>
         }
       >
-        <Button>Custom Menu Items</Button>
+        <Button marginRight={16}>Custom Menu Items</Button>
+      </Popover>
+      <Popover
+        position={Position.BOTTOM_LEFT}
+        trigger="hover"
+        content={
+          <Menu>
+            <Menu.Group>
+              <Menu.Item>Share...</Menu.Item>
+              <Menu.Item>Move...</Menu.Item>
+              <Menu.Item secondaryText="⌘R">Rename...</Menu.Item>
+            </Menu.Group>
+            <Menu.Divider />
+            <Menu.Group>
+              <Menu.Item intent="danger">Delete...</Menu.Item>
+            </Menu.Group>
+          </Menu>
+        }
+      >
+        <Button>Hover menus</Button>
       </Popover>
 
       <UnorderedList marginTop={24}>

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -25,6 +25,10 @@ export default class Popover extends Component {
      * When true, the Popover is manually shown.
      */
     isShown: PropTypes.bool,
+    /**
+     * Open the Popover based on click or hover. Default is click.
+     */
+    trigger: PropTypes.oneOf(['click', 'hover']),
 
     /**
      * The content of the Popover.
@@ -105,7 +109,8 @@ export default class Popover extends Component {
     onOpenComplete: () => {},
     onCloseComplete: () => {},
     bringFocusInside: false,
-    shouldCloseOnExternalClick: true
+    shouldCloseOnExternalClick: true,
+    trigger: 'click'
   }
 
   constructor(props) {
@@ -236,7 +241,6 @@ export default class Popover extends Component {
     document.body.removeEventListener('keydown', this.onEsc, false)
 
     this.bringFocusBackToTarget()
-
     this.props.onClose()
   }
 
@@ -252,6 +256,18 @@ export default class Popover extends Component {
   handleKeyDown = e => {
     if (e.key === 'ArrowDown') {
       this.bringFocusInside()
+    }
+  }
+
+  handleOpenHover = () => {
+    if (this.props.trigger === 'hover') {
+      this.open()
+    }
+  }
+
+  handleCloseHover = () => {
+    if (this.props.trigger === 'hover') {
+      this.close()
     }
   }
 
@@ -277,6 +293,7 @@ export default class Popover extends Component {
 
     const popoverTargetProps = {
       onClick: this.toggle,
+      onMouseEnter: this.handleOpenHover,
       onKeyDown: this.handleKeyDown,
       role: 'button',
       'aria-expanded': isShown,
@@ -352,6 +369,7 @@ export default class Popover extends Component {
             minWidth={minWidth}
             minHeight={minHeight}
             {...statelessProps}
+            onMouseLeave={this.handleCloseHover}
           >
             {typeof content === 'function'
               ? content({ close: this.close })


### PR DESCRIPTION
The aim of this PR is to add an hover functionality on popover. The example is added as menuHover in menu stories.
