### PR TITLE
Fix custom className not applied to Tooltip components

### DIFF
--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -212,7 +212,7 @@ export default class Tooltip extends PureComponent {
             onMouseLeave={this.handleMouseLeaveTarget}
             {...statelessProps}
             className={cx(
-              statelessProps.classNames,
+              statelessProps.className,
               css ? gcss(css).toString() : undefined
             )}
           >


### PR DESCRIPTION
This PR fixes #666, which modifies [src/tooltip/src/Tooltip.js](https://github.com/segmentio/evergreen/blob/v4.21.1/src/tooltip/src/Tooltip.js#L215) to use `statelessProps.className` instead of `statelessProps.classNames`.