### PR TITLE
Change icon prop-types from string to node

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -52,12 +52,12 @@ class Button extends PureComponent {
     isActive: PropTypes.bool,
 
     /**
-     * Sets an icon before the text. Can be any icon from Evergreen.
+     * Sets an icon before the text. Can be any icon from Evergreen or a custom element.
      */
     iconBefore: PropTypes.node,
 
     /**
-     * Sets an icon after the text. Can be any icon from Evergreen.
+     * Sets an icon after the text. Can be any icon from Evergreen or a custom element.
      */
     iconAfter: PropTypes.node,
 

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -54,12 +54,12 @@ class Button extends PureComponent {
     /**
      * Sets an icon before the text. Can be any icon from Evergreen.
      */
-    iconBefore: PropTypes.string,
+    iconBefore: PropTypes.node,
 
     /**
      * Sets an icon after the text. Can be any icon from Evergreen.
      */
-    iconAfter: PropTypes.string,
+    iconAfter: PropTypes.node,
 
     /**
      * When true, the button is disabled.

--- a/src/icon/src/Icon.js
+++ b/src/icon/src/Icon.js
@@ -36,7 +36,7 @@ class Icon extends PureComponent {
      *   This type is supported to simplify usage of this component in other Blueprint components.
      *   As a consumer, you should never use `<Icon icon={<element />}` directly; simply render `<element />` instead.
      */
-    icon: PropTypes.string.isRequired,
+    icon: PropTypes.node.isRequired,
 
     /**
      * Size of the icon, in pixels.


### PR DESCRIPTION
This PR simply switches the prop-types for Icon (and Button icons) from `string` to `node`, which allows both strings and custom elements. Fixes #535. 

Since any valid node is correctly rendered by icon props, the PropTypes for these icons should not be restricted to strings. 

It's great to have this option for implementing custom icons with images or even FontAwesome, which already works great in spite of the PropTypes warnings. 

