### PR TITLE
Fixes #607 - Set the default list position to inside for UnorderedList and OrderedList

### DIFF
--- a/src/typography/src/OrderedList.js
+++ b/src/typography/src/OrderedList.js
@@ -22,7 +22,6 @@ export default class OrderedList extends PureComponent {
     margin: 0,
     marginLeft: '1.1em',
     padding: 0,
-    listStylePosition: 'inside',
     listStyle: 'decimal'
   }
 

--- a/src/typography/src/UnorderedList.js
+++ b/src/typography/src/UnorderedList.js
@@ -33,7 +33,6 @@ export default class UnorderedList extends PureComponent {
     margin: 0,
     marginLeft: '1.1em',
     padding: 0,
-    listStylePosition: 'inside',
     listStyle: 'disc'
   }
 


### PR DESCRIPTION
Per issue #607 : This sets the `listStylePosition` directly so that it's not clobbered by `listStyle`