### PR TITLE
Add textAlign prop to TextTableCell

### DIFF
--- a/src/table/src/TextTableCell.js
+++ b/src/table/src/TextTableCell.js
@@ -40,7 +40,7 @@ export default class TextTableCell extends PureComponent {
           size={300}
           flex="1"
           {...ellipsis}
-          {...(isNumber ? { fontFamily: 'mono' } : {})}
+          {...(isNumber ? { fontFamily: 'mono', textAlign: 'right' } : {})}
           {...textProps}
         >
           {children}


### PR DESCRIPTION
The `isNumber` prop, when true, should align the text right. This commit adds the `textAlign` prop to the Text component, when `isNumber` is true.
