### PR TITLE
Makes docs app use same react instance as evergreen-ui

### DIFF
--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -23,6 +23,7 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       // Force Gatsby to look for dependencies within the local node_modules from docs.
       modules: ['node_modules'],
       alias: {
+        react: path.resolve(__dirname, '../node_modules/react'),
         'evergreen-ui': path.resolve(__dirname, '../src/index.js'),
         components: path.resolve(__dirname, './src/components')
       }


### PR DESCRIPTION
This change (or something to the effect of this change) is required in order for future usage of hooks.

The problem is that when you run the `docs`, it's using the locally built `evergreen-ui` which has one version of React while the `docs` have another.

The error can be explained here https://github.com/facebook/react/issues/13991.

I'm not sure if this is the best course of action in order to make hooks work in the `docs` app, but after converting the `Spinner` component to use hooks (worked in storybook but not `docs`), this ended up working.