### PR TITLE
Allow passing a ref (innerRef) to a Checkbox

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -603,6 +603,10 @@ declare module 'evergreen-ui' {
      */
     indeterminate?: boolean
     /**
+     * Function that returns the ref of the checkbox.
+     */
+    innerRef?: (ref: React.RefObject<HTMLElement>) => void,
+    /**
      * When true, the radio is disabled.
      */
     disabled?: boolean

--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -74,6 +74,11 @@ class Checkbox extends PureComponent {
     indeterminate: PropTypes.bool,
 
     /**
+     * Function that returns the ref of the checkbox.
+     */
+    innerRef: PropTypes.func,
+
+    /**
      * Function called when state changes.
      */
     onChange: PropTypes.func,
@@ -104,13 +109,17 @@ class Checkbox extends PureComponent {
   static defaultProps = {
     checked: false,
     indeterminate: false,
+    innerRef: () => {},
     onChange: () => {},
     appearance: 'default'
   }
 
-  setIndeterminate = el => {
-    if (!el) return
-    el.indeterminate = this.props.indeterminate
+  handleInnerRef = el => {
+    if (el) {
+      el.indeterminate = this.props.indeterminate
+    }
+
+    this.props.innerRef(el)
   }
 
   render() {
@@ -127,6 +136,7 @@ class Checkbox extends PureComponent {
       onChange,
       value,
       indeterminate,
+      innerRef,
       ...props
     } = this.props
 
@@ -152,7 +162,7 @@ class Checkbox extends PureComponent {
           onChange={onChange}
           disabled={disabled}
           aria-invalid={isInvalid}
-          innerRef={this.setIndeterminate}
+          innerRef={this.handleInnerRef}
         />
         <Box
           boxSizing="border-box"

--- a/src/checkbox/stories/index.stories.js
+++ b/src/checkbox/stories/index.stories.js
@@ -3,6 +3,12 @@ import React from 'react'
 import Box from 'ui-box'
 import { Checkbox } from '..'
 
+const innerRef = el => {
+  if (el) {
+    el.disabled = true
+  }
+}
+
 storiesOf('checkbox', module).add('Checkbox', () => (
   <Box padding={40}>
     <Checkbox label="Checkbox default" />
@@ -11,5 +17,11 @@ storiesOf('checkbox', module).add('Checkbox', () => (
     <Checkbox disabled checked label="Checkbox checked disabled" />
     <Checkbox indeterminate label="Checkbox indeterminate" />
     <Checkbox checked indeterminate label="Checkbox checked indeterminate" />
+    <Checkbox
+      checked
+      indeterminate
+      innerRef={innerRef}
+      label="Checkbox checked indeterminate disabled with ref"
+    />
   </Box>
 ))


### PR DESCRIPTION
I believe it is time to think about implementing ref forwarding – so that passing a ref always does what you expect.

I have started using https://github.com/react-hook-form/react-hook-form – and it would be nice if this library would support it as the API is really great.
