### PR TITLE
avoid implicit any type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,9 @@
 declare module 'evergreen-ui' {
   import { IconName } from '@blueprintjs/icons'
   import * as React from 'react'
-  import { extractStyles as boxExtractStyles } from 'ui-box'
-  import Box from 'ui-box'
+  import Box, { extractStyles as boxExtractStyles } from 'ui-box'
   import { BoxProps, Is } from 'ui-box/dist/types/box-types'
+  import { StyleAttribute, CSSProperties } from 'glamor'
   import { DownshiftProps, GetInputPropsOptions } from 'downshift'
 
   type PositionTypes = 'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'
@@ -1201,10 +1201,10 @@ declare module 'evergreen-ui' {
     position?: PositionTypes
     isShown?: boolean
     children: (params: {
-      top: number,
-      left: number,
-      zIndex: NonNullable<StackProps['value']>,
-      css,
+      top: number
+      left: number
+      zIndex: NonNullable<StackProps['value']>
+      css: StyleAttribute | CSSProperties,
       style: {
         transformOrigin: string,
         left: number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1201,9 +1201,9 @@ declare module 'evergreen-ui' {
     position?: PositionTypes
     isShown?: boolean
     children: (params: {
-      top: number
-      left: number
-      zIndex: NonNullable<StackProps['value']>
+      top: number,
+      left: number,
+      zIndex: NonNullable<StackProps['value']>,
       css: StyleAttribute | CSSProperties,
       style: {
         transformOrigin: string,


### PR DESCRIPTION
Previously `css` resulted in an implicit any error:

```
$ tsc
node_modules/evergreen-ui/index.d.ts:1207:7 - error TS7008: Member 'css' implicitly has an 'any' type.

1207       css,
           ~~~


Found 1 error.
```