### PR TITLE
Remove forced overflow

### DIFF
--- a/src/table/src/TableBody.js
+++ b/src/table/src/TableBody.js
@@ -12,7 +12,7 @@ export default class TableBody extends PureComponent {
   render() {
     const { children, ...props } = this.props
     return (
-      <Pane data-evergreen-table-body flex="1" overflowY="scroll" {...props}>
+      <Pane data-evergreen-table-body flex="1" overflowY="auto" {...props}>
         {children}
       </Pane>
     )


### PR DESCRIPTION
In windows forced overflow looks meaningless:
![image](https://user-images.githubusercontent.com/300067/58896400-ed549980-86c3-11e9-9609-b51f87e61119.png)
Since it does not affect OSX, why not making a default look good? @mshwery 