### PR TITLE
Add showDelay prop to Tooltip

### DIFF
--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -39,6 +39,11 @@ export default class Tooltip extends PureComponent {
     hideDelay: PropTypes.number.isRequired,
 
     /**
+     * Time in ms before showing the Tooltip.
+     */
+    showDelay: PropTypes.number.isRequired,
+
+    /**
      * When True, manually show the Tooltip.
      */
     isShown: PropTypes.bool,
@@ -57,7 +62,8 @@ export default class Tooltip extends PureComponent {
   static defaultProps = {
     appearance: 'default',
     position: Position.BOTTOM,
-    hideDelay: 120
+    hideDelay: 120,
+    showDelay: 0
   }
 
   constructor(props, context) {
@@ -65,6 +71,7 @@ export default class Tooltip extends PureComponent {
 
     this.state = {
       id: `evergreen-tooltip-${++idCounter}`,
+      willShow: false,
       isShown: props.isShown,
       isShownByTarget: false
     }
@@ -80,14 +87,28 @@ export default class Tooltip extends PureComponent {
   show = () => {
     if (this.state.isShown) return
     this.setState({
-      isShown: true
+      willShow: true
     })
+    setTimeout(() => {
+      if (!this.state.willShow) return
+      this.setState({
+        isShown: true
+      })
+    }, this.props.showDelay)
   }
 
   hide = () => {
-    if (!this.state.isShown) return
+    if (!this.state.isShown) {
+      if (!this.state.willShow) return
+      this.setState({
+        willShow: false
+      })
+      return
+    }
+
     this.setState({
-      isShown: false
+      isShown: false,
+      willShow: false
     })
   }
 
@@ -154,7 +175,8 @@ export default class Tooltip extends PureComponent {
 
   handleMouseLeaveTarget = () => {
     this.setState({
-      isShownByTarget: false
+      isShownByTarget: false,
+      willShow: false
     })
   }
 

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -98,14 +98,6 @@ export default class Tooltip extends PureComponent {
   }
 
   hide = () => {
-    if (!this.state.isShown) {
-      if (!this.state.willShow) return
-      this.setState({
-        willShow: false
-      })
-      return
-    }
-
     this.setState({
       isShown: false,
       willShow: false

--- a/src/tooltip/stories/index.stories.js
+++ b/src/tooltip/stories/index.stories.js
@@ -1,10 +1,10 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import Box from 'ui-box'
-import { Tooltip } from '..'
 import { Text } from '../../typography'
 import { Position } from '../../constants'
 import { Button } from '../../buttons'
+import { Tooltip } from '..'
 
 storiesOf('tooltip', module)
   .add('Tooltip', () => (
@@ -26,6 +26,11 @@ storiesOf('tooltip', module)
       <Tooltip isShown={false} content="Should never see it">
         <Text marginLeft={40} display="inline-block" cursor="help">
           Disabled tooltip
+        </Text>
+      </Tooltip>
+      <Tooltip showDelay={800} content="My delayed tooltip content">
+        <Text marginLeft={40} display="inline-block" cursor="help">
+          Delayed tooltip
         </Text>
       </Tooltip>
     </Box>

--- a/src/tooltip/stories/index.stories.js
+++ b/src/tooltip/stories/index.stories.js
@@ -1,10 +1,10 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import Box from 'ui-box'
+import { Tooltip } from '..'
 import { Text } from '../../typography'
 import { Position } from '../../constants'
 import { Button } from '../../buttons'
-import { Tooltip } from '..'
 
 storiesOf('tooltip', module)
   .add('Tooltip', () => (


### PR DESCRIPTION
This PR adds a `showDelay` prop to `Tooltip`, which takes a value in milliseconds (default 0). The tooltip will only show if the target is hovered for this length of time. If the mouse enters then leaves before the delay is up, the tooltip will not show.

I also added an additional tooltip button in Storybook to demonstrate the delay.

This feature was requested in #620. I believe this is a useful feature - it's common for apps to have text or buttons that require a long hover before showing extra info.

![example tooltip delay](https://user-images.githubusercontent.com/28285686/64828724-ac5c0300-d597-11e9-978d-a0c868c206a5.gif)
