### PR TITLE
fix missing animations due to premature glamor classname-ifying

### DIFF
--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import { css } from 'glamor'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
@@ -38,14 +37,16 @@ const closeAnimation = css.keyframes('closeAnimation', {
   }
 })
 
-const animationStylesClass = css({
+const animationStyles = {
   '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${animationEasing.spring} both`
+    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${
+      animationEasing.spring
+    } both`
   },
   '&[data-state="exiting"]': {
     animation: `${closeAnimation} 120ms ${animationEasing.acceleration} both`
   }
-}).toString()
+}
 
 export default class CornerDialog extends PureComponent {
   static propTypes = {
@@ -245,6 +246,7 @@ export default class CornerDialog extends PureComponent {
               backgroundColor="white"
               elevation={4}
               width={width}
+              css={animationStyles}
               data-state={state}
               padding={32}
               position="fixed"
@@ -254,7 +256,6 @@ export default class CornerDialog extends PureComponent {
                   : positions.BOTTOM_RIGHT
               ]}
               {...containerProps}
-              className={cx(containerProps.className, animationStylesClass)}
             >
               <Pane display="flex" alignItems="center" marginBottom={12}>
                 <Heading is="h4" size={600} flex="1">

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import { css } from 'glamor'
 import React from 'react'
 import PropTypes from 'prop-types'
@@ -37,7 +36,7 @@ const closeAnimation = css.keyframes('closeAnimation', {
   }
 })
 
-const animationStylesClass = css({
+const animationStyles = {
   '&[data-state="entering"], &[data-state="entered"]': {
     animation: `${openAnimation} ${ANIMATION_DURATION}ms ${
       animationEasing.deceleration
@@ -48,7 +47,7 @@ const animationStylesClass = css({
       animationEasing.acceleration
     } both`
   }
-}).toString()
+}
 
 class Dialog extends React.Component {
   static propTypes = {
@@ -300,9 +299,9 @@ class Dialog extends React.Component {
             marginY={topOffsetWithUnit}
             display="flex"
             flexDirection="column"
+            css={animationStyles}
             data-state={state}
             {...containerProps}
-            className={cx(containerProps.className, animationStylesClass)}
           >
             {hasHeader && (
               <Pane

--- a/src/layers/src/Pane.js
+++ b/src/layers/src/Pane.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import { css as gcss } from 'glamor'
+import { css as glamorCss } from 'glamor'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
@@ -174,7 +174,7 @@ class Pane extends PureComponent {
 
     const className = cx(
       props.className,
-      gcss({
+      glamorCss({
         ...css,
         ...hoverElevationStyle,
         ...activeElevationStyle

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import { css as gcss } from 'glamor'
+import { css as glamorCss } from 'glamor'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Positioner } from '../../positioner'
@@ -378,13 +378,16 @@ export default class Popover extends Component {
             minWidth={minWidth}
             minHeight={minHeight}
             {...statelessProps}
-            className={cx(statelessProps.className, css ? gcss(css).toString() : undefined)}
+            className={cx(
+              statelessProps.className,
+              css ? glamorCss(css).toString() : undefined
+            )}
             style={
               statelessProps && statelessProps.style
                 ? {
-                  ...style,
-                  ...statelessProps.style
-                }
+                    ...style,
+                    ...statelessProps.style
+                  }
                 : style
             }
             onMouseLeave={this.handleCloseHover}

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -75,7 +75,7 @@ const withAnimations = (animateIn, animateOut) => {
 }
 
 const animationStylesClass = {
-  [Position.LEFT]: css({
+  [Position.LEFT]: {
     transform: `translateX(-100%)`,
     ...withAnimations(
       css.keyframes('anchoredLeftSlideInAnimation', {
@@ -87,8 +87,8 @@ const animationStylesClass = {
         to: { transform: `translateX(-100%)` }
       })
     )
-  }),
-  [Position.RIGHT]: css({
+  },
+  [Position.RIGHT]: {
     transform: `translateX(100%)`,
     ...withAnimations(
       css.keyframes('anchoredRightSlideInAnimation', {
@@ -100,8 +100,8 @@ const animationStylesClass = {
         to: { transform: `translateX(100%)` }
       })
     )
-  }),
-  [Position.TOP]: css({
+  },
+  [Position.TOP]: {
     transform: `translateY(-100%)`,
     ...withAnimations(
       css.keyframes('anchoredTopSlideInAnimation', {
@@ -113,8 +113,8 @@ const animationStylesClass = {
         to: { transform: `translateY(-100%)` }
       })
     )
-  }),
-  [Position.BOTTOM]: css({
+  },
+  [Position.BOTTOM]: {
     transform: `translateY(100%)`,
     ...withAnimations(
       css.keyframes('anchoredBottomSlideInAnimation', {
@@ -126,7 +126,7 @@ const animationStylesClass = {
         to: { transform: `translateY(100%)` }
       })
     )
-  })
+  }
 }
 
 class SideSheet extends React.Component {
@@ -232,7 +232,7 @@ class SideSheet extends React.Component {
           <Pane
             width={width}
             {...paneProps[position]}
-            className={animationStylesClass[position]}
+            css={animationStylesClass[position]}
             data-state={state}
           >
             <SheetClose

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import { css as gcss } from 'glamor'
+import { css as glamorCss } from 'glamor'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import debounce from 'lodash.debounce'
@@ -213,7 +213,7 @@ export default class Tooltip extends PureComponent {
             {...statelessProps}
             className={cx(
               statelessProps.className,
-              css ? gcss(css).toString() : undefined
+              css ? glamorCss(css).toString() : undefined
             )}
           >
             {content}

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -1,3 +1,5 @@
+import cx from 'classnames'
+import { css as gcss } from 'glamor'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
@@ -35,7 +37,16 @@ class Text extends PureComponent {
   }
 
   render() {
-    const { theme, size, color, fontFamily, marginTop, ...props } = this.props
+    const {
+      className,
+      css,
+      theme,
+      size,
+      color,
+      fontFamily,
+      marginTop,
+      ...props
+    } = this.props
 
     const { marginTop: defaultMarginTop, ...textStyle } = theme.getTextStyle(
       size
@@ -51,6 +62,7 @@ class Text extends PureComponent {
         fontFamily={theme.getFontFamily(fontFamily)}
         marginTop={finalMarginTop}
         {...textStyle}
+        className={cx(className, css ? gcss(css).toString() : undefined)}
         {...props}
       />
     )

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import { css as gcss } from 'glamor'
+import { css as glamorCss } from 'glamor'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
@@ -62,7 +62,7 @@ class Text extends PureComponent {
         fontFamily={theme.getFontFamily(fontFamily)}
         marginTop={finalMarginTop}
         {...textStyle}
-        className={cx(className, css ? gcss(css).toString() : undefined)}
+        className={cx(className, css ? glamorCss(css).toString() : undefined)}
         {...props}
       />
     )


### PR DESCRIPTION
When we migrated off of `ui-box`'s `css` prop, we made the mistake of merging styles into a classname too early in a few cases (where more styles need to be incorporated). This leads to style overrides that don't quite match up with expectations it seems. Plumbing the `css` prop down to components like Pane and Text allows us the ability to more safely merge those styles.

Fixes #669