### PR TITLE
Fix select menu keyboard navigation

### DIFF
--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -103,6 +103,10 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
           options={state.options}
           selected={state.selected}
           onSelect={item => {
+            if (state.selected.includes(item.value)) {
+              return
+            }
+
             const selected = [...state.selected, item.value]
             const selectedItems = selected
             const selectedItemsLength = selectedItems.length


### PR DESCRIPTION
This implements the ideas described on https://github.com/segmentio/evergreen/issues/589. On MacOS `COMMAND + LEFT ARROW` or `COMMAND + RIGHT ARROW` do the navigation to the beginning and end of the search query respectively. I believe similar thing works on windows.

In summary:
- Up and down keyboard arrows for navigation between elements in the `SelectMenu`. This is a backwards incompatible change as the arrows won't select items anymore.
- Enter to select/deselect an element in the `SelectMenu`.

A video of it in action: https://recordit.co/ugChPoW5P6


