### PR TITLE
Fixes useTheme hook to use correct usage of useContext

### DIFF
--- a/src/theme/src/useTheme.js
+++ b/src/theme/src/useTheme.js
@@ -1,8 +1,8 @@
 import { useContext } from 'react'
-import { ThemeProvider, ThemeConsumer } from './ThemeContext'
+import ThemeContext from './ThemeContext'
 
 function useTheme() {
-  return useContext({ Consumer: ThemeConsumer, Provider: ThemeProvider })
+  return useContext(ThemeContext)
 }
 
 export default useTheme


### PR DESCRIPTION
`useContext` must take in a `Context` object, not a regular JSON

See here:
https://reactjs.org/docs/hooks-reference.html#usecontext
