### PR TITLE
Fix Bug With Import Naming

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:interface-name max-classes-per-file no-empty-interface */
 
 declare module 'evergreen-ui' {
-  import { IconName } from '@blueprintjs/icons'
+  import { IconName as BlueprintIconName } from '@blueprintjs/icons'
   import * as React from 'react'
   import Box, { extractStyles as boxExtractStyles } from 'ui-box'
   import { BoxProps, Is } from 'ui-box/dist/types/box-types'
@@ -22,7 +22,7 @@ declare module 'evergreen-ui' {
   type Elevation = 0 | 1 | 2 | 3 | 4
   type FontSizeSmall = 300 | 400
 
-  export type IconName = IconName
+  export type IconName = BlueprintIconName
 
 
   export interface Colors {


### PR DESCRIPTION
When attempting to update the `app`'s version of TS to 3.7, the linter complains because of this issue in Evergreen:
```
./node_modules/.bin/tsc --project . --allowJs false
node_modules/evergreen-ui/index.d.ts:4:12 - error TS2440: Import declaration conflicts with local declaration of 'IconName'.
import { IconName } from '@blueprintjs/icons'
```
This fixes the import declaration conflict.