### PR TITLE
Fix doc comment for isNumber prop

### DIFF
--- a/src/table/src/TextTableCell.js
+++ b/src/table/src/TextTableCell.js
@@ -17,7 +17,7 @@ export default class TextTableCell extends PureComponent {
     ...TableCell.propTypes,
 
     /**
-     * Adds textAlign: right and fontFamily: mono.
+     * Adds fontFamily: mono.
      */
     isNumber: PropTypes.bool.isRequired,
 


### PR DESCRIPTION
The `isNumber` prop doesn't add `textAlign: right` to the cell.

Follow on from #596 