### PR TITLE
Improve EditableCell behavior

### DIFF
--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -16,9 +16,9 @@ class EditableCell extends React.PureComponent {
     ...TableCell.propTypes,
 
     /*
-    * Makes the TableCell focusable.
-    * Will add tabIndex={-1 || this.props.tabIndex}.
-    */
+     * Makes the TableCell focusable.
+     * Will add tabIndex={-1 || this.props.tabIndex}.
+     */
     isSelectable: PropTypes.bool.isRequired,
 
     /**
@@ -87,20 +87,20 @@ class EditableCell extends React.PureComponent {
      * When the user presses a character on the keyboard, use that character
      * as the value in the text field.
      */
-    if (key === 'Enter' || key === 'Shift') {
+    if (key === 'Enter') {
       this.setState({
         isEditing: true
       })
     } else if (
-      key.match(/^[a-z]{0,10}$/) &&
+      key.match(/^[a-zA-Z0-9]$/) &&
       !e.metaKey &&
       !e.ctrlKey &&
       !e.altKey
     ) {
-      this.setState(prevState => ({
+      this.setState({
         isEditing: true,
-        value: prevState.value + key
-      }))
+        value: key
+      })
     }
   }
 

--- a/src/table/src/EditableCellField.js
+++ b/src/table/src/EditableCellField.js
@@ -65,6 +65,8 @@ export default class EditableCellField extends React.PureComponent {
 
     requestAnimationFrame(() => {
       this.textareaRef.focus()
+      // Move cursor to end of cell content
+      this.textareaRef.selectionStart = this.textareaRef.value.length
     })
   }
 


### PR DESCRIPTION
This PR fixes #637, which states the following problems in editable table cells:

- Cell textarea opens when Shift is pressed (Expected: Textarea should not open with Shift)
- Caret position starts at beginning of textarea (Expected: Caret should start at end of text)
- When focusing a cell then pressing a letter, the letter is appended to the end of the text (Expected: pressed letter should replace the existing cell text)
- When focusing a cell then pressing a number, nothing happens (Expected: The textarea should open, replacing existing text with the pressed number)