### PR TITLE
fix:closeOnSelect must be destructed from props

### DIFF
--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -225,6 +225,7 @@ export default class OptionsList extends PureComponent {
     const {
       options: originalOptions,
       close,
+      closeOnSelect,
       width,
       height,
       onSelect,


### PR DESCRIPTION
This closeOnSelect must be declared separately in const{options}