### PR TITLE
Remove `selected` restraint

### DIFF
--- a/src/menu/src/MenuOptionsGroup.js
+++ b/src/menu/src/MenuOptionsGroup.js
@@ -39,10 +39,10 @@ class MenuOptionsGroup extends React.PureComponent {
           </Heading>
         )}
         <Pane>
-          {options.map(option => {
+          {options.map((option, i) => {
             return (
               <MenuOption
-                key={option.value}
+                key={option.value + i}
                 isSelected={option.value === selected}
                 onSelect={() => onChange(option.value)}
               >

--- a/src/menu/src/MenuOptionsGroup.js
+++ b/src/menu/src/MenuOptionsGroup.js
@@ -39,10 +39,10 @@ class MenuOptionsGroup extends React.PureComponent {
           </Heading>
         )}
         <Pane>
-          {options.map((option, i) => {
+          {options.map((option) => {
             return (
               <MenuOption
-                key={option.value + i}
+                key={option.value}
                 isSelected={option.value === selected}
                 onSelect={() => onChange(option.value)}
               >

--- a/src/menu/src/MenuOptionsGroup.js
+++ b/src/menu/src/MenuOptionsGroup.js
@@ -15,7 +15,7 @@ class MenuOptionsGroup extends React.PureComponent {
     /**
      * The current value of the option group.
      */
-    selected: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    selected: PropTypes.any,
 
     /**
      * Function called when selection changes.


### PR DESCRIPTION
We may want to store in select menu something other than just numbers/strings, for example, dates or date ranges (arrays of two dates). All works fine but this prop type check raises an error.
@mshwery