### PR TITLE
Disable default scrollIntoView behavior

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -27,6 +27,8 @@ const fuzzyFilter = itemToString => {
   return (items, input) => fuzzaldrin.filter(items, input)
 }
 
+const noop = () => {}
+
 const autocompleteItemRenderer = props => <AutocompleteItem {...props} />
 
 // https://github.com/paypal/downshift/issues/164
@@ -255,6 +257,7 @@ export default class Autocomplete extends PureComponent {
         initialInputValue={initialInputValue || defaultInputValue}
         getToggleButtonProps={getToggleButtonProps || getButtonProps}
         stateReducer={this.stateReducer}
+        scrollIntoView={noop}
         {...props}
       >
         {({


### PR DESCRIPTION
#631 introduces a small issue with `scrollIntoView` where the page would scroll to display the items list. This is already handled by the `Popover` being displayed above or below the input, depending on the available space.

Before:

![existing](https://user-images.githubusercontent.com/166147/66225448-b8d80500-e6d8-11e9-9f1f-7ccc76d77471.gif)


After:

![new](https://user-images.githubusercontent.com/166147/66225469-c2fa0380-e6d8-11e9-8d0e-392e93f3fed4.gif)

This simply disables the `scrollIntoView` default behavior.
