### PR TITLE
Fix src of the avatar documentation

### DIFF
--- a/docs/src/pages/components/avatar.mdx
+++ b/docs/src/pages/components/avatar.mdx
@@ -27,8 +27,8 @@ Use the `src` property to create a avatar with a image.
 
 ```jsx
 <Avatar
-  src="https://pbs.twimg.com/profile_images/756196362576723968/6GUgJG4L_400x400.jpg"
-  name="Jeroen Ransijn"
+  src="https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg"
+  name="Alan Turing"
   size={40}
 />
 ```


### PR DESCRIPTION
The src now points to a public domain image hosted on wikimedia

From the reported issue: https://github.com/segmentio/evergreen/issues/574. The image I used is under public domain: https://en.wikipedia.org/wiki/Alan_Turing#/media/File:Alan_Turing_Aged_16.jpg

It renders well now:
<img width="818" alt="Screen Shot 2019-06-13 at 11 54 05 AM" src="https://user-images.githubusercontent.com/1903101/59459583-f9caa780-8dd1-11e9-8d64-45b523652de2.png">

