### PR TITLE
Fixing stateless props override on Popover component

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -87,7 +87,7 @@ export default class Popover extends Component {
      * Function that will be called when the exit transition is complete.
      */
     onCloseComplete: PropTypes.func.isRequired,
-    
+
     /**
      * Function that will be called when the body is clicked.
      */
@@ -112,7 +112,7 @@ export default class Popover extends Component {
     onOpen: () => {},
     onClose: () => {},
     onOpenComplete: () => {},
-    onCloseComplete: () => {},    
+    onCloseComplete: () => {},
     onBodyClick: () => {},
     bringFocusInside: false,
     shouldCloseOnExternalClick: true,
@@ -202,7 +202,7 @@ export default class Popover extends Component {
     if (this.popoverNode && this.popoverNode.contains(e.target)) {
       return
     }
-    
+
     // Notify body click
     this.props.onBodyClick(e)
 
@@ -373,11 +373,14 @@ export default class Popover extends Component {
             }}
             data-state={state}
             css={css}
-            style={style}
             display={display}
             minWidth={minWidth}
             minHeight={minHeight}
             {...statelessProps}
+            style={{
+              ...style,
+              ...statelessProps.style
+            }}
             onMouseLeave={this.handleCloseHover}
           >
             {typeof content === 'function'

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -377,10 +377,14 @@ export default class Popover extends Component {
             minWidth={minWidth}
             minHeight={minHeight}
             {...statelessProps}
-            style={{
-              ...style,
-              ...statelessProps.style
-            }}
+            style={
+              statelessProps && statelessProps.style
+                ? {
+                    ...style,
+                    ...statelessProps.style
+                  }
+                : style
+            }
             onMouseLeave={this.handleCloseHover}
           >
             {typeof content === 'function'


### PR DESCRIPTION
Fixing issue reported on: https://github.com/segmentio/evergreen/issues/639

I was taking a look at the `PopOver` component and I noticed that when I pass a value for the `statelessProps` props - with a style object - it'll start to override and lost all the previous style properties.

It's because it was just spreading the `statelessProps` into the component and overriding all the default styling values.

So my change was basically to merge the `statelessProps.style` with the current `style` into one single `style` props.

So, I can do something like this without losing any default style props.
```js
<Popover
          ...
          statelessProps={{
            style: {
              zIndex: 1000
            }
          }}
         ...
/>
```