### PR TITLE
Fix selected proptype

### DIFF
--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -38,7 +38,7 @@ export default class OptionsList extends PureComponent {
     /**
      * This holds the values of the options
      */
-    selected: PropTypes.arrayOf(PropTypes.string),
+    selected: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     onSelect: PropTypes.func,
     onDeselect: PropTypes.func,
     onFilterChange: PropTypes.func,


### PR DESCRIPTION
Selected value can be array of the option items' values.
For now it only allows strings, whereas it can do numbers too, and it does, but gives warnings in console.
