### PR TITLE
Adding custom CSS (open/close) animations to the Dialog component

### DIFF
--- a/docs/src/pages/components/dialog.mdx
+++ b/docs/src/pages/components/dialog.mdx
@@ -23,7 +23,6 @@ This could be a deletion of some sorts or initiating a lengthy download.
 > An element is considered modal if it [blocks interaction with the rest of the application](https://en.wikipedia.org/wiki/Modal_window).
 > We use the term “dialog” to avoid confusion with the adjective.
 
-
 ### Focus Management
 
 When opening a `Dialog`, focus will be brought inside the `Dialog`
@@ -191,7 +190,6 @@ This will hide the confirm and cancel buttons.
 Use the `hasHeader` prop to show or hide the header.
 This will hide both the close icon button as the title.
 
-
 ```jsx
 <Component initialState={{ isShown: false }}>
   {({ state, setState }) => (
@@ -213,7 +211,6 @@ This will hide both the close icon button as the title.
 ## Remove default footer and header
 
 Use the `hasFooter`, `hasHeader` props to show or hide the footer and header.
-
 
 ```jsx
 <Component initialState={{ isShown: false }}>
@@ -241,13 +238,55 @@ Use the `preventBodyScrolling` prop to disable scrolling outside the dialog.
 ```jsx
 <Component initialState={{ isShown: false }}>
   {({ state, setState }) => (
-    <Pane paddingY='40vh'>
+    <Pane paddingY="40vh">
       <Dialog
         isShown={state.isShown}
         onCloseComplete={() => setState({ isShown: false })}
         preventBodyScrolling
       >
         Scroll-locked body
+      </Dialog>
+
+      <Button onClick={() => setState({ isShown: true })}>Show Dialog</Button>
+    </Pane>
+  )}
+</Component>
+```
+
+## Using custom CSS animations
+
+Use `openAnimation`, `closeAnimation` and `animationDuration` to set custom CSS animations.
+
+```jsx
+<Component initialState={{ isShown: false }}>
+  {({ state, setState }) => (
+    <Pane paddingY="40vh">
+      <Dialog
+        isShown={state.isShown}
+        onCloseComplete={() => setState({ isShown: false })}
+        animationDuration={400}
+        openAnimation={{
+          from: {
+            transform: 'translateX(1000px)',
+            opacity: 0
+          },
+          to: {
+            transform: 'translateX(0)',
+            opacity: 1
+          }
+        }}
+        closeAnimation={{
+          from: {
+            transform: 'translateX(0)',
+            opacity: 1
+          },
+          to: {
+            transform: 'translateX(1000px)',
+            opacity: 0
+          }
+        }}
+      >
+        You're using custom CSS animations.
       </Dialog>
 
       <Button onClick={() => setState({ isShown: true })}>Show Dialog</Button>

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -12,40 +12,32 @@ const animationEasing = {
   acceleration: `cubic-bezier(0.4, 0.0, 1, 1)`
 }
 
-const ANIMATION_DURATION = 200
+const DEFAULT_ANIMATION_DURATION = 400
 
-const openAnimation = css.keyframes('openAnimation', {
-  from: {
-    transform: 'scale(0.8)',
-    opacity: 0
-  },
-  to: {
-    transform: 'scale(1)',
-    opacity: 1
-  }
-})
+const generateOpenAnimation = animation => {
+  return css.keyframes('openAnimation', animation)
+}
 
-const closeAnimation = css.keyframes('closeAnimation', {
-  from: {
-    transform: 'scale(1)',
-    opacity: 1
-  },
-  to: {
-    transform: 'scale(0.8)',
-    opacity: 0
-  }
-})
+const generateCloseAnimation = animation => {
+  return css.keyframes('closeAnimation', animation)
+}
 
-const animationStyles = {
-  '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.deceleration
-    } both`
-  },
-  '&[data-state="exiting"]': {
-    animation: `${closeAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.acceleration
-    } both`
+const animationStyles = (
+  openAnimation,
+  closeAnimation,
+  animationDuration = DEFAULT_ANIMATION_DURATION
+) => {
+  return {
+    '&[data-state="entering"], &[data-state="entered"]': {
+      animation: `${generateOpenAnimation(
+        openAnimation
+      )} ${animationDuration}ms ${animationEasing.deceleration} both`
+    },
+    '&[data-state="exiting"]': {
+      animation: `${generateCloseAnimation(
+        closeAnimation
+      )} ${animationDuration}ms ${animationEasing.acceleration} both`
+    }
   }
 }
 
@@ -192,7 +184,23 @@ class Dialog extends React.Component {
     /**
      * Props that are passed to the Overlay component.
      */
-    overlayProps: PropTypes.object
+    overlayProps: PropTypes.object,
+
+    /**
+     * Props used to set the duration of the open and close animations related to
+     * the Dialog component
+     */
+    animationDuration: PropTypes.number,
+
+    /**
+     * Props responsible to add a custom open CSS animation to the Dialog component
+     */
+    openAnimation: PropTypes.object,
+
+    /**
+     * Props responsible to add a custom close CSS animation to the Dialog component
+     */
+    closeAnimation: PropTypes.object
   }
 
   static defaultProps = {
@@ -215,7 +223,28 @@ class Dialog extends React.Component {
     onCancel: close => close(),
     onConfirm: close => close(),
     preventBodyScrolling: false,
-    overlayProps: {}
+    overlayProps: {},
+    animationDuration: 400,
+    openAnimation: {
+      from: {
+        transform: 'scale(0.8)',
+        opacity: 0
+      },
+      to: {
+        transform: 'scale(1)',
+        opacity: 1
+      }
+    },
+    closeAnimation: {
+      from: {
+        transform: 'scale(1)',
+        opacity: 1
+      },
+      to: {
+        transform: 'scale(0.8)',
+        opacity: 0
+      }
+    }
   }
 
   renderChildren = close => {
@@ -258,7 +287,10 @@ class Dialog extends React.Component {
       contentContainerProps,
       minHeightContent,
       preventBodyScrolling,
-      overlayProps
+      overlayProps,
+      openAnimation,
+      closeAnimation,
+      animationDuration
     } = this.props
 
     const sideOffsetWithUnit = Number.isInteger(sideOffset)
@@ -299,7 +331,11 @@ class Dialog extends React.Component {
             marginY={topOffsetWithUnit}
             display="flex"
             flexDirection="column"
-            css={animationStyles}
+            css={animationStyles(
+              openAnimation,
+              closeAnimation,
+              animationDuration
+            )}
             data-state={state}
             {...containerProps}
           >

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -12,7 +12,7 @@ const animationEasing = {
   acceleration: `cubic-bezier(0.4, 0.0, 1, 1)`
 }
 
-const DEFAULT_ANIMATION_DURATION = 400
+const DEFAULT_ANIMATION_DURATION = 200
 
 const generateOpenAnimation = animation => {
   return css.keyframes('openAnimation', animation)

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -224,7 +224,7 @@ class Dialog extends React.Component {
     onConfirm: close => close(),
     preventBodyScrolling: false,
     overlayProps: {},
-    animationDuration: 400,
+    animationDuration: 200,
     openAnimation: {
       from: {
         transform: 'scale(0.8)',

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -237,6 +237,7 @@ storiesOf('dialog', module)
               title="Dialog with Custom CSS animation"
               onCloseComplete={hide}
               hasFooter={false}
+              animationDuration={400}
               openAnimation={{
                 from: {
                   transform: 'translateX(1000px)',

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -229,6 +229,48 @@ storiesOf('dialog', module)
           </Box>
         )}
       </DialogManager>
+      <DialogManager>
+        {({ isShown, show, hide }) => (
+          <Box marginBottom={16}>
+            <Dialog
+              isShown={isShown}
+              title="Dialog with Custom CSS animation"
+              onCloseComplete={hide}
+              hasFooter={false}
+              openAnimation={{
+                from: {
+                  transform: 'translateX(1000px)',
+                  opacity: 0
+                },
+                to: {
+                  transform: 'translateX(0)',
+                  opacity: 1
+                }
+              }}
+              closeAnimation={{
+                from: {
+                  transform: 'translateX(0)',
+                  opacity: 1
+                },
+                to: {
+                  transform: 'translateX(1000px)',
+                  opacity: 0
+                }
+              }}
+            >
+              <Box>
+                <Paragraph>
+                  You are also able to use custom CSS animations to your Dialog
+                  components
+                </Paragraph>
+              </Box>
+            </Dialog>
+            <Button onClick={show}>
+              Show Dialog with Custom CSS animation
+            </Button>
+          </Box>
+        )}
+      </DialogManager>
     </Box>
   ))
   .add('Dialog with nested Combobox', () => (


### PR DESCRIPTION
# Dialog - Adding custom CSS (open/close) animations 🎉

With this PR I'm aiming to add to the Dialog component the support to add custom animations. So, as you can see on the storybook, we can open/close it in different ways.

I hope it gets approved. We're needing it on our current project.

Thank you :)

**@Edit**
![GIF](https://media.giphy.com/media/hQWdcXrmWCvfwdZDcC/giphy.gif)

_Code:_
```jsx
<Dialog
        isShown={state.isShown}
        onCloseComplete={() => setState({ isShown: false })}
        animationDuration={400}
        openAnimation={{
          from: {
            transform: 'translateX(1000px)',
            opacity: 0
          },
          to: {
            transform: 'translateX(0)',
            opacity: 1
          }
        }}
        closeAnimation={{
          from: {
            transform: 'translateX(0)',
            opacity: 1
          },
          to: {
            transform: 'translateX(1000px)',
            opacity: 0
          }
        }}
      >
        You're using custom CSS animations.
      </Dialog>
```
