### PR TITLE
Allow string props in SelectMenuContent dimensions

### DIFF
--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -31,8 +31,8 @@ export default class SelectMenuContent extends PureComponent {
   static propTypes = {
     close: PropTypes.func,
     title: PropTypes.string,
-    width: PropTypes.number,
-    height: PropTypes.number,
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     headerHeight: PropTypes.number,
     options: PropTypes.arrayOf(OptionShapePropType),
     hasTitle: PropTypes.bool,


### PR DESCRIPTION
This follows on from #579

