### PR TITLE
Fixes input onBlur error in FilePicker

### DIFF
--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -174,7 +174,9 @@ export default class FilePicker extends PureComponent {
   }
 
   handleBlur = e => {
-    if (e && e.target) e.target.files = this.state.files
+    // Setting e.target.files to an array fails. It must be a FileList
+    if (e && e.target) e.target.files = this.fileInput.files
+
     safeInvoke(this.props.onBlur, e)
   }
 }

--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -175,7 +175,7 @@ export default class FilePicker extends PureComponent {
 
   handleBlur = e => {
     // Setting e.target.files to an array fails. It must be a FileList
-    if (e && e.target) e.target.files = this.fileInput.files
+    if (e && e.target) e.target.files = this.fileInput && this.fileInput.files
 
     safeInvoke(this.props.onBlur, e)
   }


### PR DESCRIPTION
Fixes [#597 ](https://github.com/segmentio/evergreen/issues/597)

This error occurs because you're not allowed to set `event.target`'s `files` property to a regular array, it must be a `FileList`.

Unfortunately you can't create a `FileList` from an array so to work around that I used the ref to pull the input's `FileList` directly.

This seems to fix the issue + maintain the previous functionality of the `onBlur` handler