### PR TITLE
Add isMultiSelect optional prop to Menu.OptionsGroup

### DIFF
--- a/src/menu/src/MenuOptionsGroup.js
+++ b/src/menu/src/MenuOptionsGroup.js
@@ -25,11 +25,27 @@ class MenuOptionsGroup extends React.PureComponent {
     /**
      * List of options rendered in the group.
      */
-    options: PropTypes.array
+    options: PropTypes.array,
+
+    /**
+     * When true, multi select is accounted for.
+     */
+    isMultiSelect: PropTypes.bool
+  }
+
+  isSelected = option => {
+    const { value } = option
+    const { isMultiSelect, selected } = this.props
+
+    if (isMultiSelect) {
+      return Boolean(selected.find(itemValue => itemValue === value))
+    }
+
+    return Boolean(value === selected)
   }
 
   render() {
-    const { title, options, selected, onChange } = this.props
+    const { title, options, onChange } = this.props
 
     return (
       <Pane paddingY={8}>
@@ -39,11 +55,11 @@ class MenuOptionsGroup extends React.PureComponent {
           </Heading>
         )}
         <Pane>
-          {options.map((option) => {
+          {options.map(option => {
             return (
               <MenuOption
                 key={option.value}
-                isSelected={option.value === selected}
+                isSelected={this.isSelected(option)}
                 onSelect={() => onChange(option.value)}
               >
                 {option.label}

--- a/src/menu/stories/index.stories.js
+++ b/src/menu/stories/index.stories.js
@@ -130,6 +130,44 @@ storiesOf('menu', module)
         position={Position.BOTTOM_LEFT}
         content={
           <Menu>
+            <Component initialState={{ selected: ['email', 'state'] }}>
+              {({ state, setState }) => {
+                return (
+                  <Menu.OptionsGroup
+                    title="Show"
+                    options={[
+                      { label: 'Email', value: 'email' },
+                      { label: 'Phone', value: 'phone' },
+                      { label: 'State', value: 'state' },
+                      { label: 'Country', value: 'country' },
+                      { label: 'Type', value: 'type' }
+                    ]}
+                    selected={state.selected}
+                    isMultiSelect
+                    onChange={value => {
+                      const { selected } = state
+                      if (selected.find(itemValue => itemValue === value)) {
+                        const index = selected.indexOf(value)
+                        selected.splice(index, 1)
+                      } else {
+                        selected.push(value)
+                      }
+
+                      setState({ selected })
+                    }}
+                  />
+                )
+              }}
+            </Component>
+          </Menu>
+        }
+      >
+        <Button marginRight={16}>Multiselect Option Group</Button>
+      </Popover>
+      <Popover
+        position={Position.BOTTOM_LEFT}
+        content={
+          <Menu>
             <ul>
               <li>
                 <a href="..." role="menuitem">


### PR DESCRIPTION
This was an enhancement suggested in #584 .  This PR adds an optional boolean prop to the `Menu.OptionsGroup` component `isMultiSelect`.  When true, this allows multiple items in the options group to be selected at the same time.