### PR TITLE
Expose onBodyClick to popover

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -198,7 +198,7 @@ export default class Popover extends Component {
       return
     }
     
-    // notify body click
+    // Notify body click
     this.props.onBodyClick(e)
 
     if (this.props.shouldCloseOnExternalClick === false) {

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -83,6 +83,11 @@ export default class Popover extends Component {
      * Function that will be called when the exit transition is complete.
      */
     onCloseComplete: PropTypes.func.isRequired,
+    
+    /**
+     * Function that will be called when the body is clicked.
+     */
+    onBodyClick: PropTypes.func.isRequired,
 
     /**
      * When true, bring focus inside of the Popover on open.
@@ -103,7 +108,8 @@ export default class Popover extends Component {
     onOpen: () => {},
     onClose: () => {},
     onOpenComplete: () => {},
-    onCloseComplete: () => {},
+    onCloseComplete: () => {},    
+    onBodyClick: () => {},
     bringFocusInside: false,
     shouldCloseOnExternalClick: true
   }
@@ -191,6 +197,9 @@ export default class Popover extends Component {
     if (this.popoverNode && this.popoverNode.contains(e.target)) {
       return
     }
+    
+    // notify body click
+    this.props.onBodyClick(e)
 
     if (this.props.shouldCloseOnExternalClick === false) {
       return


### PR DESCRIPTION
With controlled Popover state via `isShown` we may want to still be able to intercept bodyClick event.
Now there's no way to do that. 

Workarounds for manual bodyclick interception are horrible, since react events system disregards native bubbling, and popover gives no access to refs. @mshwery