### PR TITLE
Allow dimensions in SelectMenu to be strings

### DIFF
--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -17,12 +17,12 @@ export default class SelectMenu extends PureComponent {
     /**
      * The width of the Select Menu.
      */
-    width: PropTypes.number,
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
      * The height of the Select Menu.
      */
-    height: PropTypes.number,
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
      * The options to show in the menu.


### PR DESCRIPTION
Stringy `height="100%"` works perfectly, cept it logs an error in console.
This should fix it.
@mshwery 