### PR TITLE
chore(storybook/Dialog): Rename of the dialog title

### DIFF
--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -212,7 +212,7 @@ storiesOf('dialog', module)
               isShown={isShown}
               shouldCloseOnOverlayClick={false}
               shouldCloseOnEscapePress={false}
-              title="Dialog with Internal Scrolling"
+              title="Dialog with overlay and escape key disabled"
               onCloseComplete={hide}
               onCancel={close => {
                 console.log('You canceled')


### PR DESCRIPTION
I've fixed the wrong dialog title.

Although I clicked the "Show Dialog with overlay and escape key disabled" button in Dialog section, the dialog title was "Dialog with Internal Scrolling". I've renamed to "Dialog with overlay and escape key disabled".

**Before**:
<img width="1091" alt="Screen Shot 2019-07-04 at 9 06 54 PM" src="https://user-images.githubusercontent.com/4310946/60692061-d7441f80-9ea1-11e9-86dc-01f64571e307.png">

**After**:
<img width="1090" alt="Screen Shot 2019-07-04 at 9 12 37 PM" src="https://user-images.githubusercontent.com/4310946/60692056-d27f6b80-9ea1-11e9-84a1-11cd22c5261c.png">