### PR TITLE
Make correct oneOfType arguments

### DIFF
--- a/src/table/src/TableHead.js
+++ b/src/table/src/TableHead.js
@@ -13,7 +13,7 @@ export default class TableHead extends PureComponent {
     /**
      * The height of the table head.
      */
-    height: PropTypes.oneOfType(PropTypes.number, PropTypes.string).isRequired,
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
 
     /**
      * This should always be true if you are using TableHead together with a TableBody.


### PR DESCRIPTION
@mshwery I'm really sorry - the #587 had wrong arguments for `oneOfType`, it needs to be an  array, that resulted in warning in console. This PR is hotfix.