### PR TITLE
Update downshift to 3.3.1

### DIFF
--- a/docs/src/pages/components/autocomplete.mdx
+++ b/docs/src/pages/components/autocomplete.mdx
@@ -99,7 +99,7 @@ Get the `openMenu` prop to manually open the menu on certain events such as `onF
 >
   {({
     getInputProps,
-    getButtonProps,
+    getToggleButtonProps,
     getRef,
     inputValue,
     toggleMenu
@@ -110,7 +110,7 @@ Get the `openMenu` prop to manually open the menu on certain events such as `onF
         value={inputValue}
         {...getInputProps()}
       />
-      <Button onClick={toggleMenu} {...getButtonProps()}>
+      <Button onClick={toggleMenu} {...getToggleButtonProps()}>
         Trigger
       </Button>
     </Pane>
@@ -133,7 +133,7 @@ Consider using that component before using the `Autocomplete` component directly
   {({
     key,
     getInputProps,
-    getButtonProps,
+    getToggleButtonProps,
     getRef,
     inputValue,
     openMenu,
@@ -151,7 +151,7 @@ Consider using that component before using the `Autocomplete` component directly
         onFocus={openMenu}
         {...getInputProps()}
       />
-      <Button onClick={toggleMenu} {...getButtonProps()}>
+      <Button onClick={toggleMenu} {...getToggleButtonProps()}>
         Trigger
       </Button>
     </Pane>

--- a/docs/src/pages/components/combobox.mdx
+++ b/docs/src/pages/components/combobox.mdx
@@ -72,7 +72,7 @@ Typing in the text input will filter the list.
 
 ```jsx
 <Combobox
-  defaultSelectedItem={{ label: 'Banana' }}
+  initialSelectedItem={{ label: 'Banana' }}
   items={[{ label: 'Banana' }, { label: 'Pear' }, { label: 'Kiwi' }]}
   itemToString={item => item ? item.label : ''}
   onChange={selected => console.log(selected)}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.2.1",
-    "downshift": "^1.31.16",
+    "downshift": "^3.3.1",
     "fuzzaldrin-plus": "^0.6.0",
     "glamor": "^2.20.40",
     "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   "size-limit": [
     {
       "path": "commonjs/index.js",
-      "limit": "204 KB"
+      "limit": "210 KB"
     }
   ],
   "husky": {

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -147,6 +147,22 @@ export default class Autocomplete extends PureComponent {
     })
   }
 
+  stateReducer = (state, changes) => {
+    const { items } = this.props
+
+    if (
+      Object.prototype.hasOwnProperty.call(changes, 'isOpen') &&
+      changes.isOpen
+    ) {
+      return {
+        ...changes,
+        highlightedIndex: items.indexOf(state.selectedItem)
+      }
+    }
+
+    return changes
+  }
+
   renderResults = ({
     width,
     inputValue,
@@ -237,6 +253,7 @@ export default class Autocomplete extends PureComponent {
         initialSelectedItem={initialSelectedItem || defaultSelectedItem}
         initialInputValue={initialInputValue || defaultInputValue}
         getToggleButtonProps={getToggleButtonProps || getButtonProps}
+        stateReducer={this.stateReducer}
         {...props}
       >
         {({

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -48,9 +48,22 @@ export default class Autocomplete extends PureComponent {
     selectedItem: PropTypes.any,
 
     /**
-     * The selected item to be selected & shown by default on the autocomplete
+     * The selected item to be selected & shown by default on the autocomplete (deprecated)
+     * @return {Error} a deprecation warning
      */
-    defaultSelectedItem: PropTypes.any,
+    defaultSelectedItem: () =>
+      new Error(
+        `The 'defaultSelectedItem' prop is deprecated, use 'initialSelectedItem' instead`
+      ),
+
+    /**
+     * The selected item to be selected & shown by default on the autocomplete (deprecated)
+     * @return {Error} a deprecation warning
+     */
+    defaultInputValue: () =>
+      new Error(
+        `The 'defaultInputValue' prop is deprecated, use 'initialInputValue' instead`
+      ),
 
     /**
      * In case the array of items is not an array of strings,
@@ -102,6 +115,15 @@ export default class Autocomplete extends PureComponent {
      * Defines the maximum height the results container will be
      */
     popoverMaxHeight: PropTypes.number,
+
+    /**
+     * The selected item to be selected & shown by default on the autocomplete (deprecated)
+     * @return {Error} a deprecation warning
+     */
+    getButtonProps: () =>
+      new Error(
+        `The 'getButtonProps' prop is deprecated, use 'getToggleButtonProps' instead`
+      ),
 
     ...Downshift.propTypes
   }
@@ -201,12 +223,22 @@ export default class Autocomplete extends PureComponent {
       itemsFilter,
       popoverMaxHeight,
       popoverMinWidth,
-      defaultSelectedItem,
+      defaultSelectedItem, // Deprecated
+      initialSelectedItem,
+      defaultInputValue, // Deprecated
+      initialInputValue,
+      getButtonProps, // Deprecated
+      getToggleButtonProps,
       ...props
     } = this.props
 
     return (
-      <Downshift defaultSelectedItem={defaultSelectedItem} {...props}>
+      <Downshift
+        initialSelectedItem={initialSelectedItem || defaultSelectedItem}
+        initialInputValue={initialInputValue || defaultInputValue}
+        getToggleButtonProps={getToggleButtonProps || getButtonProps}
+        {...props}
+      >
         {({
           isOpen: isShown,
           inputValue,

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -7,6 +7,7 @@ import { Popover } from '../../popover'
 import { Position } from '../../constants'
 import { Heading } from '../../typography'
 import { Pane } from '../../layers'
+import deprecated from '../../lib/deprecated'
 import AutocompleteItem from './AutocompleteItem'
 
 const fuzzyFilter = itemToString => {
@@ -49,21 +50,19 @@ export default class Autocomplete extends PureComponent {
 
     /**
      * The selected item to be selected & shown by default on the autocomplete (deprecated)
-     * @return {Error} a deprecation warning
      */
-    defaultSelectedItem: () =>
-      new Error(
-        `The 'defaultSelectedItem' prop is deprecated, use 'initialSelectedItem' instead`
-      ),
+    defaultSelectedItem: deprecated(
+      PropTypes.any,
+      'Use "initialSelectedItem" instead.'
+    ),
 
     /**
      * The selected item to be selected & shown by default on the autocomplete (deprecated)
-     * @return {Error} a deprecation warning
      */
-    defaultInputValue: () =>
-      new Error(
-        `The 'defaultInputValue' prop is deprecated, use 'initialInputValue' instead`
-      ),
+    defaultInputValue: deprecated(
+      PropTypes.any,
+      'Use "initialInputValue" instead.'
+    ),
 
     /**
      * In case the array of items is not an array of strings,
@@ -118,12 +117,11 @@ export default class Autocomplete extends PureComponent {
 
     /**
      * The selected item to be selected & shown by default on the autocomplete (deprecated)
-     * @return {Error} a deprecation warning
      */
-    getButtonProps: () =>
-      new Error(
-        `The 'getButtonProps' prop is deprecated, use 'getToggleButtonProps' instead`
-      ),
+    getButtonProps: deprecated(
+      PropTypes.func,
+      'Use "getToggleButtonProps" instead.'
+    ),
 
     ...Downshift.propTypes
   }

--- a/src/autocomplete/stories/index.stories.js
+++ b/src/autocomplete/stories/index.stories.js
@@ -129,7 +129,7 @@ storiesOf('autocomplete', module).add('Autocomplete', () => (
       <Autocomplete onChange={handleChange} items={items}>
         {({
           getInputProps,
-          getButtonProps,
+          getToggleButtonProps,
           getRef,
           inputValue,
           toggleMenu
@@ -140,7 +140,7 @@ storiesOf('autocomplete', module).add('Autocomplete', () => (
               value={inputValue}
               {...getInputProps()}
             />
-            <Button onClick={toggleMenu} {...getButtonProps()}>
+            <Button onClick={toggleMenu} {...getToggleButtonProps()}>
               Trigger
             </Button>
           </Box>

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -38,7 +38,16 @@ export default class Combobox extends PureComponent {
     /**
      * Default selected item when uncontrolled.
      */
-    defaultSelectedItem: PropTypes.any,
+    initialSelectedItem: PropTypes.any,
+
+    /**
+     * Default selected item when uncontrolled (deprecated)
+     * @return {Error} a deprecation warning
+     */
+    defaultSelectedItem: () =>
+      new Error(
+        `The 'defaultSelectedItem' prop is deprecated, use 'initialSelectedItem' instead`
+      ),
 
     /**
      * The placeholder text when there is no value present.
@@ -103,7 +112,8 @@ export default class Combobox extends PureComponent {
     const {
       items,
       selectedItem,
-      defaultSelectedItem,
+      defaultSelectedItem, // Deprecated
+      initialSelectedItem,
       itemToString,
       width,
       height,
@@ -123,7 +133,7 @@ export default class Combobox extends PureComponent {
       <Autocomplete
         items={items}
         selectedItem={selectedItem}
-        defaultSelectedItem={defaultSelectedItem}
+        initialSelectedItem={initialSelectedItem || defaultSelectedItem}
         itemToString={itemToString}
         onChange={onChange}
         onStateChange={this.handleStateChange}
@@ -136,7 +146,7 @@ export default class Combobox extends PureComponent {
           openMenu,
           inputValue,
           getInputProps,
-          getButtonProps,
+          getToggleButtonProps,
           clearSelection
         }) => (
           <Box
@@ -186,7 +196,7 @@ export default class Combobox extends PureComponent {
               borderBottomLeftRadius={0}
               disabled={disabled}
               isLoading={isLoading}
-              {...getButtonProps({
+              {...getToggleButtonProps({
                 ...buttonProps,
                 onClick: () => {
                   if (!isShown) {

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -4,6 +4,7 @@ import Box, { dimensions, spacing, position, layout } from 'ui-box'
 import { Autocomplete } from '../../autocomplete'
 import { TextInput } from '../../text-input'
 import { IconButton } from '../../buttons'
+import deprecated from '../../lib/deprecated'
 
 export default class Combobox extends PureComponent {
   static propTypes = {
@@ -42,12 +43,11 @@ export default class Combobox extends PureComponent {
 
     /**
      * Default selected item when uncontrolled (deprecated)
-     * @return {Error} a deprecation warning
      */
-    defaultSelectedItem: () =>
-      new Error(
-        `The 'defaultSelectedItem' prop is deprecated, use 'initialSelectedItem' instead`
-      ),
+    defaultSelectedItem: deprecated(
+      PropTypes.any,
+      'Use "initialSelectedItem" instead.'
+    ),
 
     /**
      * The placeholder text when there is no value present.

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -52,7 +52,7 @@ storiesOf('combobox', module).add('Combobox', () => (
     <Box marginBottom={16}>
       <Heading>Default value</Heading>
       <Combobox
-        defaultSelectedItem="Yoda"
+        initialSelectedItem="Yoda"
         items={items}
         onChange={handleChange}
       />
@@ -60,7 +60,7 @@ storiesOf('combobox', module).add('Combobox', () => (
     <Box marginBottom={16}>
       <Heading>Custom item objects</Heading>
       <Combobox
-        defaultSelectedItem={customItems[0]}
+        initialSelectedItem={customItems[0]}
         items={customItems}
         itemToString={i => (i ? i.label : '')}
         onChange={handleChange}
@@ -81,7 +81,7 @@ storiesOf('combobox', module).add('Combobox', () => (
       <Pane display="flex" background="tint1" padding={16}>
         <Combobox
           width="100%"
-          defaultSelectedItem={customItems[0]}
+          initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}
@@ -92,7 +92,7 @@ storiesOf('combobox', module).add('Combobox', () => (
       <Pane display="flex" background="tint2" width="75%" padding={16}>
         <Combobox
           width="100%"
-          defaultSelectedItem={customItems[0]}
+          initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}
@@ -110,7 +110,7 @@ storiesOf('combobox', module).add('Combobox', () => (
       >
         <Combobox
           width="100%"
-          defaultSelectedItem={customItems[0]}
+          initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}

--- a/src/lib/deprecated.js
+++ b/src/lib/deprecated.js
@@ -1,0 +1,14 @@
+import warning from './warning'
+
+export default (propType, explanation) => {
+  return (props, propName, componentName, ...rest) => {
+    if (process.env.NODE_ENV !== 'production') {
+      warning(
+        propName in props,
+        `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`
+      )
+    }
+
+    return propType(props, propName, componentName, ...rest)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,6 +775,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.4.5":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
+  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -860,6 +867,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@reach/auto-id@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.2.0.tgz#97f9e48fe736aa5c6f4f32cf73c1f19d005f8550"
+  integrity sha512-lVK/svL2HuQdp7jgvlrLkFsUx50Az9chAhxpiPwBqcS83I2pVWvXp98FOcSCCJCV++l115QmzHhFd+ycw1zLBg==
 
 "@reactions/component@^2.0.2":
   version "2.0.2"
@@ -3969,6 +3981,11 @@ compression-webpack-plugin@^2.0.0:
     serialize-javascript "^1.4.0"
     webpack-sources "^1.0.1"
 
+compute-scroll-into-view@^1.0.9:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
+  integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4979,10 +4996,17 @@ dotenv@^5.0.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
 
-downshift@^1.31.16:
-  version "1.31.16"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
-  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
+downshift@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.3.1.tgz#429ce98be43115664d2ea54f841d80059007b883"
+  integrity sha512-PdbDQIq7hVE9HO2fHMZA1JaoVKClNHkXIcDZAlCmXksCd7cU+demBjuYhYIXUml/8n6RejXbvXakg2mK1pbUyw==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@reach/auto-id" "^0.2.0"
+    compute-scroll-into-view "^1.0.9"
+    keyboard-key "1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -8079,6 +8103,11 @@ just-extend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
+keyboard-key@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.0.4.tgz#52d8fa07b7e17757072aa22a67fb4ae85e4c46b0"
+  integrity sha512-my04dE6BCwPpwoe4KYKfPxWiwgDYQOHrVmtzn1CfzmoEsGG/ef4oZGaXCzi1+iFhG7CN5JkOuxmei5OABY8/ag==
 
 keycode@^2.1.9:
   version "2.2.0"
@@ -11247,6 +11276,11 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
+react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -11548,6 +11582,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
This is #523, reopened.

It aliases and deprecates removed props from Downshift.

This still fixes #450 by creating a `stateReducer` that will set the `highlightedItem` to the selected item when opening the autocomplete – as suggested by @kentcdodds here: https://github.com/downshift-js/downshift/issues/645#issuecomment-451805753.