### PR TITLE
Fix checkbox width on label line break

### DIFF
--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -158,6 +158,7 @@ class Checkbox extends PureComponent {
           boxSizing="border-box"
           borderRadius={3}
           display="flex"
+          flex="none"
           alignItems="center"
           justifyContent="center"
           width={16}


### PR DESCRIPTION
## Overview
This PR fixes the checkbox width being modified when the label breaks onto another line.

Props to @mshwery for the solution.

### Before
![Screen Shot 2019-11-07 at 5 21 39 PM](https://user-images.githubusercontent.com/16131737/68441620-8ca21f00-0183-11ea-87ca-45dc0adb9ff2.png)

### After
![Screen Shot 2019-11-07 at 5 21 50 PM](https://user-images.githubusercontent.com/16131737/68441634-9592f080-0183-11ea-8994-cb6f9d55247a.png)

_*Does not affect when label doesn't break onto another line._
![Screen Shot 2019-11-07 at 5 22 17 PM](https://user-images.githubusercontent.com/16131737/68441697-cb37d980-0183-11ea-99c3-c00299c32e8f.png)