### PR TITLE
Adding overlayProps to the Dialog component in order to allow some cu…

### DIFF
--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -38,14 +38,10 @@ const closeAnimation = css.keyframes('closeAnimation', {
 
 const animationStyles = {
   '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.deceleration
-    } both`
+    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
   },
   '&[data-state="exiting"]': {
-    animation: `${closeAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.acceleration
-    } both`
+    animation: `${closeAnimation} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
   }
 }
 
@@ -187,7 +183,12 @@ class Dialog extends React.Component {
     /**
      * Whether or not to prevent scrolling in the outer body
      */
-    preventBodyScrolling: PropTypes.bool
+    preventBodyScrolling: PropTypes.bool,
+
+    /**
+     * Props that are passed to the Overlay component.
+     */
+    overlayProps: PropTypes.object
   }
 
   static defaultProps = {
@@ -209,7 +210,8 @@ class Dialog extends React.Component {
     shouldCloseOnEscapePress: true,
     onCancel: close => close(),
     onConfirm: close => close(),
-    preventBodyScrolling: false
+    preventBodyScrolling: false,
+    overlayProps: {}
   }
 
   renderChildren = close => {
@@ -251,7 +253,8 @@ class Dialog extends React.Component {
       containerProps,
       contentContainerProps,
       minHeightContent,
-      preventBodyScrolling
+      preventBodyScrolling,
+      overlayProps
     } = this.props
 
     const sideOffsetWithUnit = Number.isInteger(sideOffset)
@@ -274,7 +277,8 @@ class Dialog extends React.Component {
         containerProps={{
           display: 'flex',
           alignItems: 'flex-start',
-          justifyContent: 'center'
+          justifyContent: 'center',
+          ...overlayProps
         }}
         preventBodyScrolling={preventBodyScrolling}
       >


### PR DESCRIPTION
It's a similar change I've on the merged PR (https://github.com/segmentio/evergreen/pull/640) but on the `Dialog` component at this time.

Currently the `Overlay` component - inside the `Dialog` - only have the following `containerProps`:

```
containerProps={{
   display: 'flex',
   alignItems: 'flex-start',
   justifyContent: 'center',
}}
```

So I added a new props called `overlayProps` in order to allow us to make more customisations with it.

So, in this way, we're going to keep the default values to `containerProps` and override or add more  when it's passed.