### PR TITLE
expose the`ThemeContext` to use the new context hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export {
 export { SidebarTab, Tab, Tablist, TabNavigation } from './tabs'
 export { TagInput } from './tag-input'
 export { TextInput, TextInputField } from './text-input'
-export { ThemeProvider, ThemeConsumer, withTheme, defaultTheme } from './theme'
+export { ThemeContext, ThemeProvider, ThemeConsumer, withTheme, defaultTheme } from './theme'
 export { Textarea } from './textarea'
 export { toaster } from './toaster'
 export { Tooltip } from './tooltip'

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,3 +1,3 @@
 export { default as defaultTheme } from './src/default-theme'
-export { ThemeProvider, ThemeConsumer } from './src/ThemeContext'
+export { default as ThemeContext, ThemeProvider, ThemeConsumer } from './src/ThemeContext'
 export { default as withTheme } from './src/withTheme'

--- a/src/theme/src/ThemeContext.js
+++ b/src/theme/src/ThemeContext.js
@@ -4,9 +4,11 @@ import defaultTheme from './default-theme'
 /**
  * Use React 16.3+ createContext API.
  */
+const ThemeContext = React.createContext(defaultTheme)
 const {
   Provider: ThemeProvider,
   Consumer: ThemeConsumer
-} = React.createContext(defaultTheme)
+} = ThemeContext
 
+export default ThemeContext
 export { ThemeProvider, ThemeConsumer }


### PR DESCRIPTION
According to the documentation in the `useContext` hook is necessary to use directly the entire `context`:
https://reactjs.org/docs/hooks-reference.html#usecontext

If I try to pass the `Consumer` or the `Provider` to `useContext` the following messages are printed in the console:

```javascript
    useContext(ThemeConsumer)
```
<img width="547" alt="Screen Shot 2019-06-08 at 08 13 31" src="https://user-images.githubusercontent.com/208789/59146563-22affe80-89c6-11e9-9bb7-b9e7f8346a85.png">


```javascript
    useContext(ThemeProvider)
```

<img width="545" alt="Screen Shot 2019-06-08 at 08 13 55" src="https://user-images.githubusercontent.com/208789/59146565-352a3800-89c6-11e9-8617-f07e1037477f.png">

to prevent this I expose the `ThemeContext`