### PR TITLE
Autocomplete tag input

### DIFF
--- a/src/tag-input/src/AutocompleteTagInput.js
+++ b/src/tag-input/src/AutocompleteTagInput.js
@@ -1,0 +1,37 @@
+/**
+ * @overview Autocomplete of tag input component
+ */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withTheme } from '../../theme'
+import AutocompleteTagInputItem from './AutocompleteTagInputItem'
+
+class AutocompleteTagInput extends React.Component {
+  static propTypes = {
+    /** String than will be shown in autocomplete. */
+    options: PropTypes.array,
+    /**
+     * Callback invoked where autocomplete option is clicked.
+     */
+    onClick: PropTypes.func
+  }
+
+  render() {
+    const { options, onClick } = this.props
+
+    return (
+      <div>
+        {options.map(element => (
+          <AutocompleteTagInputItem
+            onClick={onClick}
+            word={element.word}
+            key={element.index}
+          />
+        ))}
+      </div>
+    )
+  }
+}
+
+export default withTheme(AutocompleteTagInput)

--- a/src/tag-input/src/AutocompleteTagInput.js
+++ b/src/tag-input/src/AutocompleteTagInput.js
@@ -4,6 +4,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import Box from 'ui-box'
 import { withTheme } from '../../theme'
 import AutocompleteTagInputItem from './AutocompleteTagInputItem'
 
@@ -21,15 +22,25 @@ class AutocompleteTagInput extends React.Component {
     const { options, onClick } = this.props
 
     return (
-      <div>
+      <Box
+        position="absolute"
+        top="135%"
+        height="70px"
+        overflow="auto"
+        width="100%"
+        left="0"
+        color="#425A70"
+        background="#E4E7EB"
+        paddingLeft="15px"
+      >
         {options.map(element => (
           <AutocompleteTagInputItem
             onClick={onClick}
             word={element.word}
-            key={element.index}
+            key={element.id}
           />
         ))}
-      </div>
+      </Box>
     )
   }
 }

