### PR TITLE
Fix "Autocomplete does not select option on mobile (on tap)" (#623)

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -207,6 +207,10 @@ export default class Autocomplete extends PureComponent {
             renderItem={({ index, style }) => {
               const item = items[index]
               const itemString = itemToString(item)
+              const onSelect = () => {
+                selectItemAtIndex(index)
+              }
+
               return renderItem(
                 getItemProps({
                   item,
@@ -214,9 +218,8 @@ export default class Autocomplete extends PureComponent {
                   index,
                   style,
                   children: itemString,
-                  onMouseUp: () => {
-                    selectItemAtIndex(index)
-                  },
+                  onMouseUp: onSelect,
+                  onTouchEnd: onSelect,
                   isSelected: itemToString(selectedItem) === itemString,
                   isHighlighted: highlightedIndex === index
                 })


### PR DESCRIPTION
## Context

When using a phone or a device with touch control choose an item from autocomplete. It results in nothing and the autocomplete value remains empty.

## Why?

It's because items for autocomplete rely only on mouse action. Whenever `onMouseUp` happens, the item will be chosen.

## Solution

It's needed to provide touch support by adding another event handler called `onTouchEnd`.