### PR TITLE
clear timeout when component unmounts

### DIFF
--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -86,12 +86,16 @@ export default class Tooltip extends PureComponent {
     this.hide = debounce(this.hide, this.props.hideDelay)
   }
 
+  componentWillUnmount() {
+    clearTimeout(this.timeout)
+  }
+
   show = () => {
     if (this.state.isShown) return
     this.setState({
       willShow: true
     })
-    setTimeout(() => {
+    this.timeout = setTimeout(() => {
       if (!this.state.willShow) return
       this.setState({
         isShown: true


### PR DESCRIPTION
fixes the following React warning:

> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.