### PR TITLE
Make avatar image fit when non-square dimensions

### DIFF
--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -167,7 +167,7 @@ class Avatar extends PureComponent {
         )}
         {!imageUnavailable && (
           <Image
-            style={{ objectFit: 'cover' }} // ui-box doesn't support objectFit directly
+            style={{ objectFit: 'cover' }} // Unsupported by ui-box directly
             width="100%"
             height="100%"
             src={src}

--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -167,7 +167,8 @@ class Avatar extends PureComponent {
         )}
         {!imageUnavailable && (
           <Image
-            width="auto"
+            objectFit="cover"
+            width="100%"
             height="100%"
             src={src}
             onError={this.handleError}

--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -167,7 +167,7 @@ class Avatar extends PureComponent {
         )}
         {!imageUnavailable && (
           <Image
-            objectFit="cover"
+            style={{ objectFit: 'cover' }} // ui-box doesn't support objectFit directly
             width="100%"
             height="100%"
             src={src}

--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -7,6 +7,8 @@ import { withTheme } from '../../theme'
 import globalGetInitials from './utils/getInitials'
 import globalHash from './utils/hash'
 
+const isObjectFitSupported = 'objectFit' in document.documentElement.style
+
 const initialsProps = {
   top: 0,
   position: 'absolute',
@@ -168,7 +170,7 @@ class Avatar extends PureComponent {
         {!imageUnavailable && (
           <Image
             style={{ objectFit: 'cover' }} // Unsupported by ui-box directly
-            width="100%"
+            width={isObjectFitSupported ? '100%' : 'auto'} // Fallback to old behaviour on IE
             height="100%"
             src={src}
             onError={this.handleError}

--- a/src/avatar/stories/index.stories.js
+++ b/src/avatar/stories/index.stories.js
@@ -63,6 +63,20 @@ storiesOf('avatar', module).add('Avatar', () => (
         size={40}
       />
       <Avatar
+        key="Alan Turing"
+        src="https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg"
+        name="Alan Turing"
+        marginRight={12}
+        size={40}
+      />
+      <Avatar
+        key="Matt Shwery"
+        src="https://avatars1.githubusercontent.com/u/710752?s=460&v=4"
+        name="Matt Shwery"
+        marginRight={12}
+        size={40}
+      />
+      <Avatar
         key="transparent"
         forceShowInitials
         src="http://www.cityrider.com/fixed/43aspect.png"


### PR DESCRIPTION
When using an avatar image with non-square dimensions, it won't fit inside the avatar circle. (see https://evergreen.segment.com/components/avatar for an example)

If needed I could keep the old functionality and add this functionality under a flag (ex: fitImage: boolean prop)