### PR TITLE
Fix jumping check icon within `<Switch>` when placed inside `<Dialog>`

### DIFF
--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -15,7 +15,6 @@ const handleStyle = {
 const iconContainerStyle = {
   transition: `all 500ms ${animationEasing.spring}`,
   opacity: 0,
-  transform: 'scale(0.0)',
   display: 'flex',
   position: 'absolute',
   alignItems: 'center',
@@ -23,6 +22,13 @@ const iconContainerStyle = {
   paddingLeft: 4,
   '&[data-checked="true"]': {
     opacity: 1,
+    transform: 'scale(1)'
+  },
+  '> svg': {
+    transition: `all 500ms ${animationEasing.spring}`,
+    transform: 'scale(0)'
+  },
+  '&[data-checked="true"] > svg': {
     transform: 'scale(1)'
   }
 }


### PR DESCRIPTION
I still don't know what specifically caused it within `<Dialog>`, but the fix was to move `scale` transition onto `svg` itself.

Before:

![Kapture 2019-10-23 at 15 19 53](https://user-images.githubusercontent.com/697676/67440624-bfa6b900-f5ae-11e9-96be-d956262608ab.gif)


After:

![Kapture 2019-10-23 at 16 02 32](https://user-images.githubusercontent.com/697676/67440620-bd445f00-f5ae-11e9-9765-de7f60cfb487.gif)