--- a/src/tag-input/src/AutocompleteTagInput.js
+++ b/src/tag-input/src/AutocompleteTagInput.js
@@ -15,11 +15,34 @@ class AutocompleteTagInput extends React.Component {
     /**
      * Callback invoked where autocomplete option is clicked.
      */
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    /**
+     * Size of font
+     */
+    fontSize: PropTypes.string,
+    /**
+     * Color of font
+     */
+    color: PropTypes.string,
+    /**
+     * Color of background
+     */
+    backgroundColor: PropTypes.string,
+    /**
+     * Font
+     */
+    fontFamily: PropTypes.string
   }
 
   render() {
-    const { options, onClick } = this.props
+    const {
+      options = [],
+      onClick,
+      fontSize = '15px',
+      color = '#425A70',
+      backgroundColor = '#E4E7EB',
+      fontFamily = 'helvetica'
+    } = this.props
 
     return (
       <Box
@@ -29,8 +52,10 @@ class AutocompleteTagInput extends React.Component {
         overflow="auto"
         width="100%"
         left="0"
-        color="#425A70"
-        background="#E4E7EB"
+        color={color}
+        fontFamily={fontFamily}
+        background={backgroundColor}
+        fontSize={fontSize}
         paddingLeft="15px"
       >
         {options.map(element => (

--- a/src/tag-input/src/AutocompleteTagInputItem.js
+++ b/src/tag-input/src/AutocompleteTagInputItem.js
@@ -19,7 +19,13 @@ class AutocompleteTagInputItem extends React.Component {
     const { word, onClick } = this.props
 
     return (
-      <Box display="block" width="100%" marginTop="5px" marginBottom="5px">
+      <Box
+        display="block"
+        width="100%"
+        marginTop="5px"
+        marginBottom="5px"
+        cursor="pointer"
+      >
         <span
           onClick={() => {
             onClick(word)

--- a/src/tag-input/src/AutocompleteTagInputItem.js
+++ b/src/tag-input/src/AutocompleteTagInputItem.js
@@ -1,0 +1,32 @@
+/**
+ * @overview Autocomplete Item of tag input component
+ */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withTheme } from '../../theme'
+
+class AutocompleteTagInputItem extends React.Component {
+  static propTypes = {
+    /** String than will be shown in autocomplete. */
+    word: PropTypes.string,
+    /** Function than is called when autocomplete item is clicked  */
+    onClick: PropTypes.func
+  }
+
+  render() {
+    const { word, onClick } = this.props
+
+    return (
+      <h1
+        onClick={() => {
+          onClick(word)
+        }}
+      >
+        {word}
+      </h1>
+    )
+  }
+}
+
+export default withTheme(AutocompleteTagInputItem)

--- a/src/tag-input/src/AutocompleteTagInputItem.js
+++ b/src/tag-input/src/AutocompleteTagInputItem.js
@@ -4,6 +4,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import Box from 'ui-box'
 import { withTheme } from '../../theme'
 
 class AutocompleteTagInputItem extends React.Component {
@@ -18,13 +19,15 @@ class AutocompleteTagInputItem extends React.Component {
     const { word, onClick } = this.props
 
     return (
-      <h1
-        onClick={() => {
-          onClick(word)
-        }}
-      >
-        {word}
-      </h1>
+      <Box display="block" width="100%" marginTop="5px" marginBottom="5px">
+        <span
+          onClick={() => {
+            onClick(word)
+          }}
+        >
+          {word}
+        </span>
+      </Box>
     )
   }
 }

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -169,8 +169,6 @@ class TagInput extends React.Component {
       this.addTags(value)
     } else if (event.key === 'Backspace' && selectionEnd === 0) {
       this.handleBackspaceToRemove(event)
-    } else {
-      this.searchAutoComplete(value)
     }
   }
 
@@ -189,20 +187,20 @@ class TagInput extends React.Component {
     })
   }
 
-  searchAutoComplete = keyWord => {
+  searchAutoComplete = event => {
+    const { value } = event.target
     const { autoCompleteOptions } = this.props
 
-    const optionsToShow = autoCompleteOptions
-      .filter(element => element.includes(keyWord))
-      .map((element, index) => {
-        return {
-          id: index,
-          word: element
-        }
-      })
+    if (value) {
+      const optionsToShow = autoCompleteOptions
+        .filter(element => element.toUpperCase().includes(value.toUpperCase()))
+        .map((element, index) => ({ id: index, word: element }))
 
-    if (optionsToShow) {
-      this.setState({ optionsToShow })
+      if (optionsToShow) {
+        this.setState({ optionsToShow })
+      }
+    } else {
+      this.setState({ optionsToShow: [] })
     }
   }
 
@@ -307,6 +305,7 @@ class TagInput extends React.Component {
           onChange={this.handleInputChange}
           onFocus={this.handleInputFocus}
           onKeyDown={this.handleKeyDown}
+          onKeyUp={this.searchAutoComplete}
         />
       </Box>
     )

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -89,7 +89,7 @@ class TagInput extends React.Component {
     height: 32,
     separator: /[,\n\r]/,
     values: [],
-    autoCompleteOptions: ['teste', 'teste'],
+    autoCompleteOptions: [],
     tagProps: {}
   }
 
@@ -278,14 +278,17 @@ class TagInput extends React.Component {
         paddingLeft={Math.round(height / 3.2)}
         paddingRight={Math.round(height / 3.2)}
         paddingY="2px"
+        position="relative"
         {...props}
         onBlur={this.handleBlur}
       >
-        {optionsToShow && (
-          <AutocompleteTagInput
-            options={optionsToShow}
-            onClick={this.handleAutoComplete}
-          />
+        {optionsToShow.length > 0 && (
+          <Box borderRadius={borderRadius} paddingY="2px">
+            <AutocompleteTagInput
+              options={optionsToShow}
+              onClick={this.handleAutoComplete}
+            />
+          </Box>
         )}
         {values.map(this.maybeRenderTag)}
         <Text

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -80,7 +80,7 @@ class TagInput extends React.Component {
     /** Controlled tag values. Each value is rendered inside a tag. */
     values: PropTypes.arrayOf(PropTypes.node),
     /** Autocomplete options for tags */
-    autoCompleteOptions: PropTypes.array
+    autoComplete: PropTypes.object
   }
 
   static defaultProps = {
@@ -89,7 +89,7 @@ class TagInput extends React.Component {
     height: 32,
     separator: /[,\n\r]/,
     values: [],
-    autoCompleteOptions: [],
+    autoComplete: {},
     tagProps: {}
   }
 
@@ -189,10 +189,10 @@ class TagInput extends React.Component {
 
   searchAutoComplete = event => {
     const { value } = event.target
-    const { autoCompleteOptions } = this.props
+    const { autoComplete } = this.props
 
     if (value) {
-      const optionsToShow = autoCompleteOptions
+      const optionsToShow = autoComplete.options
         .filter(element => element.toUpperCase().includes(value.toUpperCase()))
         .map((element, index) => ({ id: index, word: element }))
 
@@ -257,6 +257,7 @@ class TagInput extends React.Component {
       tagProps,
       theme,
       values,
+      autoComplete,
       ...props
     } = this.props
 
@@ -285,6 +286,7 @@ class TagInput extends React.Component {
             <AutocompleteTagInput
               options={optionsToShow}
               onClick={this.handleAutoComplete}
+              {...autoComplete.style}
             />
           </Box>
         )}

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -11,6 +11,7 @@ import { withTheme } from '../../theme'
 import { majorScale } from '../../scales'
 import safeInvoke from '../../lib/safe-invoke'
 import Tag from './Tag'
+import AutocompleteTagInput from './AutocompleteTagInput'
 
 let inputId = 1
 
@@ -77,7 +78,9 @@ class TagInput extends React.Component {
      */
     theme: PropTypes.object.isRequired,
     /** Controlled tag values. Each value is rendered inside a tag. */
-    values: PropTypes.arrayOf(PropTypes.node)
+    values: PropTypes.arrayOf(PropTypes.node),
+    /** Autocomplete options for tags */
+    autoComplete: PropTypes.array
   }
 
   static defaultProps = {
@@ -86,12 +89,14 @@ class TagInput extends React.Component {
     height: 32,
     separator: /[,\n\r]/,
     values: [],
+    autoComplete: ['teste', 'teste'],
     tagProps: {}
   }
 
   state = {
     inputValue: '',
-    isFocused: false
+    isFocused: false,
+    autoComplete: []
   }
 
   id = `TagInput-${inputId++}`
@@ -164,6 +169,8 @@ class TagInput extends React.Component {
       this.addTags(value)
     } else if (event.key === 'Backspace' && selectionEnd === 0) {
       this.handleBackspaceToRemove(event)
+    } else {
+      this.searchAutoComplete(value)
     }
   }
 
@@ -173,6 +180,32 @@ class TagInput extends React.Component {
       event.currentTarget.parentElement.getAttribute('data-tag-index')
     )
     this.removeTagAtIndex(index)
+  }
+
+  handleAutoComplete = word => {
+    this.addTags(word)
+    this.setState({
+      autoComplete: []
+    })
+  }
+
+  searchAutoComplete = keyWord => {
+    const { autoComplete } = this.props
+
+    const autoCompleteOption = autoComplete
+      .filter(element => element.includes(keyWord))
+      .map((element, index) => {
+        return {
+          id: index,
+          word: element
+        }
+      })
+
+    if (autoCompleteOption) {
+      this.setState({
+        autoComplete: autoCompleteOption
+      })
+    }
   }
 
   maybeRenderTag = (tag, index) => {
@@ -231,7 +264,7 @@ class TagInput extends React.Component {
       ...props
     } = this.props
 
-    const { inputValue, isFocused } = this.state
+    const { inputValue, isFocused, autoComplete } = this.state
 
     const themedContainerClassName = theme.getTagInputClassName('default')
     const themedInputClassName = theme.getTextInputClassName('none')
@@ -250,6 +283,12 @@ class TagInput extends React.Component {
         {...props}
         onBlur={this.handleBlur}
       >
+        {autoComplete && (
+          <AutocompleteTagInput
+            options={autoComplete}
+            onClick={this.handleAutoComplete}
+          />
+        )}
         {values.map(this.maybeRenderTag)}
         <Text
           is="input"

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -80,7 +80,7 @@ class TagInput extends React.Component {
     /** Controlled tag values. Each value is rendered inside a tag. */
     values: PropTypes.arrayOf(PropTypes.node),
     /** Autocomplete options for tags */
-    autoComplete: PropTypes.array
+    autoCompleteOptions: PropTypes.array
   }
 
   static defaultProps = {
@@ -89,14 +89,14 @@ class TagInput extends React.Component {
     height: 32,
     separator: /[,\n\r]/,
     values: [],
-    autoComplete: ['teste', 'teste'],
+    autoCompleteOptions: ['teste', 'teste'],
     tagProps: {}
   }
 
   state = {
     inputValue: '',
     isFocused: false,
-    autoComplete: []
+    optionsToShow: []
   }
 
   id = `TagInput-${inputId++}`
@@ -185,14 +185,14 @@ class TagInput extends React.Component {
   handleAutoComplete = word => {
     this.addTags(word)
     this.setState({
-      autoComplete: []
+      optionsToShow: []
     })
   }
 
   searchAutoComplete = keyWord => {
-    const { autoComplete } = this.props
+    const { autoCompleteOptions } = this.props
 
-    const autoCompleteOption = autoComplete
+    const optionsToShow = autoCompleteOptions
       .filter(element => element.includes(keyWord))
       .map((element, index) => {
         return {
@@ -201,10 +201,8 @@ class TagInput extends React.Component {
         }
       })
 
-    if (autoCompleteOption) {
-      this.setState({
-        autoComplete: autoCompleteOption
-      })
+    if (optionsToShow) {
+      this.setState({ optionsToShow })
     }
   }
 
@@ -264,7 +262,7 @@ class TagInput extends React.Component {
       ...props
     } = this.props
 
-    const { inputValue, isFocused, autoComplete } = this.state
+    const { inputValue, isFocused, optionsToShow } = this.state
 
     const themedContainerClassName = theme.getTagInputClassName('default')
     const themedInputClassName = theme.getTextInputClassName('none')
@@ -283,9 +281,9 @@ class TagInput extends React.Component {
         {...props}
         onBlur={this.handleBlur}
       >
-        {autoComplete && (
+        {optionsToShow && (
           <AutocompleteTagInput
-            options={autoComplete}
+            options={optionsToShow}
             onClick={this.handleAutoComplete}
           />
         )}

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -2,8 +2,8 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { TagInput } from '..'
 import { Heading } from '../../typography'
+import { TagInput } from '..'
 
 const StoryHeader = props => <Box marginBottom={16} {...props} />
 const StoryHeading = props => <Heading size={600} marginBottom={0} {...props} />
@@ -137,6 +137,26 @@ storiesOf('tag-input', module).add('TagInput', () => (
             onAdd={addValues}
             onChange={handleChange}
             onRemove={removeValue}
+          />
+        )}
+      </StateManager>
+    </StorySection>
+    <StorySection>
+      <StoryHeader>
+        <StoryHeading>With autocomplete options</StoryHeading>
+      </StoryHeader>
+      <StateManager>
+        {({ values, addValues, removeValue }) => (
+          <TagInput
+            inputProps={{ placeholder: 'Enter something...' }}
+            values={values}
+            onAdd={addValues}
+            onRemove={removeValue}
+            autoCompleteOptions={[
+              'Autocomplete 1',
+              'Autocomplete 2',
+              'Autocomplete 3'
+            ]}
           />
         )}
       </StateManager>

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -152,11 +152,10 @@ storiesOf('tag-input', module).add('TagInput', () => (
             values={values}
             onAdd={addValues}
             onRemove={removeValue}
-            autoCompleteOptions={[
-              'Autocomplete 1',
-              'Autocomplete 2',
-              'Autocomplete 3'
-            ]}
+            autoComplete={{
+              options: ['Autocomplete 1', 'Autocomplete 2', 'Autocomplete 3'],
+              style: {}
+            }}
           />
         )}
       </StateManager>


### PR DESCRIPTION
Hello Guys, I saw any issues like #530 talking about autocomplete options on Tag Input Component. So I did this feature, but i could not use the default component auto complete, so I needed to create a new Auto complete component, but the final result was very cool. I added in story book too and I am sending one image for show how is:

![example](https://user-images.githubusercontent.com/49662698/64453794-c42b1700-d0bf-11e9-9b55-80ab16bf5706.png)

The code for use autocomplete options must to be:

`<TagInput
        inputProps={{ placeholder: 'Enter something...' }}
        values={values}
        onAdd={addValues}
        onRemove={removeValue}
        autoCompleteOptions={[
              'Autocomplete 1',
              'Autocomplete 2',
              'Autocomplete 3'
        ]}
/>`

Example on Tag input stories line 150.
Hope you like :)
