### PR TITLE
Add optional icon to SelectMenu options

### DIFF
--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -178,7 +178,10 @@ It's possible to include icons in the menu list.
 ```jsx
 <SelectMenu
   title="Options with icons"
-  options={[{ label: 'Apple', value: 'Apple', icon: https://upload.wikimedia.org/wikipedia/commons/d/d2/Malus-Boskoop_organic.jpg }]}
+  options={[
+    { label: 'Apple', value: 'Apple', icon: 'https://upload.wikimedia.org/wikipedia/commons/d/d2/Malus-Boskoop_organic.jpg' },
+    { label: 'Banana', value: 'Banana', icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Bananas_white_background_DS.jpg/2560px-Bananas_white_background_DS.jpg' },
+  ]}
 >
   <Button>Select option...</Button>
 </SelectMenu>

--- a/docs/src/pages/components/select-menu.mdx
+++ b/docs/src/pages/components/select-menu.mdx
@@ -171,6 +171,19 @@ It's also possible to close `<SelectMenu>` from within empty view:
 </SelectMenu>
 ```
 
+## Menu with icons
+
+It's possible to include icons in the menu list.
+
+```jsx
+<SelectMenu
+  title="Options with icons"
+  options={[{ label: 'Apple', value: 'Apple', icon: https://upload.wikimedia.org/wikipedia/commons/d/d2/Malus-Boskoop_organic.jpg }]}
+>
+  <Button>Select option...</Button>
+</SelectMenu>
+```
+
 
 ## Multiselect with deselect example
 

--- a/src/select-menu/src/Option.js
+++ b/src/select-menu/src/Option.js
@@ -2,11 +2,13 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Icon } from '../../icon'
+import { Image } from '../../image'
 import { TableRow, TextTableCell } from '../../table'
 
 export default class Option extends PureComponent {
   static propTypes = {
     label: PropTypes.string,
+    icon: PropTypes.string,
     style: PropTypes.any,
     height: PropTypes.number,
     onSelect: PropTypes.func,
@@ -28,6 +30,7 @@ export default class Option extends PureComponent {
       disabled,
       style,
       height,
+      icon,
       ...props
     } = this.props
 
@@ -72,7 +75,10 @@ export default class Option extends PureComponent {
           alignSelf="stretch"
           cursor={disabled ? 'default' : 'pointer'}
         >
-          {label}
+          <Pane alignItems="center" display="flex">
+            {icon && <Image src={icon} width={24} marginRight={8} />}
+            {label}
+          </Pane>
         </TextTableCell>
       </TableRow>
     )

--- a/src/select-menu/src/OptionShapePropType.js
+++ b/src/select-menu/src/OptionShapePropType.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 const OptionShapePropType = PropTypes.shape({
   label: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  disabled: PropTypes.bool // Optional
+  disabled: PropTypes.bool, // Optional
+  icon: PropTypes.string // Optional
 })
 
 export default OptionShapePropType

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -239,7 +239,6 @@ export default class OptionsList extends PureComponent {
       optionsFilter,
       isMultiSelect,
       defaultSearchValue,
-      closeOnSelect,
       ...props
     } = this.props
     const options = this.search(originalOptions)
@@ -286,6 +285,7 @@ export default class OptionsList extends PureComponent {
               return renderItem({
                 key: item.value,
                 label: item.label,
+                icon: item.icon,
                 style,
                 height: optionSize,
                 onSelect: () => this.handleSelect(item),

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -7,7 +7,7 @@ import { Button } from '../../buttons'
 import { Text } from '../../typography'
 import { Pane } from '../../layers'
 import { TextInput } from '../../text-input'
-import options from './starwars-options'
+import options, { optionsWithIcons } from './starwars-options'
 import Manager from './Manager'
 
 storiesOf('select-menu', module).add('SelectMenu', () => (
@@ -38,6 +38,18 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
           closeOnSelect
         >
           <Button>Menu will close on select</Button>
+        </SelectMenu>
+      )}
+    </Manager>
+    <Manager>
+      {({ setState, state }) => (
+        <SelectMenu
+          title="Select name"
+          options={optionsWithIcons}
+          selected={state.selected}
+          onSelect={item => setState({ selected: item.value })}
+        >
+          <Button>Options with icons</Button>
         </SelectMenu>
       )}
     </Manager>

--- a/src/select-menu/stories/starwars-options.js
+++ b/src/select-menu/stories/starwars-options.js
@@ -4,3 +4,9 @@ export default starWarsNames.all.map(name => ({
   label: name,
   value: name
 }))
+
+export const optionsWithIcons = starWarsNames.all.map(name => ({
+  label: name,
+  value: name,
+  icon: 'https://cdn.filepicker.io/api/file/nmizXMdSdqKQa9z1JOCC'
+}))


### PR DESCRIPTION
This PR adds an optional icon input for SelectMenu options.

<img width="240" alt="Screen Shot 2019-08-28 at 2 13 58 PM" src="https://user-images.githubusercontent.com/8645285/63893423-f8efed80-c99e-11e9-9e31-8bde3feb4f98.png"> 
<img width="240" alt="Screen Shot 2019-08-28 at 2 13 58 PM" src="https://user-images.githubusercontent.com/8645285/63896343-a0245300-c9a6-11e9-9c75-90a9e9af06d7.png"> 

These are the original designs that call for this kind of SelectMenu:
![image_preview (1)](https://user-images.githubusercontent.com/8645285/63893443-073e0980-c99f-11e9-9077-610bda8bc271.png)

Updated the docs:
<img width="726" alt="Screen Shot 2019-08-28 at 3 47 39 PM" src="https://user-images.githubusercontent.com/8645285/63897810-50945600-c9ab-11e9-8490-d90828801db9.png">
<img width="725" alt="Screen Shot 2019-08-28 at 3 47 44 PM" src="https://user-images.githubusercontent.com/8645285/63897811-50945600-c9ab-11e9-9995-a66d527ecc20.png">
