### PR TITLE
Don't pass closeOnSelect to Pane in OptionsList

### DIFF
--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -239,6 +239,7 @@ export default class OptionsList extends PureComponent {
       optionsFilter,
       isMultiSelect,
       defaultSearchValue,
+      closeOnSelect,
       ...props
     } = this.props
     const options = this.search(originalOptions)


### PR DESCRIPTION
We need to pull out `closeOnSelect` so that we don't pass it in `props` to the `Pane` in `OptionsList`. Follow on to: https://github.com/segmentio/evergreen/pull/588

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2907397/63835739-ef2da200-c92c-11e9-97ce-5d0e8b865c54.png) | ![image](https://user-images.githubusercontent.com/2907397/63835743-f5238300-c92c-11e9-87d5-1a232c02c040.png) |
