### PR TITLE
Complete Theming Support in v4

### DIFF
--- a/docs/src/components/TopBar.js
+++ b/docs/src/components/TopBar.js
@@ -6,7 +6,7 @@ import GitHubButton from 'react-github-button'
 import GitHubIcon from './GitHubIcon'
 import SpectrumIcon from './SpectrumIcon'
 import LogoWordmark from './LogoWordmark'
-// eslint-disable-next-line import/no-unassigned-import
+// eslint-disable-next-line import/no-unassigned-import, import/extensions
 import 'react-github-button/assets/style.css'
 
 // ConsentManager uses a package `@segment/in-regions` that breaks SSR

--- a/docs/src/pages/get-started/theming.mdx
+++ b/docs/src/pages/get-started/theming.mdx
@@ -13,12 +13,13 @@ Please note: at this moment in time, theming isn't fully supported yet! There ar
 
 ## Simple theming
 
-The `ThemeProvider` Component, you can either override the default styles(shown below) or use your own theme completely.
-You can add anything you want to the theme object, as long as you have required properties.
+The `ThemeProvider` Component, you can create your own copy of the default styles and add your own variants. You can add anything you want to the theme object, as long as you have required properties.
+
+The best way to create a copy of the theme object is to call the `extend()` method on the `defaultTheme`
 
 ```jsx
 const newTheme = {
-  ...defaultTheme,
+  ...defaultTheme.extend(),
   spinnerColor: 'hotpink'
 }
 
@@ -41,12 +42,12 @@ You can theme certain parts of your app differently by nesting the `ThemeProvide
 
 ```jsx
 const parentTheme = {
-  ...defaultTheme,
+  ...defaultTheme.extend(),
   spinnerColor: 'hotpink'
 }
 
 const childTheme = {
-  ...defaultTheme,
+  ...defaultTheme.extend(), // bonus: you can also do parentTheme.extend()
   spinnerColor: 'blue'
 }
 
@@ -76,7 +77,7 @@ The `withTheme` HOC allows you to easily pass the theme object down to your comp
 
 ```jsx
 const theme = {
-  ...defaultTheme,
+  ...defaultTheme.extend(),
   myNewButtonStyles: {
     color: 'white',
     backgroundColor: 'hotpink',
@@ -112,7 +113,7 @@ The `useTheme` hook provides the same functionalities as the `withTheme` HOC.
 
 ```jsx
 const theme = {
-  ...defaultTheme,
+  ...defaultTheme.extend(),
   myNewButtonStyles: {
     color: 'white',
     backgroundColor: 'hotpink',

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,15 @@ declare module 'evergreen-ui' {
   import { StyleAttribute, CSSProperties } from 'glamor'
   import { DownshiftProps, GetInputPropsOptions } from 'downshift'
 
-  type PositionTypes = 'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'
+  type PositionTypes =
+    | 'top'
+    | 'top-left'
+    | 'top-right'
+    | 'bottom'
+    | 'bottom-left'
+    | 'bottom-right'
+    | 'left'
+    | 'right'
   type IntentTypes = 'none' | 'success' | 'warning' | 'danger'
   type DefaultAppearance = 'default'
   type AlertAppearance = DefaultAppearance | 'card'
@@ -23,7 +31,6 @@ declare module 'evergreen-ui' {
   type FontSizeSmall = 300 | 400
 
   export type IconName = BlueprintIconName
-
 
   export interface Colors {
     background: {
@@ -385,6 +392,187 @@ declare module 'evergreen-ui' {
     }
   }
 
+  export interface ButtonColors {
+    primary: {
+      default: {
+        gradientStart: string
+        gradientEnd: string
+      }
+      success: {
+        gradientStart: string
+        gradientEnd: string
+      }
+      warning: {
+        gradientStart: string
+        gradientEnd: string
+      }
+      danger: {
+        gradientStart: string
+        gradientEnd: string
+      }
+    }
+    minimal: {
+      default: string
+      hoverBackground: string
+      focusBackground: string
+      activeBackground: string
+    }
+  }
+
+  export interface CheckboxColors {
+    active: {
+      backgroundColor: string
+      shadowColor: string
+    }
+    focus: {
+      shadowColor: string
+    }
+  }
+
+  export interface CodeColors {
+    backgroundColor: string
+    shadowColor: string
+  }
+
+  export interface DefaultControlColors {
+    base: {
+      backgroundColor: string
+      gradientStart: string
+      gradientEnd: string
+    }
+    hover: {
+      gradientStart: string
+      gradientEnd: string
+    }
+    focus: {
+      shadowColor: string
+    }
+    active: {
+      backgroundColor: string
+    }
+    focusAndActive: {
+      shadowColor: string
+    }
+    invalid: {
+      shadowColor: string
+    }
+  }
+
+  export interface RowColors {
+    default: {
+      base: string
+      hover: string
+      focus: string
+      active: string
+    }
+    none: {
+      base: string
+      hover: string
+      focus: string
+      active: string
+    }
+    danger: string
+    warning: string
+    success: string
+  }
+
+  export interface SwitchColors {
+    focus: {
+      shadowColor: string
+    }
+    checked: {
+      backgroundColor: string
+      color: string
+    }
+    checkedHover: {
+      backgroundColor: string
+      color: string
+    }
+    checkedActive: {
+      backgroundColor: string
+      color: string
+    }
+  }
+
+  export interface TabColors {
+    focus: {
+      shadowColor: string
+    }
+    active: {
+      backgroundColor: string
+      color: string
+    }
+  }
+
+  export interface TableColors {
+    cell: {
+      focus: {
+        backgroundColor: string
+        shadowColor: string
+      }
+    }
+  }
+
+  export interface TagInputColors {
+    base: {
+      backgroundColor: string
+    }
+    focus: {
+      shadowColor1: string
+      shadowColor2: string
+    }
+  }
+
+  export interface TextareaColors {
+    default: {
+      base: {
+        backgroundColor: string
+      }
+      focus: {
+        shadowColor1: string
+        shadowColor2: string
+      }
+    }
+    neutral: {
+      focus: {
+        shadowColor: string
+      }
+    }
+    editableCell: {
+      focus: {
+        shadowColor: string
+      }
+    }
+  }
+
+  export interface TextDropdownColors {
+    default: {
+      focus: {
+        shadowColor: string
+      }
+    }
+  }
+
+  export interface TextInputColors {
+    none: {
+      backgroundColor: string
+    }
+    default: {
+      base: {
+        backgroundColor: string
+      }
+      focus: {
+        shadowColor1: string
+        shadowColor2: string
+      }
+    }
+    neutral: {
+      focus: {
+        shadowColor: string
+      }
+    }
+  }
+
   export interface Theme {
     avatarColors: string[]
     badgeColors: string[]
@@ -394,7 +582,19 @@ declare module 'evergreen-ui' {
     overlayBackgroundColor: string
     palette: Palette
     scales: ColorScales
+    buttonColors: ButtonColors
+    checkboxColors: CheckboxColors
+    codeColors: CodeColors
+    defaultControlColors: DefaultControlColors
+    rowColors: RowColors
     spinnerColor: string
+    switchColors: SwitchColors
+    tabColorss: TabColors
+    tableColors: TableColors
+    tagInputColors: TagInputColors
+    textareaColors: TextareaColors
+    textDropdownColors: TextDropdownColors
+    textInputColors: TextInputColors
     typography: Typography
     getIconColor(color: string): string
     getAvatarProps(args: {
@@ -402,6 +602,7 @@ declare module 'evergreen-ui' {
       color: string
       hashValue?: string
     }): { color: string; backgroundColor: string }
+    extend(): Theme
   }
 
   export const defaultTheme: Theme
@@ -432,15 +633,18 @@ declare module 'evergreen-ui' {
     /**
      * Function called when the remove button is clicked.
      */
-    onRemove?: (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => void
+    onRemove?: (
+      event:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.TouchEvent<HTMLButtonElement>
+    ) => void
     /**
      * The appearance of the alert.
      */
     appearance?: AlertAppearance
   }
 
-  export class Alert extends React.PureComponent<AlertProps> {
-  }
+  export class Alert extends React.PureComponent<AlertProps> {}
 
   interface OptionProps extends TableRowProps {
     height?: number | string
@@ -453,11 +657,13 @@ declare module 'evergreen-ui' {
     children?: JSX.Element | null
   }
 
-  export class AutocompleteItem extends React.PureComponent<AutocompleteItemProps> {
-  }
+  export class AutocompleteItem extends React.PureComponent<
+    AutocompleteItemProps
+  > {}
 
   // https://github.com/downshift-js/downshift
-  export interface AutocompleteProps extends Omit<DownshiftProps<any>, 'children'> {
+  export interface AutocompleteProps
+    extends Omit<DownshiftProps<any>, 'children'> {
     // @deprecated
     defaultSelectedItem?: string
     title?: React.ReactNode
@@ -465,25 +671,26 @@ declare module 'evergreen-ui' {
     renderItem?: (i: AutocompleteItemProps) => JSX.Element | null
     itemsFilter?: (items: string[], input: string) => string[]
     children: (props: {
-                 toggle: () => void,
-                 getRef: (ref: React.RefObject<HTMLElement>) => void,
-                 isShown: NonNullable<PopoverProps['isShown']>,
-                 getInputProps: <T>(options?: T) => T & {
-                   onChange: (event: React.ChangeEvent) => void,
-                   onKeyDown: (event: React.KeyboardEvent) => void,
-                   onBlur: (event: React.FocusEvent) => void,
-                   id: string,
-                   value: string,
-                   'aria-autocomplete': 'list',
-                   'aria-activedescendant': number | null,
-                   'aria-controls': string | null,
-                   'aria-labelledby': string,
-                   autoComplete: 'off'
-                 },
-                 openMenu: () => any,
-                 inputValue: string,
-               }
-    ) => React.ReactNode
+      toggle: () => void
+      getRef: (ref: React.RefObject<HTMLElement>) => void
+      isShown: NonNullable<PopoverProps['isShown']>
+      getInputProps: <T>(
+        options?: T
+      ) => T & {
+        onChange: (event: React.ChangeEvent) => void
+        onKeyDown: (event: React.KeyboardEvent) => void
+        onBlur: (event: React.FocusEvent) => void
+        id: string
+        value: string
+        'aria-autocomplete': 'list'
+        'aria-activedescendant': number | null
+        'aria-controls': string | null
+        'aria-labelledby': string
+        autoComplete: 'off'
+      }
+      openMenu: () => any
+      inputValue: string
+    }) => React.ReactNode
     itemSize?: number
     position?: PositionTypes
     isFilterDisabled?: boolean
@@ -494,10 +701,10 @@ declare module 'evergreen-ui' {
     onChange: (selectedItem: any) => void
   }
 
-  export class Autocomplete extends React.PureComponent<AutocompleteProps> {
-  }
+  export class Autocomplete extends React.PureComponent<AutocompleteProps> {}
 
-  export interface AvatarProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  export interface AvatarProps
+    extends React.ComponentPropsWithoutRef<typeof Box> {
     src?: string
     size?: number
     /**
@@ -513,19 +720,26 @@ declare module 'evergreen-ui' {
     sizeLimitOneCharacter?: number
   }
 
-  export class Avatar extends React.PureComponent<AvatarProps> {
-  }
+  export class Avatar extends React.PureComponent<AvatarProps> {}
 
   export type BackButtonProps = ButtonProps
 
-  export class BackButton extends React.PureComponent<BackButtonProps> {
-  }
+  export class BackButton extends React.PureComponent<BackButtonProps> {}
 
   export interface BadgeProps extends StrongProps {
     /**
      * The color used for the badge. When the value is `automatic`, use the hash function to determine the color.
      */
-    color?: 'automatic' | 'neutral' | 'blue' | 'red' | 'orange' | 'yellow' | 'green' | 'teal' | 'purple'
+    color?:
+      | 'automatic'
+      | 'neutral'
+      | 'blue'
+      | 'red'
+      | 'orange'
+      | 'yellow'
+      | 'green'
+      | 'teal'
+      | 'purple'
     /**
      * Whether or not to apply hover/focus/active styles.
      */
@@ -533,10 +747,10 @@ declare module 'evergreen-ui' {
     isSolid?: boolean
   }
 
-  export class Badge extends React.PureComponent<BadgeProps> {
-  }
+  export class Badge extends React.PureComponent<BadgeProps> {}
 
-  export interface ButtonProps extends React.ComponentPropsWithoutRef<typeof Text> {
+  export interface ButtonProps
+    extends React.ComponentPropsWithoutRef<typeof Text> {
     intent?: IntentTypes
     appearance?: ButtonAppearance
     /**
@@ -568,13 +782,11 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class Button extends React.PureComponent<ButtonProps> {
-  }
+  export class Button extends React.PureComponent<ButtonProps> {}
 
   export type CardProps = React.ComponentProps<typeof Pane>
 
-  export class Card extends React.PureComponent<CardProps> {
-  }
+  export class Card extends React.PureComponent<CardProps> {}
 
   export interface CheckboxProps extends BoxProps<'input'> {
     /**
@@ -626,16 +838,14 @@ declare module 'evergreen-ui' {
     onChange?(event: React.ChangeEvent<HTMLInputElement>): void
   }
 
-  export class Checkbox extends React.PureComponent<CheckboxProps> {
-  }
+  export class Checkbox extends React.PureComponent<CheckboxProps> {}
 
   export type CodeProps = TextProps
 
+  export class Code extends React.PureComponent<CodeProps> {}
 
-  export class Code extends React.PureComponent<CodeProps> {
-  }
-
-  export interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  export interface ComboboxProps
+    extends React.ComponentPropsWithoutRef<typeof Box> {
     /**
      * The options to show in the menu.
      */
@@ -691,8 +901,7 @@ declare module 'evergreen-ui' {
     isLoading?: boolean
   }
 
-  export class Combobox extends React.PureComponent<ComboboxProps> {
-  }
+  export class Combobox extends React.PureComponent<ComboboxProps> {}
 
   export interface CornerDialogProps {
     /**
@@ -763,8 +972,7 @@ declare module 'evergreen-ui' {
     containerProps?: CardProps
   }
 
-  export class CornerDialog extends React.PureComponent<CornerDialogProps> {
-  }
+  export class CornerDialog extends React.PureComponent<CornerDialogProps> {}
 
   export interface DialogProps {
     /**
@@ -882,8 +1090,7 @@ declare module 'evergreen-ui' {
     preventBodyScrolling?: boolean
   }
 
-  export class Dialog extends React.PureComponent<DialogProps> {
-  }
+  export class Dialog extends React.PureComponent<DialogProps> {}
 
   export interface IconProps extends BoxProps<'svg'> {
     icon: IconName | JSX.Element
@@ -911,10 +1118,10 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class Icon extends React.PureComponent<IconProps> {
-  }
+  export class Icon extends React.PureComponent<IconProps> {}
 
-  export interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  export interface FormFieldProps
+    extends React.ComponentPropsWithoutRef<typeof Box> {
     /**
      * The label used above the input element.
      */
@@ -950,20 +1157,17 @@ declare module 'evergreen-ui' {
     inputWidth?: number | string
   }
 
-  export class FormField extends React.PureComponent<FormFieldProps> {
-  }
+  export class FormField extends React.PureComponent<FormFieldProps> {}
 
-  export interface FormFieldDescriptionProps extends ParagraphProps {
-  }
+  export interface FormFieldDescriptionProps extends ParagraphProps {}
 
-  export class FormFieldDescription extends React.PureComponent<FormFieldDescriptionProps> {
-  }
+  export class FormFieldDescription extends React.PureComponent<
+    FormFieldDescriptionProps
+  > {}
 
-  export interface FormFieldHintProps extends ParagraphProps {
-  }
+  export interface FormFieldHintProps extends ParagraphProps {}
 
-  export class FormFieldHint extends React.PureComponent<ParagraphProps> {
-  }
+  export class FormFieldHint extends React.PureComponent<ParagraphProps> {}
 
   export interface FormFieldLabelProps extends LabelProps {
     /**
@@ -972,21 +1176,22 @@ declare module 'evergreen-ui' {
     isAstrixShown?: boolean
   }
 
-  export class FormFieldLabel extends React.PureComponent<FormFieldLabelProps> {
-  }
+  export class FormFieldLabel extends React.PureComponent<
+    FormFieldLabelProps
+  > {}
 
-  export interface FormFieldValidationMessageProps extends PaneProps {
-  }
+  export interface FormFieldValidationMessageProps extends PaneProps {}
 
-  export class FormFieldValidationMessage extends React.PureComponent<FormFieldValidationMessageProps> {
-  }
+  export class FormFieldValidationMessage extends React.PureComponent<
+    FormFieldValidationMessageProps
+  > {}
 
-  export interface HeadingProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  export interface HeadingProps
+    extends React.ComponentPropsWithoutRef<typeof Box> {
     size?: keyof Typography['headings']
   }
 
-  export class Heading extends React.PureComponent<HeadingProps> {
-  }
+  export class Heading extends React.PureComponent<HeadingProps> {}
 
   export interface IconButtonProps extends ButtonProps {
     /**
@@ -1021,15 +1226,13 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class IconButton extends React.PureComponent<IconButtonProps> {
-  }
+  export class IconButton extends React.PureComponent<IconButtonProps> {}
 
   export interface ImageProps extends BoxProps<'img'> {
     src?: string
   }
 
-  export class Image extends React.PureComponent<ImageProps> {
-  }
+  export class Image extends React.PureComponent<ImageProps> {}
 
   export interface InlineAlertProps extends PaneProps {
     intent?: IntentTypes
@@ -1045,13 +1248,11 @@ declare module 'evergreen-ui' {
     size?: keyof Typography['text']
   }
 
-  export class InlineAlert extends React.PureComponent<InlineAlertProps> {
-  }
+  export class InlineAlert extends React.PureComponent<InlineAlertProps> {}
 
   export type LabelProps = TextProps
 
-  export class Label extends React.PureComponent<LabelProps> {
-  }
+  export class Label extends React.PureComponent<LabelProps> {}
 
   export interface LinkProps extends TextProps {
     /**
@@ -1077,8 +1278,7 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class Link extends React.PureComponent<LinkProps> {
-  }
+  export class Link extends React.PureComponent<LinkProps> {}
 
   export interface ListItemProps extends TextProps {
     /**
@@ -1092,8 +1292,7 @@ declare module 'evergreen-ui' {
     iconColor?: string
   }
 
-  export class ListItem extends React.PureComponent<ListItemProps> {
-  }
+  export class ListItem extends React.PureComponent<ListItemProps> {}
 
   export interface MenuProps {
     children: React.ReactNode[] | React.ReactNode
@@ -1125,28 +1324,34 @@ declare module 'evergreen-ui' {
     title?: React.ReactNode
     selected?: T
     onChange?: (value: T) => void
-    options: Array<{ value: T, label: string }>
+    options: Array<{ value: T; label: string }>
   }
 
   export class Menu extends React.PureComponent<MenuProps> {
     // @ts-ignore
-    public static Item = class MenuItem extends React.PureComponent<MenuItemProps> {
-    }
+    public static Item = class MenuItem extends React.PureComponent<
+      MenuItemProps
+    > {}
     // @ts-ignore
-    public static Divider = class MenuDivider extends React.PureComponent {
-    }
+    public static Divider = class MenuDivider extends React.PureComponent {}
     // @ts-ignore
-    public static Group = class MenuGroup extends React.PureComponent<MenuGroupProps> {
-    }
+    public static Group = class MenuGroup extends React.PureComponent<
+      MenuGroupProps
+    > {}
     // @ts-ignore
-    public static Option = class Option extends React.PureComponent<MenuOptionProps> {
-    }
+    public static Option = class Option extends React.PureComponent<
+      MenuOptionProps
+    > {}
     // @ts-ignore
-    public static OptionsGroup = class MenuOptionsGroup<T extends string | number | null> extends React.PureComponent<MenuOptionsGroupProps<T>> {
-    }
+    public static OptionsGroup = class MenuOptionsGroup<
+      T extends string | number | null
+    > extends React.PureComponent<MenuOptionsGroupProps<T>> {}
   }
 
-  export type PaneProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, 'border' | 'borderTop' | 'borderRight' | 'borderBottom' | 'borderLeft'> & {
+  export type PaneProps = Omit<
+    React.ComponentPropsWithoutRef<typeof Box>,
+    'border' | 'borderTop' | 'borderRight' | 'borderBottom' | 'borderLeft'
+  > & {
     background?: keyof Colors['background'] | string
     border?: boolean | string
     borderTop?: boolean | string
@@ -1158,13 +1363,11 @@ declare module 'evergreen-ui' {
     activeElevation?: Elevation
   }
 
-  export class Pane extends React.PureComponent<PaneProps> {
-  }
+  export class Pane extends React.PureComponent<PaneProps> {}
 
   export type PillProps = BadgeProps
 
-  export class Pill extends React.PureComponent<PillProps> {
-  }
+  export class Pill extends React.PureComponent<PillProps> {}
 
   export type PopoverStatelessProps = React.ComponentPropsWithoutRef<typeof Box>
 
@@ -1172,9 +1375,15 @@ declare module 'evergreen-ui' {
     position?: PositionTypes
     isShown?: boolean
     trigger?: 'click' | 'hover'
-    content: React.ReactNode | ((object: { close: () => void }) => React.ReactNode)
+    content:
+      | React.ReactNode
+      | ((object: { close: () => void }) => React.ReactNode)
     children:
-      ((props: { toggle: () => void, getRef: (ref: React.RefObject<HTMLElement>) => void, isShow: NonNullable<PopoverProps['isShown']> }) => React.ReactNode)
+      | ((props: {
+          toggle: () => void
+          getRef: (ref: React.RefObject<HTMLElement>) => void
+          isShow: NonNullable<PopoverProps['isShown']>
+        }) => React.ReactNode)
       | React.ReactNode
     display?: string
     minWidth?: number | string
@@ -1190,47 +1399,47 @@ declare module 'evergreen-ui' {
     statelessProps?: PopoverStatelessProps
   }
 
-  export class Popover extends React.PureComponent<PopoverProps> {
-  }
+  export class Popover extends React.PureComponent<PopoverProps> {}
 
   export type ParagraphProps = React.ComponentPropsWithoutRef<typeof Box> & {
     size?: keyof Typography['paragraph']
     fontFamily?: FontFamily
   }
 
-  export class Paragraph extends React.PureComponent<ParagraphProps> {
-  }
+  export class Paragraph extends React.PureComponent<ParagraphProps> {}
 
   export interface PositionerProps {
     position?: PositionTypes
     isShown?: boolean
     children: (params: {
-      top: number,
-      left: number,
-      zIndex: NonNullable<StackProps['value']>,
-      css: StyleAttribute | CSSProperties,
+      top: number
+      left: number
+      zIndex: NonNullable<StackProps['value']>
+      css: StyleAttribute | CSSProperties
       style: {
-        transformOrigin: string,
-        left: number,
-        top: number,
-        zIndex: NonNullable<StackProps['value']>,
-      },
-      getRef: (ref: React.RefObject<HTMLElement>) => void,
-      animationDuration: PositionerProps['animationDuration'],
+        transformOrigin: string
+        left: number
+        top: number
+        zIndex: NonNullable<StackProps['value']>
+      }
+      getRef: (ref: React.RefObject<HTMLElement>) => void
+      animationDuration: PositionerProps['animationDuration']
       state: PositionState
     }) => React.ReactNode
     innerRef?: (ref: React.RefObject<HTMLElement>) => void
     bodyOffset?: number
     targetOffset?: number
-    target: (params: { getRef: () => React.RefObject<HTMLElement>, isShow: boolean }) => React.ReactNode
+    target: (params: {
+      getRef: () => React.RefObject<HTMLElement>
+      isShow: boolean
+    }) => React.ReactNode
     initialScale?: number
     animationDuration?: number
     onCloseComplete?: () => void
     onOpenComplete?: () => void
   }
 
-  export class Positioner extends React.PureComponent<PositionerProps> {
-  }
+  export class Positioner extends React.PureComponent<PositionerProps> {}
 
   export interface RadioProps extends Omit<BoxProps<'input'>, 'onChange'> {
     /**
@@ -1252,7 +1461,10 @@ declare module 'evergreen-ui' {
     /**
      * Function called when state changes
      */
-    onChange?(event: React.ChangeEvent<HTMLInputElement>, checked: boolean): void
+    onChange?(
+      event: React.ChangeEvent<HTMLInputElement>,
+      checked: boolean
+    ): void
     /**
      * When true, the radio is disabled.
      */
@@ -1281,8 +1493,7 @@ declare module 'evergreen-ui' {
     appearance?: DefaultAppearance
   }
 
-  export class Radio extends React.PureComponent<RadioProps> {
-  }
+  export class Radio extends React.PureComponent<RadioProps> {}
 
   interface RadioGroupOption {
     label: React.ReactNode
@@ -1321,8 +1532,7 @@ declare module 'evergreen-ui' {
     onChange?(value: string): void
   }
 
-  export class RadioGroup extends React.PureComponent<RadioGroupProps> {
-  }
+  export class RadioGroup extends React.PureComponent<RadioGroupProps> {}
 
   export interface Option {
     label?: string
@@ -1345,8 +1555,8 @@ declare module 'evergreen-ui' {
     renderItem: (props: {
       key: Option['value']
       label: Option['label']
-      style: object,
-      height: NonNullable<OptionsListProps['optionSize']>,
+      style: object
+      height: NonNullable<OptionsListProps['optionSize']>
       onSelect: () => void
       onDeselect: () => void
       isSelectable: boolean
@@ -1362,17 +1572,16 @@ declare module 'evergreen-ui' {
     defaultSearchValue?: string
   }
 
-  export class OptionsList extends React.PureComponent<OptionsListProps> {
-  }
+  export class OptionsList extends React.PureComponent<OptionsListProps> {}
 
   export interface SearchInputProps extends TextInputProps {
     height?: number
   }
 
-  export class SearchInput extends React.PureComponent<SearchInputProps> {
-  }
+  export class SearchInput extends React.PureComponent<SearchInputProps> {}
 
-  export interface SearchTableHeaderCellProps extends Omit<TableHeaderCellProps, 'onChange'> {
+  export interface SearchTableHeaderCellProps
+    extends Omit<TableHeaderCellProps, 'onChange'> {
     /**
      * The value of the input.
      */
@@ -1399,11 +1608,19 @@ declare module 'evergreen-ui' {
     icon?: IconProps['icon']
   }
 
-  export class SearchTableHeaderCell extends React.PureComponent<SearchTableHeaderCellProps> {
-  }
+  export class SearchTableHeaderCell extends React.PureComponent<
+    SearchTableHeaderCellProps
+  > {}
 
-  export interface SegmentedControlProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'defaultValue' | 'onChange'> {
-    options: Array<{ label: string, value: NonNullable<SegmentedControlProps['value']> }>
+  export interface SegmentedControlProps
+    extends Omit<
+      React.ComponentPropsWithoutRef<typeof Box>,
+      'defaultValue' | 'onChange'
+    > {
+    options: Array<{
+      label: string
+      value: NonNullable<SegmentedControlProps['value']>
+    }>
     value?: number | string | boolean
     defaultValue?: number | string | boolean
     onChange: (value: NonNullable<SegmentedControlProps['value']>) => void
@@ -1411,10 +1628,12 @@ declare module 'evergreen-ui' {
     height?: number
   }
 
-  export class SegmentedControl extends React.PureComponent<SegmentedControlProps> {
-  }
+  export class SegmentedControl extends React.PureComponent<
+    SegmentedControlProps
+  > {}
 
-  export interface SelectProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
+  export interface SelectProps
+    extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
     /**
      * The initial value of an uncontrolled select
      */
@@ -1451,13 +1670,11 @@ declare module 'evergreen-ui' {
     onChange?(event: React.ChangeEvent<HTMLSelectElement>): void
   }
 
-  export class Select extends React.PureComponent<SelectProps> {
-  }
+  export class Select extends React.PureComponent<SelectProps> {}
 
   export type SelectFieldProps = FormFieldProps
 
-  export class SelectField extends React.PureComponent<SelectFieldProps> {
-  }
+  export class SelectField extends React.PureComponent<SelectFieldProps> {}
 
   export interface SelectMenuContentProps {
     close?: OptionsListProps['close']
@@ -1472,17 +1689,20 @@ declare module 'evergreen-ui' {
     filterIcon?: OptionsListProps['filterIcon']
     listProps?: OptionsListProps
     isMultiSelect?: boolean
-    titleView?: React.ReactNode | ((props: {
-      close: NonNullable<SelectMenuContentProps['close']>,
-      title: SelectMenuContentProps['title'],
-      headerHeight: NonNullable<SelectMenuContentProps['headerHeight']>,
-    }) => React.ReactNode)
+    titleView?:
+      | React.ReactNode
+      | ((props: {
+          close: NonNullable<SelectMenuContentProps['close']>
+          title: SelectMenuContentProps['title']
+          headerHeight: NonNullable<SelectMenuContentProps['headerHeight']>
+        }) => React.ReactNode)
     detailView?: React.ReactNode
     emptyView?: React.ReactNode
   }
 
-  export class SelectMenuContent extends React.PureComponent<SelectMenuContentProps> {
-  }
+  export class SelectMenuContent extends React.PureComponent<
+    SelectMenuContentProps
+  > {}
 
   export interface SelectMenuItem {
     label: string
@@ -1491,9 +1711,12 @@ declare module 'evergreen-ui' {
     disabled?: boolean
   }
 
-  export type SelectMenuPropsViewCallback = (args: { close(): void }) => React.ReactNode
+  export type SelectMenuPropsViewCallback = (args: {
+    close(): void
+  }) => React.ReactNode
 
-  export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'content'> {
+  export interface SelectMenuProps
+    extends Omit<PopoverProps, 'position' | 'content'> {
     /**
      * The title of the Select Menu.
      */
@@ -1573,8 +1796,7 @@ declare module 'evergreen-ui' {
     closeOnSelect?: boolean
   }
 
-  export class SelectMenu extends React.PureComponent<SelectMenuProps> {
-  }
+  export class SelectMenu extends React.PureComponent<SelectMenuProps> {}
 
   export interface SideSheetProps {
     children: React.ReactNode | (() => React.ReactNode)
@@ -1591,22 +1813,18 @@ declare module 'evergreen-ui' {
     preventBodyScrolling?: boolean
   }
 
-  export class SideSheet extends React.PureComponent<SideSheetProps> {
-  }
+  export class SideSheet extends React.PureComponent<SideSheetProps> {}
 
   export type SidebarTabProps = TabProps
 
-  export class SidebarTab extends React.PureComponent<SidebarTabProps> {
-  }
+  export class SidebarTab extends React.PureComponent<SidebarTabProps> {}
 
-  export interface SmallProps extends BoxProps<'small'> {
+  export interface SmallProps extends BoxProps<'small'> {}
 
-  }
+  export class Small extends React.PureComponent<SmallProps> {}
 
-  export class Small extends React.PureComponent<SmallProps> {
-  }
-
-  export interface SpinnerProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  export interface SpinnerProps
+    extends React.ComponentPropsWithoutRef<typeof Box> {
     /**
      * Delay after which spinner should be visible.
      */
@@ -1617,21 +1835,18 @@ declare module 'evergreen-ui' {
     size?: number
   }
 
-  export class Spinner extends React.PureComponent<SpinnerProps> {
-  }
+  export class Spinner extends React.PureComponent<SpinnerProps> {}
 
   export interface StackProps {
     children: (zIndex: number) => React.ReactNode
     value?: number
   }
 
-  export class Stack extends React.PureComponent<StackProps> {
-  }
+  export class Stack extends React.PureComponent<StackProps> {}
 
   export type StrongProps = TextProps
 
-  export class Strong extends React.PureComponent<StrongProps> {
-  }
+  export class Strong extends React.PureComponent<StrongProps> {}
 
   export interface SwitchProps extends Omit<BoxProps<'label'>, 'onChange'> {
     /**
@@ -1682,14 +1897,11 @@ declare module 'evergreen-ui' {
     defaultChecked?: boolean
   }
 
-  export class Switch extends React.PureComponent<SwitchProps> {
-  }
+  export class Switch extends React.PureComponent<SwitchProps> {}
 
-  export interface TableBodyProps extends PaneProps {
-  }
+  export interface TableBodyProps extends PaneProps {}
 
-  export class TableBody extends React.PureComponent<TableBodyProps> {
-  }
+  export class TableBody extends React.PureComponent<TableBodyProps> {}
 
   export interface TableCellProps extends PaneProps {
     /**
@@ -1722,10 +1934,10 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class TableCell extends React.PureComponent<TableCellProps> {
-  }
+  export class TableCell extends React.PureComponent<TableCellProps> {}
 
-  interface TableEditableCellProps extends Omit<TextTableCellProps, 'placeholder' | 'onChange'> {
+  interface TableEditableCellProps
+    extends Omit<TextTableCellProps, 'placeholder' | 'onChange'> {
     autoFocus?: boolean
     /**
      * Makes the TableCell focusable.
@@ -1754,19 +1966,18 @@ declare module 'evergreen-ui' {
     onChange?(value: string): void
   }
 
-  export interface TableHeaderCellProps extends TableCellProps {
-  }
+  export interface TableHeaderCellProps extends TableCellProps {}
 
-  export class TableHeaderCell extends React.PureComponent<TableHeaderCellProps> {
-  }
+  export class TableHeaderCell extends React.PureComponent<
+    TableHeaderCellProps
+  > {}
 
   export interface TableHeadProps extends PaneProps {
     height?: number | string
     accountForScrollbar?: boolean
   }
 
-  export class TableHead extends React.PureComponent<TableHeadProps> {
-  }
+  export class TableHead extends React.PureComponent<TableHeadProps> {}
 
   export interface TableRowProps extends PaneProps {
     /**
@@ -1812,10 +2023,10 @@ declare module 'evergreen-ui' {
     onDeselect?(): void
   }
 
-  export class TableRow extends React.PureComponent<TableRowProps> {
-  }
+  export class TableRow extends React.PureComponent<TableRowProps> {}
 
-  export interface TableSelectMenuCellProps extends Omit<TextTableCellProps, 'placeholder'> {
+  export interface TableSelectMenuCellProps
+    extends Omit<TextTableCellProps, 'placeholder'> {
     /**
      * Makes the TableCell focusable.
      * Will add tabIndex={-1 || this.props.tabIndex}.
@@ -1879,16 +2090,16 @@ declare module 'evergreen-ui' {
     scrollToAlignment?: 'start' | 'center' | 'end' | 'auto'
   }
 
-  export interface TableProps extends PaneProps {
-  }
+  export interface TableProps extends PaneProps {}
 
   export class Table extends React.PureComponent<TableProps> {
     // @ts-ignore
     public static Body = TableBody
 
     // @ts-ignore
-    public static VirtualBody = class VirtualBody extends React.PureComponent<TableVirtualBodyProps> {
-    }
+    public static VirtualBody = class VirtualBody extends React.PureComponent<
+      TableVirtualBodyProps
+    > {}
 
     // @ts-ignore
     public static Head = TableHead
@@ -1906,11 +2117,13 @@ declare module 'evergreen-ui' {
     public static TextCell = TextTableCell
 
     // @ts-ignore
-    public static EditableCell = class EditableCell extends React.PureComponent<TableEditableCellProps> {
-    }
+    public static EditableCell = class EditableCell extends React.PureComponent<
+      TableEditableCellProps
+    > {}
     // @ts-ignore
-    public static SelectMenuCell = class SelectMenuCell extends React.PureComponent<TableSelectMenuCellProps> {
-    }
+    public static SelectMenuCell = class SelectMenuCell extends React.PureComponent<
+      TableSelectMenuCellProps
+    > {}
   }
 
   export interface TabProps extends TextProps {
@@ -1930,20 +2143,18 @@ declare module 'evergreen-ui' {
     appearance?: DefaultAppearance
   }
 
-  export class Tab extends React.PureComponent<TabProps> {
-  }
+  export class Tab extends React.PureComponent<TabProps> {}
 
   export type TablistProps = React.ComponentPropsWithoutRef<typeof Box>
 
-  export class Tablist extends React.PureComponent<TablistProps> {
-  }
+  export class Tablist extends React.PureComponent<TablistProps> {}
 
   export type TabNavigationProps = BoxProps<'nav'>
 
-  export class TabNavigation extends React.PureComponent<TabNavigationProps> {
-  }
+  export class TabNavigation extends React.PureComponent<TabNavigationProps> {}
 
-  export interface TagInputProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
+  export interface TagInputProps
+    extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
     addOnBlur?: boolean
     className?: string
     disabled?: boolean
@@ -1961,8 +2172,7 @@ declare module 'evergreen-ui' {
     values?: string[]
   }
 
-  export class TagInput extends React.PureComponent<TagInputProps> {
-  }
+  export class TagInput extends React.PureComponent<TagInputProps> {}
 
   export interface TextareaProps extends TextProps {
     required?: boolean
@@ -1977,8 +2187,7 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class Textarea extends React.PureComponent<TextareaProps> {
-  }
+  export class Textarea extends React.PureComponent<TextareaProps> {}
 
   export interface TextDropdownButtonProps extends TextProps {
     /**
@@ -2010,8 +2219,9 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class TextDropdownButton extends React.PureComponent<TextDropdownButtonProps> {
-  }
+  export class TextDropdownButton extends React.PureComponent<
+    TextDropdownButtonProps
+  > {}
 
   export interface TextTableCellProps extends TableCellProps {
     /**
@@ -2024,23 +2234,22 @@ declare module 'evergreen-ui' {
     textProps?: TextProps
   }
 
-  export class TextTableCell extends React.PureComponent<TextTableCellProps> {
-  }
+  export class TextTableCell extends React.PureComponent<TextTableCellProps> {}
 
   export interface TextTableHeaderCellProps extends PaneProps {
     textProps?: TextProps
   }
 
-  export class TextTableHeaderCell extends React.PureComponent<TextTableHeaderCellProps> {
-  }
+  export class TextTableHeaderCell extends React.PureComponent<
+    TextTableHeaderCellProps
+  > {}
 
   export type TextProps = React.ComponentPropsWithoutRef<typeof Box> & {
     size?: keyof Typography['text']
     fontFamily?: FontFamily | string
   }
 
-  export class Text extends React.PureComponent<TextProps> {
-  }
+  export class Text extends React.PureComponent<TextProps> {}
 
   export type TextInputProps = React.ComponentProps<typeof Text> & {
     /**
@@ -2078,8 +2287,7 @@ declare module 'evergreen-ui' {
     className?: string
   }
 
-  export class TextInput extends React.PureComponent<TextInputProps> {
-  }
+  export class TextInput extends React.PureComponent<TextInputProps> {}
 
   export interface TextInputFieldProps extends TextInputProps {
     /**
@@ -2117,8 +2325,9 @@ declare module 'evergreen-ui' {
     inputWidth?: number | string
   }
 
-  export class TextInputField extends React.PureComponent<TextInputFieldProps> {
-  }
+  export class TextInputField extends React.PureComponent<
+    TextInputFieldProps
+  > {}
 
   export interface TooltipStatelessProps extends PaneProps {
     /**
@@ -2158,10 +2367,10 @@ declare module 'evergreen-ui' {
     statelessProps?: TooltipStatelessProps
   }
 
-  export class Tooltip extends React.PureComponent<TooltipProps> {
-  }
+  export class Tooltip extends React.PureComponent<TooltipProps> {}
 
-  export interface UnorderedListProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  export interface UnorderedListProps
+    extends React.ComponentPropsWithoutRef<typeof Box> {
     /**
      * Size of the text used in a list item.
      */
@@ -2177,18 +2386,19 @@ declare module 'evergreen-ui' {
     iconColor?: string
   }
 
-  export class UnorderedList extends React.PureComponent<UnorderedListProps> {
-  }
+  export class UnorderedList extends React.PureComponent<UnorderedListProps> {}
 
   export function majorScale(x: number): number
 
   export function minorScale(x: number): number
 
-  export function extractStyles(options?: { nonce?: React.ScriptHTMLAttributes<'script'>['nonce'] }): {
+  export function extractStyles(options?: {
+    nonce?: React.ScriptHTMLAttributes<'script'>['nonce']
+  }): {
     css: string
     cache: {
-      uiBoxCache: ReturnType<typeof boxExtractStyles>['cache'],
-      glamorIds: string[],
+      uiBoxCache: ReturnType<typeof boxExtractStyles>['cache']
+      glamorIds: string[]
     }
     hydrationScript: JSX.Element
   }
@@ -2284,36 +2494,25 @@ declare module 'evergreen-ui' {
 
   type UnknownProps = Record<string, any>
 
-  export class FilePicker extends React.PureComponent<UnknownProps> {
-  }
+  export class FilePicker extends React.PureComponent<UnknownProps> {}
 
-  export class Overlay extends React.PureComponent<UnknownProps> {
-  }
+  export class Overlay extends React.PureComponent<UnknownProps> {}
 
-  export class Portal extends React.PureComponent<UnknownProps> {
-  }
+  export class Portal extends React.PureComponent<UnknownProps> {}
 
-  export class OptionShapePropType extends React.PureComponent<UnknownProps> {
-  }
+  export class OptionShapePropType extends React.PureComponent<UnknownProps> {}
 
-  export class SelectedPropType extends React.PureComponent<UnknownProps> {
-  }
+  export class SelectedPropType extends React.PureComponent<UnknownProps> {}
 
-  export class StackingContext extends React.PureComponent<UnknownProps> {
-  }
+  export class StackingContext extends React.PureComponent<UnknownProps> {}
 
-  export class Ul extends React.PureComponent<UnknownProps> {
-  }
+  export class Ul extends React.PureComponent<UnknownProps> {}
 
-  export class OrderedList extends React.PureComponent<UnknownProps> {
-  }
+  export class OrderedList extends React.PureComponent<UnknownProps> {}
 
-  export class Ol extends React.PureComponent<UnknownProps> {
-  }
+  export class Ol extends React.PureComponent<UnknownProps> {}
 
-  export class Li extends React.PureComponent<UnknownProps> {
-  }
+  export class Li extends React.PureComponent<UnknownProps> {}
 
-  export class Pre extends React.PureComponent<UnknownProps> {
-  }
+  export class Pre extends React.PureComponent<UnknownProps> {}
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@babel/runtime": "^7.1.2",
+    "@babel/runtime": "^7.8.3",
     "@blueprintjs/icons": "^3.2.0",
     "@types/react": "^16.9.5",
     "arrify": "^1.0.1",
@@ -56,6 +56,7 @@
     "downshift": "^3.3.1",
     "fuzzaldrin-plus": "^0.6.0",
     "glamor": "^2.20.40",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.mapvalues": "^4.6.0",
     "prop-types": "^15.6.2",
@@ -70,13 +71,13 @@
     "react-dom": "^16.8.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.1.2",
-    "@babel/core": "^7.1.2",
-    "@babel/plugin-proposal-class-properties": "^7.1.0",
-    "@babel/plugin-transform-runtime": "^7.1.0",
-    "@babel/preset-env": "^7.1.0",
-    "@babel/preset-react": "^7.0.0",
-    "@babel/register": "^7.0.0",
+    "@babel/cli": "^7.8.3",
+    "@babel/core": "^7.8.3",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.8.3",
+    "@babel/preset-env": "^7.8.3",
+    "@babel/preset-react": "^7.8.3",
+    "@babel/register": "^7.8.3",
     "@reactions/component": "^2.0.2",
     "@rollup/plugin-commonjs": "^11.0.1",
     "@rollup/plugin-node-resolve": "^7.0.0",
@@ -202,11 +203,11 @@
   "size-limit": [
     {
       "path": "commonjs/index.js",
-      "limit": "212 KB"
+      "limit": "220 KB"
     },
     {
       "path": "umd/evergreen.min.js",
-      "limit": "212 KB"
+      "limit": "220 KB"
     }
   ],
   "husky": {

--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -75,7 +75,7 @@ class Alert extends PureComponent {
   getIconForIntent = intent => {
     const { theme } = this.props
 
-    return <Icon size={14} {...theme.getIconForIntent(intent)} />
+    return <Icon size={14} {...theme.getIconForIntent(intent, theme)} />
   }
 
   render() {
@@ -96,11 +96,14 @@ class Alert extends PureComponent {
     /**
      * Note that Alert return a className and additional properties.
      */
-    const { className, ...themeProps } = theme.getAlertProps({
-      appearance,
-      intent,
-      hasTrim
-    })
+    const { className, ...themeProps } = theme.getAlertProps(
+      {
+        appearance,
+        intent,
+        hasTrim
+      },
+      theme
+    )
 
     return (
       <Pane

--- a/src/alert/src/InlineAlert.js
+++ b/src/alert/src/InlineAlert.js
@@ -53,7 +53,13 @@ class InlineAlert extends PureComponent {
   getIconForIntent = intent => {
     const { theme } = this.props
 
-    return <Icon size={14} marginTop={2} {...theme.getIconForIntent(intent)} />
+    return (
+      <Icon
+        size={14}
+        marginTop={2}
+        {...theme.getIconForIntent(intent, theme)}
+      />
+    )
   }
 
   render() {

--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -108,10 +108,10 @@ class Avatar extends PureComponent {
 
     if (color === 'automatic') {
       const hashValue = globalHash(propsHashValue || name)
-      return theme.getAvatarProps({ isSolid, color, hashValue })
+      return theme.getAvatarProps({ isSolid, color, hashValue }, theme)
     }
 
-    return theme.getAvatarProps({ isSolid, color })
+    return theme.getAvatarProps({ isSolid, color }, theme)
   }
 
   render() {
@@ -134,7 +134,8 @@ class Avatar extends PureComponent {
     const imageUnavailable = !src || imageHasFailedLoading
     const initialsFontSize = `${theme.getAvatarInitialsFontSize(
       size,
-      sizeLimitOneCharacter
+      sizeLimitOneCharacter,
+      theme
     )}px`
 
     let initials = getInitials(name)

--- a/src/avatar/stories/index.stories.js
+++ b/src/avatar/stories/index.stories.js
@@ -104,7 +104,7 @@ storiesOf('avatar', module).add('Avatar', () => (
       {anonymousIds.map(id => (
         <Avatar
           key={id}
-          hashValue={id}
+          hashValue={`${id}`}
           name="Anonymous User"
           marginRight={12}
           size={40}

--- a/src/badges/src/Badge.js
+++ b/src/badges/src/Badge.js
@@ -54,13 +54,16 @@ class Badge extends PureComponent {
       ...props
     } = this.props
 
-    const { color, backgroundColor } = theme.getBadgeProps({
-      color: propsColor,
-      isSolid
-    })
+    const { color, backgroundColor } = theme.getBadgeProps(
+      {
+        color: propsColor,
+        isSolid
+      },
+      theme
+    )
 
     const appearance = isInteractive ? 'interactive' : 'default'
-    const classNames = cx(className, theme.getBadgeClassName(appearance))
+    const classNames = cx(className, theme.getBadgeClassName(appearance, theme))
 
     return (
       <Strong

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -123,11 +123,11 @@ class Button extends PureComponent {
       ...props
     } = this.props
 
-    const themedClassName = theme.getButtonClassName(appearance, intent)
-    const textSize = theme.getTextSizeForControlHeight(height)
+    const themedClassName = theme.getButtonClassName(appearance, intent, theme)
+    const textSize = theme.getTextSizeForControlHeight(height, theme)
 
-    const borderRadius = theme.getBorderRadiusForControlHeight(height)
-    const iconSize = theme.getIconSizeForButton(height)
+    const borderRadius = theme.getBorderRadiusForControlHeight(height, theme)
+    const iconSize = theme.getIconSizeForButton(height, theme)
 
     const pr =
       paddingRight !== undefined ? paddingRight : Math.round(height / 2) // eslint-disable-line no-negated-condition

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -39,7 +39,7 @@ class IconButton extends PureComponent {
      *   This type is supported to simplify usage of this component in other Blueprint components.
      *   As a consumer, you should never use `<Icon icon={<element />}` directly; simply render `<element />` instead.
      */
-    icon: PropTypes.string,
+    icon: PropTypes.node,
 
     /**
      * Specifies an explicit icon size instead of the default value
@@ -97,7 +97,7 @@ class IconButton extends PureComponent {
       intent,
       ...props
     } = this.props
-    const size = iconSize || theme.getIconSizeForIconButton(height)
+    const size = iconSize || theme.getIconSizeForIconButton(height, theme)
 
     return (
       <Button

--- a/src/buttons/src/TextDropdownButton.js
+++ b/src/buttons/src/TextDropdownButton.js
@@ -105,7 +105,7 @@ class TextDropdownButton extends PureComponent {
       ...props
     } = this.props
 
-    const themedClassName = theme.getTextDropdownButtonClassName()
+    const themedClassName = theme.getTextDropdownButtonClassName(theme)
 
     return (
       <Text

--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -140,7 +140,7 @@ class Checkbox extends PureComponent {
       ...props
     } = this.props
 
-    const themedClassName = theme.getCheckboxClassName(appearance)
+    const themedClassName = theme.getCheckboxClassName(appearance, theme)
 
     return (
       <Box

--- a/src/form-field/stories/index.stories.js
+++ b/src/form-field/stories/index.stories.js
@@ -15,7 +15,7 @@ storiesOf('form-field', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <FormField>FormField</FormField>
+      <FormField label="">FormField</FormField>
     </Box>
   ))
   .add('FormFieldDescription', () => (

--- a/src/icon/index.js
+++ b/src/icon/index.js
@@ -1,1 +1,2 @@
-export { default as Icon, IconNames } from './src/Icon'
+export { IconNames, DefaultIcon } from './src/DefaultIcon'
+export { default as Icon } from './src/Icon'

--- a/src/icon/src/DefaultIcon.js
+++ b/src/icon/src/DefaultIcon.js
@@ -1,0 +1,125 @@
+/* eslint react/no-array-index-key: 0, eqeqeq: 0, no-eq-null: 0 */
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+import { IconNames, IconSvgPaths16, IconSvgPaths20 } from '@blueprintjs/icons'
+
+/**
+ * This implementation is a remix of the Icon component in Blueprintjs:
+ * https://github.com/palantir/blueprint/blob/813e93f2/packages/core/src/components/icon/icon.tsx#L15
+ * Refer to the LICENSE for BlueprintJS here: https://github.com/palantir/blueprint/blob/develop/LICENSE
+ */
+class DefaultIcon extends PureComponent {
+  static SIZE_STANDARD = 16
+
+  static SIZE_LARGE = 20
+
+  static propTypes = {
+    /**
+     * Color of icon. Equivalent to setting CSS `fill` property.
+     */
+    color: PropTypes.string,
+
+    /**
+     * Name of a Blueprint UI icon, or an icon element, to render.
+     * This prop is required because it determines the content of the component, but it can
+     * be explicitly set to falsy values to render nothing.
+     *
+     * - If `null` or `undefined` or `false`, this component will render nothing.
+     * - If given an `IconName` (a string literal union of all icon names),
+     *   that icon will be rendered as an `<svg>` with `<path>` tags.
+     * - If given a `JSX.Element`, that element will be rendered and _all other props on this component are ignored._
+     *   This type is supported to simplify usage of this component in other Blueprint components.
+     *   As a consumer, you should never use `<Icon icon={<element />}` directly; simply render `<element />` instead.
+     */
+    icon: PropTypes.node.isRequired,
+
+    /**
+     * Size of the icon, in pixels.
+     * Blueprint contains 16px and 20px SVG icon images,
+     * and chooses the appropriate resolution based on this prop.
+     */
+    size: PropTypes.number.isRequired,
+
+    /**
+     * Description string.
+     * Browsers usually render this as a tooltip on hover, whereas screen
+     * readers will use it for aural feedback.
+     * By default, this is set to the icon's name for accessibility.
+     */
+    title: PropTypes.string,
+
+    /**
+     * CSS style properties.
+     */
+    style: PropTypes.object,
+
+    /**
+     * Theme provided by ThemeProvider.
+     */
+    theme: PropTypes.object.isRequired
+  }
+
+  static defaultProps = {
+    size: 16,
+    color: 'currentColor'
+  }
+
+  renderSvgPaths = (pathsSize, iconName) => {
+    const svgPathsRecord =
+      pathsSize === DefaultIcon.SIZE_STANDARD ? IconSvgPaths16 : IconSvgPaths20
+    const pathStrings = svgPathsRecord[iconName]
+
+    if (pathStrings == null) {
+      return null
+    }
+
+    return pathStrings.map((d, i) => <path key={i} d={d} fillRule="evenodd" />)
+  }
+
+  render() {
+    const { theme, color, icon, size, title, ...svgProps } = this.props
+    let { style = {} } = this.props
+
+    if (icon == null) {
+      return null
+    }
+
+    if (typeof icon !== 'string') {
+      return icon
+    }
+
+    // Choose which pixel grid is most appropriate for given icon size
+    const pixelGridSize =
+      size >= DefaultIcon.SIZE_LARGE
+        ? DefaultIcon.SIZE_LARGE
+        : DefaultIcon.SIZE_STANDARD
+    const paths = this.renderSvgPaths(pixelGridSize, icon)
+    if (paths == null) {
+      return null
+    }
+
+    const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`
+
+    if (color != null) {
+      style = { ...style, fill: theme.getIconColor(color, theme) }
+    }
+
+    return (
+      <Box
+        is="svg"
+        {...svgProps}
+        style={style}
+        data-icon={icon}
+        width={size}
+        height={size}
+        viewBox={viewBox}
+      >
+        {title ? <title>{title}</title> : null}
+        {paths}
+      </Box>
+    )
+  }
+}
+
+export { DefaultIcon, IconNames }

--- a/src/icon/src/Icon.js
+++ b/src/icon/src/Icon.js
@@ -1,127 +1,25 @@
-/* eslint react/no-array-index-key: 0, eqeqeq: 0, no-eq-null: 0 */
-import React, { PureComponent } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import Box from 'ui-box'
-import { IconNames, IconSvgPaths16, IconSvgPaths20 } from '@blueprintjs/icons'
 import { withTheme } from '../../theme'
+import { DefaultIcon } from './DefaultIcon'
 
-export { IconNames }
+// The icon wrapper selects an icon based on our getIcon resolver
+// this makes it easy to use custom icons within evergreen-ui
+const Icon = ({ icon, theme, ...props }) => {
+  const ResolvedIcon = theme.getIcon(icon, theme) || DefaultIcon
+  return <ResolvedIcon icon={icon} theme={theme} {...props} />
+}
 
-/**
- * This implementation is a remix of the Icon component in Blueprintjs:
- * https://github.com/palantir/blueprint/blob/813e93f2/packages/core/src/components/icon/icon.tsx#L15
- * Refer to the LICENSE for BlueprintJS here: https://github.com/palantir/blueprint/blob/develop/LICENSE
- */
+Icon.propTypes = {
+  /**
+   * Name of icon. By default, it could be a string or React component.
+   */
+  icon: PropTypes.node.isRequired,
 
-class Icon extends PureComponent {
-  static SIZE_STANDARD = 16
-
-  static SIZE_LARGE = 20
-
-  static propTypes = {
-    /**
-     * Color of icon. Equivalent to setting CSS `fill` property.
-     */
-    color: PropTypes.string,
-
-    /**
-     * Name of a Blueprint UI icon, or an icon element, to render.
-     * This prop is required because it determines the content of the component, but it can
-     * be explicitly set to falsy values to render nothing.
-     *
-     * - If `null` or `undefined` or `false`, this component will render nothing.
-     * - If given an `IconName` (a string literal union of all icon names),
-     *   that icon will be rendered as an `<svg>` with `<path>` tags.
-     * - If given a `JSX.Element`, that element will be rendered and _all other props on this component are ignored._
-     *   This type is supported to simplify usage of this component in other Blueprint components.
-     *   As a consumer, you should never use `<Icon icon={<element />}` directly; simply render `<element />` instead.
-     */
-    icon: PropTypes.node.isRequired,
-
-    /**
-     * Size of the icon, in pixels.
-     * Blueprint contains 16px and 20px SVG icon images,
-     * and chooses the appropriate resolution based on this prop.
-     */
-    size: PropTypes.number.isRequired,
-
-    /**
-     * Description string.
-     * Browsers usually render this as a tooltip on hover, whereas screen
-     * readers will use it for aural feedback.
-     * By default, this is set to the icon's name for accessibility.
-     */
-    title: PropTypes.string,
-
-    /**
-     * CSS style properties.
-     */
-    style: PropTypes.object,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    size: 16,
-    color: 'currentColor'
-  }
-
-  renderSvgPaths = (pathsSize, iconName) => {
-    const svgPathsRecord =
-      pathsSize === Icon.SIZE_STANDARD ? IconSvgPaths16 : IconSvgPaths20
-    const pathStrings = svgPathsRecord[iconName]
-
-    if (pathStrings == null) {
-      return null
-    }
-
-    return pathStrings.map((d, i) => <path key={i} d={d} fillRule="evenodd" />)
-  }
-
-  render() {
-    const { theme, color, icon, size, title, ...svgProps } = this.props
-    let { style = {} } = this.props
-
-    if (icon == null) {
-      return null
-    }
-
-    if (typeof icon !== 'string') {
-      return icon
-    }
-
-    // Choose which pixel grid is most appropriate for given icon size
-    const pixelGridSize =
-      size >= Icon.SIZE_LARGE ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD
-    const paths = this.renderSvgPaths(pixelGridSize, icon)
-    if (paths == null) {
-      return null
-    }
-
-    const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`
-
-    if (color != null) {
-      style = { ...style, fill: theme.getIconColor(color) }
-    }
-
-    return (
-      <Box
-        is="svg"
-        {...svgProps}
-        style={style}
-        data-icon={icon}
-        width={size}
-        height={size}
-        viewBox={viewBox}
-      >
-        {title ? <title>{title}</title> : null}
-        {paths}
-      </Box>
-    )
-  }
+  /**
+   * Theme provided by ThemeProvider.
+   */
+  theme: PropTypes.object.isRequired
 }
 
 export default withTheme(Icon)

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export {
   FormFieldLabel,
   FormFieldValidationMessage
 } from './form-field'
-export { Icon, IconNames } from './icon'
+export { Icon, IconNames, DefaultIcon } from './icon'
 export { Image } from './image'
 export { Pane, Card } from './layers'
 export { Menu } from './menu'

--- a/src/layers/src/Pane.js
+++ b/src/layers/src/Pane.js
@@ -88,7 +88,7 @@ class Pane extends PureComponent {
       ':hover': {
         ...(css[':hover'] || {}),
         transform: 'translateY(-2px)',
-        boxShadow: theme.getElevation(hoverElevation)
+        boxShadow: theme.getElevation(hoverElevation, theme)
       }
     }
   }
@@ -101,7 +101,7 @@ class Pane extends PureComponent {
       ':active': {
         ...(css[':active'] || {}),
         transform: 'translateY(-1px)',
-        boxShadow: theme.getElevation(activeElevation)
+        boxShadow: theme.getElevation(activeElevation, theme)
       }
     }
   }
@@ -156,11 +156,16 @@ class Pane extends PureComponent {
       ...props
     } = this.props
 
-    const elevationStyle = theme.getElevation(elevation)
-    const hoverElevationStyle = this.getHoverElevationStyle(hoverElevation, css)
+    const elevationStyle = theme.getElevation(elevation, theme)
+    const hoverElevationStyle = this.getHoverElevationStyle(
+      hoverElevation,
+      css,
+      theme
+    )
     const activeElevationStyle = this.getActiveElevationStyle(
       activeElevation,
-      css
+      css,
+      theme
     )
 
     const [_borderTop, _borderRight, _borderBottom, _borderLeft] = [
@@ -188,7 +193,7 @@ class Pane extends PureComponent {
         borderBottom={_borderBottom}
         borderLeft={_borderLeft}
         boxShadow={elevationStyle}
-        background={theme.getBackground(background)}
+        background={theme.getBackground(background, theme)}
         {...props}
         className={className}
       />

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -98,7 +98,11 @@ class MenuItem extends React.PureComponent {
       )
     }
 
-    const themedClassName = theme.getMenuItemClassName(appearance, 'none')
+    const themedClassName = theme.getMenuItemClassName(
+      appearance,
+      'none',
+      theme
+    )
 
     return (
       <Pane

--- a/src/menu/src/MenuOption.js
+++ b/src/menu/src/MenuOption.js
@@ -72,7 +72,11 @@ class MenuOption extends React.PureComponent {
       isSelected
     } = this.props
 
-    const themedClassName = theme.getMenuItemClassName(appearance, 'none')
+    const themedClassName = theme.getMenuItemClassName(
+      appearance,
+      'none',
+      theme
+    )
 
     const textProps = isSelected
       ? {

--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -121,7 +121,7 @@ class Radio extends PureComponent {
       appearance,
       ...props
     } = this.props
-    const themedClassName = theme.getRadioClassName(appearance)
+    const themedClassName = theme.getRadioClassName(appearance, theme)
 
     return (
       <Box

--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -22,7 +22,7 @@ class SearchInput extends PureComponent {
     const { theme, appearance, disabled, height, ...props } = this.props
     const { matchedProps, remainingProps } = splitBoxProps(props)
     const { width } = matchedProps
-    const iconSize = theme.getIconSizeForInput(height)
+    const iconSize = theme.getIconSizeForInput(height, theme)
 
     return (
       <Box

--- a/src/segmented-control/src/SegmentedControlRadio.js
+++ b/src/segmented-control/src/SegmentedControlRadio.js
@@ -121,9 +121,12 @@ class SegmentedControlRadio extends PureComponent {
       disabled
     } = this.props
 
-    const themedClassName = theme.getSegmentedControlRadioClassName(appearance)
-    const textSize = theme.getTextSizeForControlHeight(height)
-    const borderRadius = theme.getBorderRadiusForControlHeight(height)
+    const themedClassName = theme.getSegmentedControlRadioClassName(
+      appearance,
+      theme
+    )
+    const textSize = theme.getTextSizeForControlHeight(height, theme)
+    const borderRadius = theme.getBorderRadiusForControlHeight(height, theme)
 
     return (
       <Box

--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -108,10 +108,10 @@ class Select extends PureComponent {
       ...props
     } = this.props
 
-    const themedClassName = theme.getSelectClassName(appearance)
-    const textSize = theme.getTextSizeForControlHeight(height)
-    const borderRadius = theme.getBorderRadiusForControlHeight(height)
-    const iconSize = theme.getIconSizeForSelect(height)
+    const themedClassName = theme.getSelectClassName(appearance, theme)
+    const textSize = theme.getTextSizeForControlHeight(height, theme)
+    const borderRadius = theme.getBorderRadiusForControlHeight(height, theme)
+    const iconSize = theme.getIconSizeForSelect(height, theme)
     const iconMargin = height >= 36 ? 12 : 8
 
     return (

--- a/src/select/stories/index.stories.js
+++ b/src/select/stories/index.stories.js
@@ -19,7 +19,7 @@ storiesOf('select', module).add('Select', () => (
       <Description marginBottom={8}>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit sed do.
       </Description>
-      <Select appearance={appearance} name={32} id={32}>
+      <Select appearance={appearance} name="height_32" id="height_32">
         <option>Apple</option>
         <option>Pear</option>
         <option>Banana</option>
@@ -58,7 +58,12 @@ storiesOf('select', module).add('Select', () => (
       <Label htmlFor={24} size={300} display="block" marginBottom={4}>
         Height 24
       </Label>
-      <Select appearance={appearance} height={24} name={24} id={24}>
+      <Select
+        appearance={appearance}
+        height={24}
+        name="height_24"
+        id="height_24"
+      >
         <option>Apple</option>
         <option>Pear</option>
         <option>Banana</option>
@@ -69,7 +74,12 @@ storiesOf('select', module).add('Select', () => (
       <Label htmlFor={28} size={300} display="block" marginBottom={4}>
         Height 28
       </Label>
-      <Select appearance={appearance} height={28} name={28} id={28}>
+      <Select
+        appearance={appearance}
+        height={28}
+        name="height_28"
+        id="height_28"
+      >
         <option>Apple</option>
         <option>Pear</option>
         <option>Banana</option>
@@ -80,7 +90,12 @@ storiesOf('select', module).add('Select', () => (
       <Label htmlFor={36} size={400} display="block" marginBottom={4}>
         Height 36
       </Label>
-      <Select appearance={appearance} height={36} name={36} id={36}>
+      <Select
+        appearance={appearance}
+        height={36}
+        name="height_36"
+        id="height_36"
+      >
         <option>Apple</option>
         <option>Pear</option>
         <option>Banana</option>
@@ -91,7 +106,12 @@ storiesOf('select', module).add('Select', () => (
       <Label htmlFor={40} size={500} display="block" marginBottom={4}>
         Height 40
       </Label>
-      <Select appearance={appearance} height={40} name={40} id={40}>
+      <Select
+        appearance={appearance}
+        height={40}
+        name="height_40"
+        id="height_40"
+      >
         <option>Apple</option>
         <option>Pear</option>
         <option>Banana</option>

--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -176,7 +176,7 @@ class Switch extends PureComponent {
     } = this.props
 
     const checked = isControlled(this) ? checkedProps : this.state.checked
-    const themedClassName = theme.getSwitchClassName(appearance)
+    const themedClassName = theme.getSwitchClassName(appearance, theme)
 
     return (
       <Box

--- a/src/table/src/TableCell.js
+++ b/src/table/src/TableCell.js
@@ -162,7 +162,7 @@ class TableCell extends PureComponent {
       ...props
     } = this.props
 
-    const themedClassName = theme.getTableCellClassName(appearance)
+    const themedClassName = theme.getTableCellClassName(appearance, theme)
 
     return (
       <TableRowConsumer>

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -136,7 +136,7 @@ class TableRow extends PureComponent {
       isSelected,
       ...props
     } = this.props
-    const themedClassName = theme.getRowClassName(appearance, intent)
+    const themedClassName = theme.getRowClassName(appearance, intent, theme)
 
     return (
       <TableRowProvider height={height}>

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -90,7 +90,7 @@ class Tab extends PureComponent {
       )
     }
 
-    const textSize = theme.getTextSizeForControlHeight(height)
+    const textSize = theme.getTextSizeForControlHeight(height, theme)
 
     let elementBasedProps
     if (disabled) {
@@ -121,7 +121,7 @@ class Tab extends PureComponent {
 
     return (
       <Text
-        className={theme.getTabClassName(appearance)}
+        className={theme.getTabClassName(appearance, theme)}
         is={is}
         size={textSize}
         height={height}

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -233,10 +233,13 @@ class TagInput extends React.Component {
 
     const { inputValue, isFocused } = this.state
 
-    const themedContainerClassName = theme.getTagInputClassName('default')
-    const themedInputClassName = theme.getTextInputClassName('none')
-    const textSize = theme.getTextSizeForControlHeight(height)
-    const borderRadius = theme.getBorderRadiusForControlHeight(height)
+    const themedContainerClassName = theme.getTagInputClassName(
+      'default',
+      theme
+    )
+    const themedInputClassName = theme.getTextInputClassName('none', theme)
+    const textSize = theme.getTextSizeForControlHeight(height, theme)
+    const borderRadius = theme.getBorderRadiusForControlHeight(height, theme)
 
     return (
       <Box

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -83,9 +83,9 @@ class TextInput extends PureComponent {
       spellCheck,
       ...props
     } = this.props
-    const themedClassName = theme.getTextInputClassName(appearance)
-    const textSize = theme.getTextSizeForControlHeight(height)
-    const borderRadius = theme.getBorderRadiusForControlHeight(height)
+    const themedClassName = theme.getTextInputClassName(appearance, theme)
+    const textSize = theme.getTextSizeForControlHeight(height, theme)
+    const borderRadius = theme.getBorderRadiusForControlHeight(height, theme)
 
     return (
       <Text

--- a/src/text-input/stories/index.stories.js
+++ b/src/text-input/stories/index.stories.js
@@ -35,7 +35,7 @@ storiesOf('text-input', module)
         <Box key={appearance} padding={40} float="left">
           <Heading marginBottom={24}>Appearance: {appearance}</Heading>
           <Box marginBottom={24} width={360}>
-            <Label htmlFor={32} size={400} display="block">
+            <Label htmlFor={`32-${appearance}`} size={400} display="block">
               Height 32 (default)
             </Label>
             <Description marginBottom={8}>
@@ -44,56 +44,104 @@ storiesOf('text-input', module)
             <TextInput
               appearance={appearance}
               name={32}
-              id={32}
+              id={`32-${appearance}`}
               placeholder="With placeholder"
             />
           </Box>
           <Box marginBottom={24} width={360}>
-            <Label htmlFor="disabled" size={400} display="block">
+            <Label
+              htmlFor={`disabled-${appearance}`}
+              size={400}
+              display="block"
+            >
               Disabled
             </Label>
             <TextInput
               appearance={appearance}
               value="This is disabled"
               name="disabled"
-              id="disabled"
+              id={`disabled-${appearance}`}
               disabled
             />
           </Box>
           <Box marginBottom={24} width={360}>
-            <Label htmlFor="isInvalid" size={400} display="block">
+            <Label
+              htmlFor={`isInvalid-${appearance}`}
+              size={400}
+              display="block"
+            >
               Is Invalid
             </Label>
             <TextInput
               appearance={appearance}
               name="isInvalid"
-              id="isInvalid"
+              id={`isInvalid-${appearance}`}
               isInvalid
             />
           </Box>
           <Box marginBottom={24}>
-            <Label htmlFor={24} size={300} display="block" marginBottom={4}>
+            <Label
+              htmlFor={`24-${appearance}`}
+              size={300}
+              display="block"
+              marginBottom={4}
+            >
               Height 24
             </Label>
-            <TextInput appearance={appearance} height={24} name={24} id={24} />
+            <TextInput
+              appearance={appearance}
+              height={24}
+              name={24}
+              id={`24-${appearance}`}
+            />
           </Box>
           <Box marginBottom={24}>
-            <Label htmlFor={28} size={300} display="block" marginBottom={4}>
+            <Label
+              htmlFor={`28-${appearance}`}
+              size={300}
+              display="block"
+              marginBottom={4}
+            >
               Height 28
             </Label>
-            <TextInput appearance={appearance} height={28} name={28} id={28} />
+            <TextInput
+              appearance={appearance}
+              height={28}
+              name={28}
+              id={`28-${appearance}`}
+            />
           </Box>
           <Box marginBottom={24}>
-            <Label htmlFor={36} size={400} display="block" marginBottom={4}>
+            <Label
+              htmlFor={`36-${appearance}`}
+              size={400}
+              display="block"
+              marginBottom={4}
+            >
               Height 36
             </Label>
-            <TextInput appearance={appearance} height={36} name={36} id={36} />
+            <TextInput
+              appearance={appearance}
+              height={36}
+              name={36}
+              id={`36-${appearance}`}
+            />
           </Box>
           <Box marginBottom={24}>
-            <Label htmlFor={40} size={500} display="block" marginBottom={4}>
+            <Label
+              htmlFor={`40-${appearance}`}
+              size={500}
+              display="block"
+              marginBottom={4}
+            >
               Height 40
             </Label>
-            <TextInput appearance={appearance} height={40} name={40} id={40} />
+            <TextInput
+              appearance={appearance}
+              height={40}
+              name={40}
+              id={`40-${appearance}`}
+            />
           </Box>
         </Box>
       ))}

--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -95,7 +95,7 @@ class Textarea extends PureComponent {
       grammarly,
       ...props
     } = this.props
-    const themedClassName = theme.getTextareaClassName(appearance)
+    const themedClassName = theme.getTextareaClassName(appearance, theme)
 
     return (
       <Text

--- a/src/theme/src/default-theme/component-specific/buttonColors.js
+++ b/src/theme/src/default-theme/component-specific/buttonColors.js
@@ -1,0 +1,43 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  /**
+   * Colors used specifically in buttons. For example, the linear gradients and minimal stylings
+   * @property {string} primary.default.gradientStart required property. the start gradient value
+   * @property {string} primary.default.gradientEnd required property. the end gradient value
+   * @property {string} primary.success.gradientStart required property. the start gradient value
+   * @property {string} primary.success.gradientEnd required property. the end gradient value
+   * @property {string} primary.warning.gradientStart required property. the start gradient value
+   * @property {string} primary.warning.gradientEnd required property. the end gradient value
+   * @property {string} primary.danger.gradientStart required property. the start gradient value
+   * @property {string} primary.danger.gradientEnd required property. the end gradient value
+   * @property {string} minimal.default required property. Text color for minimal buttons
+   * @property {string} minimal.hoverBackground required property. background color for hovered minimal buttons
+   * @property {string} minimal.focusBackground required property. background color for focused minimal buttons
+   * @property {string} minimal.activeBackground required property. background color for active minimal buttons
+   */
+  primary: {
+    default: {
+      gradientStart: '#0788DE',
+      gradientEnd: '#116AB8'
+    },
+    success: {
+      gradientStart: '#23C277',
+      gradientEnd: '#399D6C'
+    },
+    warning: {
+      gradientStart: '#EE9913',
+      gradientEnd: '#D9822B'
+    },
+    danger: {
+      gradientStart: '#EC4C47',
+      gradientEnd: '#D64540'
+    }
+  },
+  minimal: {
+    default: scales.blue.B9,
+    hoverBackground: scales.neutral.N2A,
+    focusBackground: scales.blue.B5A,
+    activeBackground: scales.blue.B3A
+  }
+}

--- a/src/theme/src/default-theme/component-specific/checkboxColors.js
+++ b/src/theme/src/default-theme/component-specific/checkboxColors.js
@@ -1,0 +1,11 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  focus: {
+    shadowColor: scales.blue.B4A
+  },
+  active: {
+    backgroundColor: scales.blue.B3A,
+    shadowColor: scales.blue.B5A
+  }
+}

--- a/src/theme/src/default-theme/component-specific/codeColors.js
+++ b/src/theme/src/default-theme/component-specific/codeColors.js
@@ -1,0 +1,11 @@
+import scales from '../foundational-styles/scales'
+
+/**
+ * Colors used in the Code component
+ * @property {string} backgroundColor - required property. Default background for Code
+ * @property {string} shadowColor - required property. Default shadow color for Code
+ */
+export default {
+  backgroundColor: scales.blue.B2A,
+  shadowColor: scales.blue.B4A
+}

--- a/src/theme/src/default-theme/component-specific/defaultControlColors.js
+++ b/src/theme/src/default-theme/component-specific/defaultControlColors.js
@@ -1,0 +1,26 @@
+import scales from '../foundational-styles/scales'
+import palette from '../foundational-styles/palette'
+
+export default {
+  base: {
+    backgroundColor: 'white',
+    gradientStart: '#FFFFFF',
+    gradientEnd: '#F4F5F7'
+  },
+  hover: {
+    gradientStart: '#FAFBFB',
+    gradientEnd: '#EAECEE'
+  },
+  focus: {
+    shadowColor: scales.blue.B4A
+  },
+  active: {
+    backgroundColor: scales.blue.B3A
+  },
+  focusAndActive: {
+    shadowColor: scales.blue.B4A
+  },
+  invalid: {
+    shadowColor: palette.red.base
+  }
+}

--- a/src/theme/src/default-theme/component-specific/getAlertProps.js
+++ b/src/theme/src/default-theme/component-specific/getAlertProps.js
@@ -2,17 +2,19 @@ import { css } from 'glamor'
 import scales from '../foundational-styles/scales'
 import colors from '../foundational-styles/colors'
 
-const getTrimStyle = intent => ({
-  '&:before': {
-    content: '""',
-    width: 3,
-    height: '100%',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    backgroundColor: colors.intent[intent]
+const getTrimStyle = (intent, theme) => {
+  return {
+    '&:before': {
+      content: '""',
+      width: 3,
+      height: '100%',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      backgroundColor: theme?.colors?.intent?.[intent] || colors.intent[intent]
+    }
   }
-})
+}
 
 /**
  * Get the themed props for the Alert component.
@@ -20,10 +22,13 @@ const getTrimStyle = intent => ({
  * @param {string} props.appearance - default theme supports `default` and `card`.
  * @param {Intent} props.intent - intent of the alert. May be `none`.
  * @param {boolean} props.hasTrim - when true, the alert has a trim.
+ * @param {Object} theme - the current theme
  * @return {Object} { className, ...themedProps }
  */
-const getAlertProps = ({ appearance, intent, hasTrim }) => {
-  const trimClassName = hasTrim ? css(getTrimStyle(intent)).toString() : ''
+const getAlertProps = ({ appearance, intent, hasTrim }, theme) => {
+  const trimClassName = hasTrim
+    ? css(getTrimStyle(intent, theme)).toString()
+    : ''
 
   switch (appearance) {
     case 'card':
@@ -31,7 +36,8 @@ const getAlertProps = ({ appearance, intent, hasTrim }) => {
     case 'default':
     default:
       return {
-        boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
+        boxShadow: `inset 0 0 0 1px ${theme?.scales?.neutral?.N4A ||
+          scales.neutral.N4A}`,
         className: trimClassName
       }
   }

--- a/src/theme/src/default-theme/component-specific/getAvatarInitialsFontSize.js
+++ b/src/theme/src/default-theme/component-specific/getAvatarInitialsFontSize.js
@@ -1,9 +1,10 @@
 /**
  * @param {number} size
  * @param {number} sizeLimitOneCharacter
+ * @param {Object} theme - the current theme
  * @return {number} font size
  */
-const getAvatarInitialsFontSize = (size, sizeLimitOneCharacter) => {
+const getAvatarInitialsFontSize = (size, sizeLimitOneCharacter, _) => {
   if (size <= sizeLimitOneCharacter) {
     return Math.ceil(size / 2.2)
   }

--- a/src/theme/src/default-theme/component-specific/getAvatarProps.js
+++ b/src/theme/src/default-theme/component-specific/getAvatarProps.js
@@ -4,10 +4,11 @@ import fills from '../foundational-styles/fills'
  * @param {boolean} isSolid
  * @param {string} color — automatic or actual color
  * @param {number} hashValue
+ * @param {Object} theme - the current theme value
  * @return {Object} { color, backgroundColor }
  */
-const getAvatarProps = ({ isSolid, color, hashValue }) => {
-  const appearances = fills[isSolid ? 'solid' : 'subtle']
+const getAvatarProps = ({ isSolid, color, hashValue }, theme) => {
+  const appearances = (theme?.fills || fills)[isSolid ? 'solid' : 'subtle']
 
   if (color === 'automatic') {
     const keys = Object.keys(appearances)

--- a/src/theme/src/default-theme/component-specific/getBadgeClassName.js
+++ b/src/theme/src/default-theme/component-specific/getBadgeClassName.js
@@ -11,9 +11,10 @@ const interactiveAppearance = Themer.createBadgeAppearance({
 /**
  * Get the appearance of an interactive `Badge`.
  * @param {string} appearance - the appearance name
+ * @param {Object} theme - the current theme
  * @return {string} the appearance object.
  */
-const getBadgeAppearance = appearance => {
+const getBadgeAppearance = (appearance, _) => {
   switch (appearance) {
     case 'interactive':
       return interactiveAppearance

--- a/src/theme/src/default-theme/component-specific/getButtonClassName.js
+++ b/src/theme/src/default-theme/component-specific/getButtonClassName.js
@@ -5,24 +5,33 @@ import {
   getTextColorForIntent,
   getPrimaryButtonStylesForIntent
 } from '../helpers'
-import { defaultControlStyles } from '../shared'
-
-/**
- * Disabled styles are all the same for all buttons.
- */
-const { disabled } = defaultControlStyles
+import { getDefaultControlStyles } from '../shared'
+import buttonColors from './buttonColors'
 
 /**
  * Get button appearance.
  * @param {string} appearance - default, primary, minimal.
  * @param {string} intent - none, success, warning, danger.
+ * @param {Object} theme - the current theme
  * @return {Object} the appearance of the button.
  */
-const getButtonAppearance = (appearance, intent) => {
+const getButtonAppearance = (appearance, intent, theme) => {
+  const defaultControlStyles = getDefaultControlStyles(theme)
+
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+
+  /**
+   * Disabled styles are all the same for all buttons.
+   */
+  const { disabled } = defaultControlStyles
+
   switch (appearance) {
     case 'primary': {
       const { linearGradient, focusColor } = getPrimaryButtonStylesForIntent(
-        intent
+        intent,
+        theme
       )
       return Themer.createButtonAppearance({
         disabled,
@@ -30,34 +39,38 @@ const getButtonAppearance = (appearance, intent) => {
           color: 'white',
           backgroundColor: 'white',
           backgroundImage: linearGradient.base,
-          boxShadow: `inset 0 0 0 1px ${
-            scales.neutral.N5A
-          }, inset 0 -1px 1px 0 ${scales.neutral.N2A}`
+          boxShadow: `inset 0 0 0 1px ${N5A}, inset 0 -1px 1px 0 ${N2A}`
         },
         hover: {
           backgroundImage: linearGradient.hover
         },
         focus: {
-          boxShadow: `0 0 0 3px ${focusColor}, inset 0 0 0 1px ${
-            scales.neutral.N4A
-          }, inset 0 -1px 1px 0 ${scales.neutral.N5A}`
+          boxShadow: `0 0 0 3px ${focusColor}, inset 0 0 0 1px ${N4A}, inset 0 -1px 1px 0 ${N5A}`
         },
         active: {
           backgroundImage: linearGradient.active,
-          boxShadow: `inset 0 0 0 1px ${
-            scales.neutral.N4A
-          }, inset 0 1px 1px 0 ${scales.neutral.N2A}`
+          boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 1px 1px 0 ${N2A}`
         },
         focusAndActive: {
-          boxShadow: `0 0 0 3px ${focusColor}, inset 0 0 0 1px ${
-            scales.neutral.N4A
-          }, inset 0 1px 1px 0 ${scales.neutral.N2A}`
+          boxShadow: `0 0 0 3px ${focusColor}, inset 0 0 0 1px ${N4A}, inset 0 1px 1px 0 ${N2A}`
         }
       })
     }
 
     case 'minimal': {
-      const intentTextColor = getTextColorForIntent(intent, scales.blue.B9)
+      const defaultColor =
+        theme?.buttonColors?.minimal?.default || buttonColors.minimal.default
+      const hoverBackground =
+        theme?.buttonColors?.minimal?.hoverBackground ||
+        buttonColors.minimal.hoverBackground
+      const focusBackground =
+        theme?.buttonColors?.minimal?.focusBackground ||
+        buttonColors.minimal.focusBackground
+      const activeBackground =
+        theme?.buttonColors?.minimal?.activeBackground ||
+        buttonColors.minimal.activeBackground
+
+      const intentTextColor = getTextColorForIntent(intent, defaultColor, theme)
       return Themer.createButtonAppearance({
         disabled,
         base: {
@@ -65,14 +78,14 @@ const getButtonAppearance = (appearance, intent) => {
           backgroundColor: 'transparent'
         },
         hover: {
-          backgroundColor: scales.neutral.N2A
+          backgroundColor: hoverBackground
         },
         focus: {
-          boxShadow: `0 0 0 3px ${scales.blue.B5A}`
+          boxShadow: `0 0 0 3px ${focusBackground}`
         },
         active: {
           backgroundImage: 'none',
-          backgroundColor: scales.blue.B3A
+          backgroundColor: activeBackground
         },
         focusAndActive: {}
       })
@@ -80,7 +93,7 @@ const getButtonAppearance = (appearance, intent) => {
 
     case 'default':
     default: {
-      const intentTextColor = getTextColorForIntent(intent)
+      const intentTextColor = getTextColorForIntent(intent, null, theme)
       return Themer.createButtonAppearance({
         disabled,
         base: {

--- a/src/theme/src/default-theme/component-specific/getCheckboxClassName.js
+++ b/src/theme/src/default-theme/component-specific/getCheckboxClassName.js
@@ -2,81 +2,84 @@ import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
 import scales from '../foundational-styles/scales'
 import { getPrimaryButtonStylesForIntent } from '../helpers'
+import checkboxColors from './checkboxColors'
 
-const primaryStyle = getPrimaryButtonStylesForIntent()
+const getDefaultAppearance = theme => {
+  const primaryStyle = getPrimaryButtonStylesForIntent(theme)
 
-const defaultAppearance = Themer.createCheckboxAppearance({
-  base: {
-    color: 'white',
-    backgroundColor: 'white',
-    backgroundImage: `linear-gradient(to top, ${scales.neutral.N2A}, white)`,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N3A
-    }`
-  },
-  disabled: {
-    cursor: 'not-allowed',
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2A,
-    backgroundImage: 'none'
-  },
-  hover: {
-    backgroundImage: `linear-gradient(to top, ${scales.neutral.N2A}, ${
-      scales.neutral.N1A
-    })`,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  },
-  focus: {
-    boxShadow: `0 0 0 2px ${scales.blue.B4A}, inset 0 0 0 1px ${
-      scales.neutral.N5A
-    }, inset 0 -1px 1px 0 ${scales.neutral.N3A}`
-  },
-  active: {
-    backgroundImage: 'none',
-    backgroundColor: scales.blue.B3A,
-    boxShadow: `inset 0 0 0 1px ${scales.blue.B5A}`
-  },
-  checked: {
-    color: 'white',
-    backgroundImage: primaryStyle.linearGradient.base,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N5A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  },
-  checkedHover: {
-    color: 'white',
-    backgroundImage: primaryStyle.linearGradient.hover,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N5A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  },
-  checkedDisabled: {
-    color: scales.neutral.N6A,
-    backgroundImage: `linear-gradient(to top, ${scales.neutral.N2A}, ${
-      scales.neutral.N1A
-    })`,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  },
-  checkedActive: {
-    color: 'white',
-    backgroundImage: primaryStyle.linearGradient.active,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  }
-})
+  const N1A = theme?.scales?.neutral?.N1A || scales.neutral.N1A
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+  const N3A = theme?.scales?.neutral?.N3A || scales.neutral.N3A
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
+
+  const focusShadow =
+    theme?.checkboxColors?.focus?.shadowColor ||
+    checkboxColors.focus.shadowColor
+  const activeBackground =
+    theme?.checkboxColors?.active?.backgroundColor ||
+    checkboxColors.active.backgroundColor
+  const activeShadow =
+    theme?.checkboxColors?.active?.shadowColor ||
+    checkboxColors.active.shadowColor
+
+  return Themer.createCheckboxAppearance({
+    base: {
+      color: 'white',
+      backgroundColor: 'white',
+      backgroundImage: `linear-gradient(to top, ${N2A}, white)`,
+      boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 -1px 1px 0 ${N3A}`
+    },
+    disabled: {
+      cursor: 'not-allowed',
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2A,
+      backgroundImage: 'none'
+    },
+    hover: {
+      backgroundImage: `linear-gradient(to top, ${N2A}, ${N1A})`,
+      boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 -1px 1px 0 ${N2A}`
+    },
+    focus: {
+      boxShadow: `0 0 0 2px ${focusShadow}, inset 0 0 0 1px ${N5A}, inset 0 -1px 1px 0 ${N3A}`
+    },
+    active: {
+      backgroundImage: 'none',
+      backgroundColor: activeBackground,
+      boxShadow: `inset 0 0 0 1px ${activeShadow}`
+    },
+    checked: {
+      color: 'white',
+      backgroundImage: primaryStyle.linearGradient.base,
+      boxShadow: `inset 0 0 0 1px ${N5A}, inset 0 -1px 1px 0 ${N2A}`
+    },
+    checkedHover: {
+      color: 'white',
+      backgroundImage: primaryStyle.linearGradient.hover,
+      boxShadow: `inset 0 0 0 1px ${N5A}, inset 0 -1px 1px 0 ${N2A}`
+    },
+    checkedDisabled: {
+      color: N6A,
+      backgroundImage: `linear-gradient(to top, ${N2A}, ${N1A})`,
+      boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 -1px 1px 0 ${N2A}`
+    },
+    checkedActive: {
+      color: 'white',
+      backgroundImage: primaryStyle.linearGradient.active,
+      boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 -1px 1px 0 ${N2A}`
+    }
+  })
+}
 
 /**
  * There is only a single appearance in the default theme.
  * @param {String} appearance.
+ * @param {Object} theme - the current theme
  * @return {Object} the appearance of the checkbox.
  */
-const getCheckboxAppearance = () => {
-  return defaultAppearance
+const getCheckboxAppearance = theme => {
+  return getDefaultAppearance(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getCodeProps.js
+++ b/src/theme/src/default-theme/component-specific/getCodeProps.js
@@ -1,11 +1,16 @@
-import scales from '../foundational-styles/scales'
+import codeColors from './codeColors'
 
 /**
  * Get the themed properties for a `Code` text component.
  * @param {string} appearance - default, minimal.
+ * @param {Object} theme - the theme object
  * @return {string} the themd properties.
  */
-const getCodeProps = appearance => {
+const getCodeProps = (appearance, theme) => {
+  const defaultBackground =
+    theme?.codeColors?.backgroundColor || codeColors.backgroundColor
+  const defaultShadow = theme?.codeColors?.shadowColor || codeColors.shadowColor
+
   switch (appearance) {
     case 'minimal':
       return {}
@@ -13,8 +18,8 @@ const getCodeProps = appearance => {
     default:
       // Passing padding and border radius is non-ideal here.
       return {
-        backgroundColor: scales.blue.B2A,
-        boxShadow: `inset 0 0 0 1px ${scales.blue.B4A}`,
+        backgroundColor: defaultBackground,
+        boxShadow: `inset 0 0 0 1px ${defaultShadow}`,
         paddingLeft: 6,
         paddingRight: 6,
         paddingTop: 3,

--- a/src/theme/src/default-theme/component-specific/getIcon.js
+++ b/src/theme/src/default-theme/component-specific/getIcon.js
@@ -1,0 +1,10 @@
+/**
+ * Override to return an icon component that can be rendered via React
+ * The component returned will receive the same props as DefaultIcon
+ * @param {object} icon - the icon requested
+ * @param {object} theme - the theme object
+ * @return {function} Component to render, which will receive all props an Icon would
+ */
+const getIcon = (/* icon, theme */) => null
+
+export default getIcon

--- a/src/theme/src/default-theme/component-specific/getLinkClassName.js
+++ b/src/theme/src/default-theme/component-specific/getLinkClassName.js
@@ -7,76 +7,38 @@ import palette from '../foundational-styles/palette'
  * The link appearance unlike the Button is based on the color property.
  * Currently the Link does not support the Intent or the appearance interface.
  * @param {string} color
+ * @param {Object} theme - the current theme object
  * @return {Object} appearance of the link.
  */
-const getLinkAppearance = color => {
-  switch (color) {
-    case 'neutral':
-      return Themer.createLinkAppearance({
-        base: {
-          color: palette.neutral.base
-        },
-        hover: {
-          color: tinycolor(palette.neutral.base)
-            .lighten(10)
-            .toString()
-        },
-        active: {
-          color: tinycolor(palette.neutral.base)
-            .darken(10)
-            .toString()
-        },
-        focus: {
-          boxShadow: `0 0 0 2px ${tinycolor(palette.neutral.base)
-            .setAlpha(0.4)
-            .toString()}`
-        }
-      })
-    case 'green':
-      return Themer.createLinkAppearance({
-        base: {
-          color: palette.green.base
-        },
-        hover: {
-          color: tinycolor(palette.green.base)
-            .lighten(10)
-            .toString()
-        },
-        active: {
-          color: tinycolor(palette.green.base)
-            .darken(10)
-            .toString()
-        },
-        focus: {
-          boxShadow: `0 0 0 2px ${tinycolor(palette.green.base)
-            .setAlpha(0.4)
-            .toString()}`
-        }
-      })
-    case 'default':
-    case 'blue':
-    default:
-      return Themer.createLinkAppearance({
-        base: {
-          color: palette.blue.base
-        },
-        hover: {
-          color: tinycolor(palette.blue.base)
-            .lighten(10)
-            .toString()
-        },
-        active: {
-          color: tinycolor(palette.blue.base)
-            .darken(10)
-            .toString()
-        },
-        focus: {
-          boxShadow: `0 0 0 2px ${tinycolor(palette.blue.base)
-            .setAlpha(0.4)
-            .toString()}`
-        }
-      })
-  }
+const getLinkAppearance = (color, theme) => {
+  // Try and find the color + base in the theme palette
+  // then fall back to ours
+  const colorValue =
+    theme?.palette?.[color]?.base ||
+    palette?.[color]?.base ||
+    theme?.palette?.default?.base ||
+    palette.blue.base
+
+  return Themer.createLinkAppearance({
+    base: {
+      color: colorValue
+    },
+    hover: {
+      color: tinycolor(colorValue)
+        .lighten(10)
+        .toString()
+    },
+    active: {
+      color: tinycolor(colorValue)
+        .darken(10)
+        .toString()
+    },
+    focus: {
+      boxShadow: `0 0 0 2px ${tinycolor(colorValue)
+        .setAlpha(0.4)
+        .toString()}`
+    }
+  })
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getRowClassName.js
+++ b/src/theme/src/default-theme/component-specific/getRowClassName.js
@@ -1,127 +1,76 @@
 import tinycolor from 'tinycolor2'
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
-import scales from '../foundational-styles/scales'
-import palette from '../foundational-styles/palette'
-
-const Appearances = {}
-
-Appearances.default = Themer.createRowAppearance({
-  base: {
-    color: palette.neutral.base
-  },
-
-  hover: {
-    backgroundColor: scales.neutral.N1A
-  },
-
-  focus: {
-    backgroundColor: scales.blue.B1A
-  },
-
-  active: {
-    backgroundColor: scales.blue.B2A
-  },
-
-  current: {}
-})
-
-Appearances.danger = Themer.createRowAppearance({
-  base: {
-    backgroundColor: palette.red.lightest
-  },
-
-  hover: {
-    backgroundColor: tinycolor(palette.red.lightest)
-      .darken(1)
-      .toString()
-  },
-
-  focus: {
-    backgroundColor: tinycolor(palette.red.lightest)
-      .darken(1.5)
-      .toString()
-  },
-
-  active: {
-    backgroundColor: tinycolor(palette.red.lightest)
-      .darken(2.2)
-      .toString()
-  },
-
-  current: {}
-})
-
-Appearances.warning = Themer.createRowAppearance({
-  base: {
-    backgroundColor: palette.orange.lightest
-  },
-
-  hover: {
-    backgroundColor: tinycolor(palette.orange.lightest)
-      .darken(1)
-      .toString()
-  },
-
-  focus: {
-    backgroundColor: tinycolor(palette.orange.lightest)
-      .darken(1.5)
-      .toString()
-  },
-
-  active: {
-    backgroundColor: tinycolor(palette.orange.lightest)
-      .darken(2.5)
-      .toString()
-  },
-
-  current: {}
-})
-
-Appearances.success = Themer.createRowAppearance({
-  base: {
-    backgroundColor: palette.green.lightest
-  },
-
-  hover: {
-    backgroundColor: tinycolor(palette.green.lightest)
-      .darken(1)
-      .toString()
-  },
-
-  focus: {
-    backgroundColor: tinycolor(palette.green.lightest)
-      .darken(2)
-      .toString()
-  },
-
-  active: {
-    backgroundColor: tinycolor(palette.green.lightest)
-      .darken(3)
-      .toString()
-  },
-
-  current: {}
-})
+import rowColors from './rowColors'
 
 /**
  * Get the appearance of a `Row`.
  * @param {string} appearance — only one default appearance.
  * @param {string} intent - none, info, success, warning, danger.
+ * @param {object} theme - the theme object
  * @return {string} the appearance object.
  */
-const getRowAppearance = (appearance, intent) => {
-  switch (intent) {
-    case 'danger':
-      return Appearances.danger
-    case 'warning':
-      return Appearances.warning
-    case 'success':
-      return Appearances.success
-    case 'none':
-    default:
-      return Appearances.default
-  }
+const getRowAppearance = (appearance, intent, theme) => {
+  appearance = appearance || 'default' // Only one appearance right now
+
+  // Try the user appearance + intent + type, then check our own set
+  // If that fails, check just appearance + intent
+  // This allows us to shortcut danger, warning, etc
+  const baseBackground =
+    theme?.rowColors?.[appearance]?.[intent]?.base ||
+    rowColors?.[appearance]?.[intent]?.base ||
+    rowColors?.[appearance]?.[intent] ||
+    'inherit'
+
+  const hoverBackground =
+    theme?.rowColors?.[appearance]?.[intent]?.hover ||
+    rowColors?.[appearance]?.[intent]?.hover ||
+    rowColors?.[appearance]?.[intent] ||
+    'inherit'
+
+  const focusBackground =
+    theme?.rowColors?.[appearance]?.[intent]?.focus ||
+    rowColors?.[appearance]?.[intent]?.focus ||
+    rowColors?.[appearance]?.[intent] ||
+    'inherit'
+
+  const activeBackground =
+    theme?.rowColors?.[appearance]?.[intent]?.active ||
+    rowColors?.[appearance]?.[intent]?.active ||
+    rowColors?.[appearance]?.[intent] ||
+    'inherit'
+
+  return Themer.createRowAppearance({
+    base: {
+      backgroundColor: baseBackground || 'initial'
+    },
+
+    hover: {
+      backgroundColor: hoverBackground
+        ? tinycolor(hoverBackground)
+            .darken(1)
+            .toString()
+        : 'initial'
+    },
+
+    focus: {
+      backgroundColor: focusBackground
+        ? tinycolor(focusBackground)
+            .darken(2)
+            .toString()
+        : 'initial'
+    },
+
+    active: {
+      backgroundColor: activeBackground
+        ? tinycolor(activeBackground)
+            .darken(3)
+            .toString()
+        : 'initial'
+    },
+
+    current: {}
+  })
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getSegmentedControlRadioClassName.js
+++ b/src/theme/src/default-theme/component-specific/getSegmentedControlRadioClassName.js
@@ -1,22 +1,26 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
-import { defaultControlStyles } from '../shared'
+import { getDefaultControlStyles } from '../shared'
 
-const defaultAppearance = Themer.createSegmentedControlRadioAppearance({
-  base: defaultControlStyles.base,
-  disabled: defaultControlStyles.disabled,
-  hover: defaultControlStyles.hover,
-  active: defaultControlStyles.active,
-  focus: defaultControlStyles.focus
-})
+const getDefaultAppearance = theme => {
+  const defaultControlStyles = getDefaultControlStyles(theme)
+  return Themer.createSegmentedControlRadioAppearance({
+    base: defaultControlStyles.base,
+    disabled: defaultControlStyles.disabled,
+    hover: defaultControlStyles.hover,
+    active: defaultControlStyles.active,
+    focus: defaultControlStyles.focus
+  })
+}
 
 /**
  * Get the appearanece of a `SegmentedControlRadio`.
  * @param {string} appearance
+ * @param {object} theme - the current theme
  * @return {string} the appearance object.
  */
-const getSegmentedControlRadioAppearance = () => {
-  return defaultAppearance
+const getSegmentedControlRadioAppearance = theme => {
+  return getDefaultAppearance(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getSelectClassName.js
+++ b/src/theme/src/default-theme/component-specific/getSelectClassName.js
@@ -1,31 +1,33 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
-import { defaultControlStyles } from '../shared'
+import { getDefaultControlStyles } from '../shared'
 import scales from '../foundational-styles/scales'
-import palette from '../foundational-styles/palette'
-
-const SelectAppearances = {}
-
-SelectAppearances.default = Themer.createSelectAppearance({
-  base: defaultControlStyles.base,
-  disabled: defaultControlStyles.disabled,
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  hover: defaultControlStyles.hover,
-  focus: defaultControlStyles.focus,
-  active: defaultControlStyles.active
-})
+import defaultControlColors from './defaultControlColors'
 
 /**
  * Get the appearance of a `Select`.
  * @param {string} appearance
+ * @param {object} theme - the current theme object
  * @return {string} the appearance object.
  */
-const getSelectAppearance = () => {
-  return SelectAppearances.default
+const getSelectAppearance = theme => {
+  const defaultControlStyles = getDefaultControlStyles(theme)
+
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const invalidColor =
+    theme?.defaultControlColors?.invalid.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  return Themer.createSelectAppearance({
+    base: defaultControlStyles.base,
+    disabled: defaultControlStyles.disabled,
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidColor}, inset 0 1px 2px ${N4A}`
+    },
+    hover: defaultControlStyles.hover,
+    focus: defaultControlStyles.focus,
+    active: defaultControlStyles.active
+  })
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getSwitchClassName.js
+++ b/src/theme/src/default-theme/component-specific/getSwitchClassName.js
@@ -1,50 +1,82 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
 import scales from '../foundational-styles/scales'
+import switchColors from './switchColors'
 
-const defaultAppearance = Themer.createSwitchAppearance({
-  base: {
-    transition: 'all 120ms ease-in-out',
-    cursor: 'pointer',
-    color: 'white',
-    backgroundColor: scales.neutral.N5A,
-    borderRadius: 9999
-  },
-  disabled: {
-    opacity: 0.5,
-    backgroundImage: 'none'
-  },
-  hover: {
-    backgroundColor: scales.neutral.N5A
-  },
-  active: {
-    backgroundColor: scales.neutral.N6A
-  },
-  focus: {
-    boxShadow: `0 0 0 3px ${scales.blue.B6A}`
-  },
-  checked: {
-    backgroundColor: scales.blue.B8,
-    color: 'white'
-  },
-  checkedHover: {
-    backgroundColor: scales.blue.B8,
-    color: 'white'
-  },
-  checkedActive: {
-    backgroundColor: scales.blue.B9,
-    color: 'white'
-  },
-  checkedDisabled: {}
-})
+const getDefaultAppearance = theme => {
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
+
+  const focusShadow =
+    theme?.switchColors?.focus?.shadowColor || switchColors.focus.shadowColor
+
+  const checkedBackground =
+    theme?.switchColors?.checked?.backgroundColor ||
+    switchColors.checked.backgroundColor
+
+  const checkedColor =
+    theme?.switchColors?.checked?.color || switchColors.checked.color
+
+  const checkedHoverBackground =
+    theme?.switchColors?.checkedHover?.backgroundColor ||
+    switchColors.checkedHover.backgroundColor
+
+  const checkedHoverColor =
+    theme?.switchColors?.checkedHover?.color || switchColors.checkedHover.color
+
+  const checkedActiveBackground =
+    theme?.switchColors?.checkedActive?.backgroundColor ||
+    switchColors.checkedActive.backgroundColor
+
+  const checkedActiveColor =
+    theme?.switchColors?.checkedActive?.color ||
+    switchColors.checkedActive.color
+
+  return Themer.createSwitchAppearance({
+    base: {
+      transition: 'all 120ms ease-in-out',
+      cursor: 'pointer',
+      color: 'white',
+      backgroundColor: N5A,
+      borderRadius: 9999
+    },
+    disabled: {
+      opacity: 0.5,
+      backgroundImage: 'none'
+    },
+    hover: {
+      backgroundColor: N5A
+    },
+    active: {
+      backgroundColor: N6A
+    },
+    focus: {
+      boxShadow: `0 0 0 3px ${focusShadow}`
+    },
+    checked: {
+      backgroundColor: checkedBackground,
+      color: checkedColor
+    },
+    checkedHover: {
+      backgroundColor: checkedHoverBackground,
+      color: checkedHoverColor
+    },
+    checkedActive: {
+      backgroundColor: checkedActiveBackground,
+      color: checkedActiveColor
+    },
+    checkedDisabled: {}
+  })
+}
 
 /**
  * Get the className of a `Switch`.
  * @param {string} appearance
+ * @param {object} theme - the current theme object
  * @return {Object} the appearance object.
  */
-const getSwitchAppearance = () => {
-  return defaultAppearance
+const getSwitchAppearance = theme => {
+  return getDefaultAppearance(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getTabClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTabClassName.js
@@ -1,36 +1,52 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
 import scales from '../foundational-styles/scales'
-import { defaultControlStyles } from '../shared'
+import { getDefaultControlStyles } from '../shared'
+import tabColors from './tabColors'
 
-/**
- * Disabled styles are all the same.
- */
-const { disabled } = defaultControlStyles
+const getDefaultAppearance = theme => {
+  const defaultControlStyles = getDefaultControlStyles(theme)
+  /**
+   * Disabled styles are all the same.
+   */
+  const { disabled } = defaultControlStyles
 
-const defaultAppearance = Themer.createTabAppearance({
-  base: {},
-  hover: {
-    backgroundColor: scales.neutral.N2A
-  },
-  focus: {
-    boxShadow: `0 0 0 2px ${scales.blue.B5A}`
-  },
-  active: {
-    backgroundColor: scales.blue.B3A,
-    color: scales.blue.B9
-  },
-  disabled,
-  current: {}
-})
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+
+  const focusShadow =
+    theme?.tabColors?.focus?.shadowColor || tabColors.focus.shadowColor
+
+  const activeBackground =
+    theme?.tabColors?.active?.backgroundColor ||
+    tabColors.active.backgroundColor
+
+  const activeColor = theme?.tabColors?.active?.color || tabColors.active.color
+
+  return Themer.createTabAppearance({
+    base: {},
+    hover: {
+      backgroundColor: N2A
+    },
+    focus: {
+      boxShadow: `0 0 0 2px ${focusShadow}`
+    },
+    active: {
+      backgroundColor: activeBackground,
+      color: activeColor
+    },
+    disabled,
+    current: {}
+  })
+}
 
 /**
  * Get the appearance of a `Tab`.
  * @param {string} appearance
+ * @param {object} theme - the theme object
  * @return {string} the appearance object.
  */
-const getTabAppearance = () => {
-  return defaultAppearance
+const getTabAppearance = theme => {
+  return getDefaultAppearance(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getTableCellClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTableCellClassName.js
@@ -1,24 +1,35 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
-import scales from '../foundational-styles/scales'
+import tableColors from './tableColors'
 
 const Appearances = {}
 
-Appearances.default = Themer.createTableCellAppearance({
-  focus: {
-    outline: 'none',
-    backgroundColor: scales.blue.B2A,
-    boxShadow: `inset 0 0 0 1px ${scales.blue.B7A}`
-  }
-})
+Appearances.default = theme => {
+  const cellFocusBg =
+    theme?.tableColors?.cell?.focus?.backgroundColor ||
+    tableColors.cell.focus.backgroundColor
+
+  const cellFocusShadow =
+    theme?.tableColors?.cell?.focus?.shadowColor ||
+    tableColors.cell.focus.shadowColor
+
+  return Themer.createTableCellAppearance({
+    focus: {
+      outline: 'none',
+      backgroundColor: cellFocusBg,
+      boxShadow: `inset 0 0 0 1px ${cellFocusShadow}`
+    }
+  })
+}
 
 /**
  * Get the appearance of a `TableCell`.
  * @param {string} appearance
+ * @param {object} theme - the current theme
  * @return {string} the appearance object.
  */
-const getAppearance = () => {
-  return Appearances.default
+const getAppearance = theme => {
+  return Appearances.default(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getTagInputClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTagInputClassName.js
@@ -1,40 +1,58 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
 import scales from '../foundational-styles/scales'
-import palette from '../foundational-styles/palette'
+import defaultControlColors from './defaultControlColors'
+import tagInputColors from './tagInputColors'
 
 const TagInputAppearances = {}
 
-TagInputAppearances.default = Themer.createTagInputAppearance({
-  base: {
-    backgroundColor: 'white',
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N5A}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  focus: {
-    boxShadow: `inset 0 0 2px ${scales.neutral.N4A}, inset 0 0 0 1px ${
-      scales.blue.B7
-    }, 0 0 0 3px ${scales.blue.B4A}`
-  },
-  disabled: {
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2
-  }
-})
+TagInputAppearances.default = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+
+  const baseBg =
+    theme?.tagInputColors?.base?.backgroundColor ||
+    tagInputColors.base.backgroundColor
+
+  const invalidShadow =
+    theme?.defaultControlColors?.invalid?.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  const focusFirstShadow =
+    theme?.tagInputColors?.focus?.shadowColor1 ||
+    tagInputColors.focus.shadowColor1
+
+  const focusSecondShadow =
+    theme?.tagInputColors?.focus?.shadowColor2 ||
+    tagInputColors.focus.shadowColor2
+
+  return Themer.createTagInputAppearance({
+    base: {
+      backgroundColor: baseBg,
+      boxShadow: `inset 0 0 0 1px ${N5A}, inset 0 1px 2px ${N4A}`
+    },
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidShadow}, inset 0 1px 2px ${N4A}`
+    },
+    focus: {
+      boxShadow: `inset 0 0 2px ${N4A}, inset 0 0 0 1px ${focusFirstShadow}, 0 0 0 3px ${focusSecondShadow}`
+    },
+    disabled: {
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2
+    }
+  })
+}
 
 /**
  * Get the appearance of a `TagInput`.
  * @param {string} appearance - the appearance name
+ * @param {Object} theme - the current theme object
  * @return {Object} the appearance object.
  */
-const getTextInputAppearance = () => {
-  return TagInputAppearances.default
+const getTextInputAppearance = theme => {
+  return TagInputAppearances.default(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getTextDropdownButtonClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTextDropdownButtonClassName.js
@@ -1,26 +1,33 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
-import scales from '../foundational-styles/scales'
+import textDropdownColors from './textDropdownColors'
 
-const defaultAppearance = Themer.createTextDropdownButtonAppearance({
-  base: {
-    borderRadius: 3
-  },
-  hover: {},
-  focus: {
-    boxShadow: `0 0 0 3px ${scales.blue.B5A}`
-  },
-  active: {},
-  disabled: {
-    opacity: 0.5
-  }
-})
+const getDefaultAppearance = theme => {
+  const focusShadow =
+    theme?.textDropdownColors?.default?.focus?.shadowColor ||
+    textDropdownColors.default.focus.shadowColor
+
+  return Themer.createTextDropdownButtonAppearance({
+    base: {
+      borderRadius: 3
+    },
+    hover: {},
+    focus: {
+      boxShadow: `0 0 0 3px ${focusShadow}`
+    },
+    active: {},
+    disabled: {
+      opacity: 0.5
+    }
+  })
+}
 
 /**
  * Get the appearance of a `TextDropdownButton`.
+ * @param {object} theme the current theme object
  */
-const getTextDropdownButtonAppearance = () => {
-  return defaultAppearance
+const getTextDropdownButtonAppearance = theme => {
+  return getDefaultAppearance(theme)
 }
 
 /**

--- a/src/theme/src/default-theme/component-specific/getTextInputClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTextInputClassName.js
@@ -1,87 +1,130 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
 import scales from '../foundational-styles/scales'
-import palette from '../foundational-styles/palette'
+import textInputColors from './textInputColors'
+import defaultControlColors from './defaultControlColors'
 
 const InputAppearances = {}
 
-InputAppearances.default = Themer.createInputAppearance({
-  base: {
-    backgroundColor: 'white',
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N5A}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  placeholder: {
-    color: scales.neutral.N6A
-  },
-  focus: {
-    outline: 'none',
-    boxShadow: `inset 0 0 2px ${scales.neutral.N4A}, inset 0 0 0 1px ${
-      scales.blue.B7
-    }, 0 0 0 3px ${scales.blue.B4A}`
-  },
-  disabled: {
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2
-  }
-})
+InputAppearances.default = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
 
-InputAppearances.neutral = Themer.createInputAppearance({
-  base: {
-    backgroundColor: scales.neutral.N2A
-  },
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}`
-  },
-  placeholder: {
-    color: scales.neutral.N6A
-  },
-  focus: {
-    outline: 'none',
-    backgroundColor: 'white',
-    boxShadow: `0 0 0 2px ${scales.blue.B6A}`
-  },
-  disabled: {
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2
-  }
-})
+  const baseBg =
+    theme?.textInputColors?.default?.base?.backgroundColor ||
+    textInputColors.default.base.backgroundColor
 
-InputAppearances.none = Themer.createInputAppearance({
-  base: {
-    backgroundColor: 'white'
-  },
-  invalid: {},
-  placeholder: {
-    color: scales.neutral.N6A
-  },
-  focus: {
-    outline: 'none'
-  },
-  disabled: {
-    backgroundColor: scales.neutral.N2
-  }
-})
+  const invalidShadow =
+    theme?.defaultControlColors?.invalid?.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  const focusFirstShadow =
+    theme?.textInputColors?.default?.focus?.shadowColor1 ||
+    textInputColors.default.focus.shadowColor1
+
+  const focusSecondShadow =
+    theme?.textInputColors?.default?.focus?.shadowColor2 ||
+    textInputColors.default.focus.shadowColor2
+
+  return Themer.createInputAppearance({
+    base: {
+      backgroundColor: baseBg,
+      boxShadow: `inset 0 0 0 1px ${N5A}, inset 0 1px 2px ${N4A}`
+    },
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidShadow}, inset 0 1px 2px ${N4A}`
+    },
+    placeholder: {
+      color: N6A
+    },
+    focus: {
+      outline: 'none',
+      boxShadow: `inset 0 0 2px ${N4A}, inset 0 0 0 1px ${focusFirstShadow}, 0 0 0 3px ${focusSecondShadow}`
+    },
+    disabled: {
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2
+    }
+  })
+}
+
+InputAppearances.neutral = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
+
+  const invalidShadow =
+    theme?.defaultControlColors?.invalid?.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  const focusShadow =
+    theme?.textInputColors?.neutral?.focus?.shadowColor ||
+    textInputColors.neutral.focus.shadowColor
+
+  return Themer.createInputAppearance({
+    base: {
+      backgroundColor: N2A
+    },
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidShadow}`
+    },
+    placeholder: {
+      color: N6A
+    },
+    focus: {
+      outline: 'none',
+      backgroundColor: 'white',
+      boxShadow: `0 0 0 2px ${focusShadow}`
+    },
+    disabled: {
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2
+    }
+  })
+}
+
+InputAppearances.none = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
+
+  const baseBg =
+    theme?.textInputColors?.none?.base?.backgroundColor ||
+    textInputColors.none.base.backgroundColor
+
+  return Themer.createInputAppearance({
+    base: {
+      backgroundColor: baseBg
+    },
+    invalid: {},
+    placeholder: {
+      color: N6A
+    },
+    focus: {
+      outline: 'none'
+    },
+    disabled: {
+      backgroundColor: N2
+    }
+  })
+}
 
 /**
  * Get the appearance of a `TextInput`.
  * @param {string} appearance - the appearance name
+ * @param {Object} theme the current theme object
  * @return {Object} the appearance object.
  */
-const getTextInputAppearance = appearance => {
+const getTextInputAppearance = (appearance, theme) => {
   switch (appearance) {
     case 'neutral':
-      return InputAppearances.neutral
+      return InputAppearances.neutral(theme)
     case 'none':
-      return InputAppearances.none
+      return InputAppearances.none(theme)
     default:
-      return InputAppearances.default
+      return InputAppearances.default(theme)
   }
 }
 

--- a/src/theme/src/default-theme/component-specific/getTextareaClassName.js
+++ b/src/theme/src/default-theme/component-specific/getTextareaClassName.js
@@ -1,92 +1,141 @@
 import { Themer } from '../../../../themer'
 import memoizeClassName from '../utils/memoizeClassName'
 import scales from '../foundational-styles/scales'
-import palette from '../foundational-styles/palette'
+import defaultControlColors from './defaultControlColors'
+import textareaColors from './textareaColors'
 
 const Appearances = {}
 
-Appearances.default = Themer.createInputAppearance({
-  base: {
-    backgroundColor: 'white',
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N5A}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}, inset 0 1px 2px ${
-      scales.neutral.N4A
-    }`
-  },
-  placeholder: {
-    color: scales.neutral.N6A
-  },
-  focus: {
-    outline: 'none',
-    boxShadow: `inset 0 0 2px ${scales.neutral.N4A}, inset 0 0 0 1px ${
-      scales.blue.B7
-    }, 0 0 0 3px ${scales.blue.B4A}`
-  },
-  disabled: {
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2
-  }
-})
+Appearances.default = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
 
-Appearances.neutral = Themer.createInputAppearance({
-  base: {
-    backgroundColor: scales.neutral.N2A
-  },
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}`
-  },
-  placeholder: {
-    color: scales.neutral.N6A
-  },
-  focus: {
-    outline: 'none',
-    backgroundColor: 'white',
-    boxShadow: `0 0 0 2px ${scales.blue.B6A}`
-  },
-  disabled: {
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2
-  }
-})
+  const baseBg =
+    theme?.textareaColors?.default?.base?.backgroundColor ||
+    textareaColors.default.base.backgroundColor
 
-Appearances.editableCell = Themer.createInputAppearance({
-  base: {
-    backgroundColor: scales.neutral.N2A
-  },
-  invalid: {
-    boxShadow: `inset 0 0 0 1px ${palette.red.base}`
-  },
-  placeholder: {
-    color: scales.neutral.N6A
-  },
-  focus: {
-    outline: 'none',
-    backgroundColor: 'white',
-    boxShadow: `0 0 0 2px ${scales.blue.B7}`
-  },
-  disabled: {
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}`,
-    backgroundColor: scales.neutral.N2
-  }
-})
+  const invalidShadow =
+    theme?.defaultControlColors?.invalid?.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  const focusFirstShadow =
+    theme?.textareaColors?.default?.focus?.shadowColor1 ||
+    textareaColors.default.focus.shadowColor1
+
+  const focusSecondShadow =
+    theme?.textareaColors?.default?.focus?.shadowColor2 ||
+    textareaColors.default.focus.shadowColor2
+
+  return Themer.createInputAppearance({
+    base: {
+      backgroundColor: baseBg,
+      boxShadow: `inset 0 0 0 1px ${N5A}, inset 0 1px 2px ${N4A}`
+    },
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidShadow}, inset 0 1px 2px ${N4A}`
+    },
+    placeholder: {
+      color: N6A
+    },
+    focus: {
+      outline: 'none',
+      boxShadow: `inset 0 0 2px ${N4A}, inset 0 0 0 1px ${focusFirstShadow}, 0 0 0 3px ${focusSecondShadow}`
+    },
+    disabled: {
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2
+    }
+  })
+}
+
+Appearances.neutral = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
+
+  const invalidShadow =
+    theme?.defaultControlColors?.invalid?.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  const focusShadow =
+    theme?.textareaColors?.neutral?.focus?.shadowColor ||
+    textareaColors.neutral.focus.shadowColor
+
+  return Themer.createInputAppearance({
+    base: {
+      backgroundColor: N2A
+    },
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidShadow}`
+    },
+    placeholder: {
+      color: N6A
+    },
+    focus: {
+      outline: 'none',
+      backgroundColor: 'white',
+      boxShadow: `0 0 0 2px ${focusShadow}`
+    },
+    disabled: {
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2
+    }
+  })
+}
+
+Appearances.editableCell = theme => {
+  const N2 = theme?.scales?.neutral?.N2 || scales.neutral.N2
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N6A = theme?.scales?.neutral?.N6A || scales.neutral.N6A
+
+  const invalidShadow =
+    theme?.defaultControlColors?.invalid?.shadowColor ||
+    defaultControlColors.invalid.shadowColor
+
+  const focusShadow =
+    theme?.textareaColors?.editableCell?.focus?.shadowColor ||
+    textareaColors.editableCell.focus.shadowColor
+
+  return Themer.createInputAppearance({
+    base: {
+      backgroundColor: N2A
+    },
+    invalid: {
+      boxShadow: `inset 0 0 0 1px ${invalidShadow}`
+    },
+    placeholder: {
+      color: N6A
+    },
+    focus: {
+      outline: 'none',
+      backgroundColor: 'white',
+      boxShadow: `0 0 0 2px ${focusShadow}`
+    },
+    disabled: {
+      boxShadow: `inset 0 0 0 1px ${N4A}`,
+      backgroundColor: N2
+    }
+  })
+}
 
 /**
  * Get the appearance of a `TextInput`.
  * @param {string} appearance
+ * @param {Object} theme the current theme
  * @return {Object} the appearance object.
  */
-const getTextareaAppearance = appearance => {
+const getTextareaAppearance = (appearance, theme) => {
   switch (appearance) {
     case 'neutral':
-      return Appearances.neutral
+      return Appearances.neutral(theme)
     case 'editable-cell':
-      return Appearances.editableCell
+      return Appearances.editableCell(theme)
     default:
-      return Appearances.default
+      return Appearances.default(theme)
   }
 }
 

--- a/src/theme/src/default-theme/component-specific/getTooltipProps.js
+++ b/src/theme/src/default-theme/component-specific/getTooltipProps.js
@@ -1,7 +1,9 @@
 import tinycolor from 'tinycolor2'
 import palette from '../foundational-styles/palette'
 
-const getTooltipProps = appearance => {
+const getTooltipProps = (appearance, theme) => {
+  const neutralBase = theme?.palette?.neutral?.base || palette.neutral.base
+
   switch (appearance) {
     case 'card':
       return {
@@ -12,7 +14,7 @@ const getTooltipProps = appearance => {
     default:
       return {
         color: 'white',
-        backgroundColor: tinycolor(palette.neutral.base)
+        backgroundColor: tinycolor(neutralBase)
           .setAlpha(0.95)
           .toString()
       }

--- a/src/theme/src/default-theme/component-specific/index.js
+++ b/src/theme/src/default-theme/component-specific/index.js
@@ -2,7 +2,19 @@
 export { default as overlayBackgroundColor } from './overlayBackgroundColor'
 export { default as avatarColors } from './avatarColors'
 export { default as badgeColors } from './badgeColors'
+export { default as buttonColors } from './buttonColors'
+export { default as checkboxColors } from './checkboxColors'
+export { default as codeColors } from './codeColors'
+export { default as defaultControlColors } from './defaultControlColors'
+export { default as rowColors } from './rowColors'
 export { default as spinnerColor } from './spinnerColor'
+export { default as switchColors } from './switchColors'
+export { default as tabColors } from './tabColors'
+export { default as tableColors } from './tableColors'
+export { default as tagInputColors } from './tagInputColors'
+export { default as textareaColors } from './textareaColors'
+export { default as textDropdownColors } from './textDropdownColors'
+export { default as textInputColors } from './textInputColors'
 
 // Class Name Getters.
 export { default as getBadgeClassName } from './getBadgeClassName'
@@ -13,19 +25,18 @@ export { default as getRadioClassName } from './getRadioClassName'
 export { default as getTagInputClassName } from './getTagInputClassName'
 export { default as getTextInputClassName } from './getTextInputClassName'
 export { default as getTextareaClassName } from './getTextareaClassName'
-export {
-  default as getTextDropdownButtonClassName
-} from './getTextDropdownButtonClassName'
+export { default as getTextDropdownButtonClassName } from './getTextDropdownButtonClassName'
 export { default as getTabClassName } from './getTabClassName'
 export { default as getRowClassName } from './getRowClassName'
 export { default as getMenuItemClassName } from './getMenuItemClassName'
 export { default as getSelectClassName } from './getSelectClassName'
 export { default as getTooltipProps } from './getTooltipProps'
-export {
-  default as getSegmentedControlRadioClassName
-} from './getSegmentedControlRadioClassName'
+export { default as getSegmentedControlRadioClassName } from './getSegmentedControlRadioClassName'
 export { default as getSwitchClassName } from './getSwitchClassName'
 export { default as getTableCellClassName } from './getTableCellClassName'
+
+// Component Resolvers.
+export { default as getIcon } from './getIcon'
 
 // Props Getters.
 export { default as getAlertProps } from './getAlertProps'
@@ -34,6 +45,4 @@ export { default as getAvatarProps } from './getAvatarProps'
 export { default as getBadgeProps } from './getBadgeProps'
 
 // Single Prop Getters.
-export {
-  default as getAvatarInitialsFontSize
-} from './getAvatarInitialsFontSize'
+export { default as getAvatarInitialsFontSize } from './getAvatarInitialsFontSize'

--- a/src/theme/src/default-theme/component-specific/rowColors.js
+++ b/src/theme/src/default-theme/component-specific/rowColors.js
@@ -1,0 +1,15 @@
+import scales from '../foundational-styles/scales'
+import palette from '../foundational-styles/palette'
+
+export default {
+  default: {
+    base: 'white',
+    none: 'white',
+    hover: scales.neutral.N1A,
+    focus: scales.blue.B1A,
+    active: scales.blue.B2A,
+    danger: palette.red.lightest,
+    warning: palette.orange.lightest,
+    success: palette.green.lightest
+  }
+}

--- a/src/theme/src/default-theme/component-specific/switchColors.js
+++ b/src/theme/src/default-theme/component-specific/switchColors.js
@@ -1,0 +1,19 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  focus: {
+    shadowColor: scales.blue.B6A
+  },
+  checked: {
+    backgroundColor: scales.blue.B8,
+    color: 'white'
+  },
+  checkedHover: {
+    backgroundColor: scales.blue.B8,
+    color: 'white'
+  },
+  checkedActive: {
+    backgroundColor: scales.blue.B9,
+    color: 'white'
+  }
+}

--- a/src/theme/src/default-theme/component-specific/tabColors.js
+++ b/src/theme/src/default-theme/component-specific/tabColors.js
@@ -1,0 +1,11 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  focus: {
+    shadowColor: scales.blue.B5A
+  },
+  active: {
+    backgroundColor: scales.blue.B3A,
+    color: scales.blue.B9
+  }
+}

--- a/src/theme/src/default-theme/component-specific/tableColors.js
+++ b/src/theme/src/default-theme/component-specific/tableColors.js
@@ -1,0 +1,10 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  cell: {
+    focus: {
+      backgroundColor: scales.blue.B2A,
+      shadowColor: scales.blue.B7A
+    }
+  }
+}

--- a/src/theme/src/default-theme/component-specific/tagInputColors.js
+++ b/src/theme/src/default-theme/component-specific/tagInputColors.js
@@ -1,0 +1,12 @@
+import scales from '../foundational-styles/scales'
+
+// The tag input has different coloring than other controls
+export default {
+  base: {
+    backgroundColor: 'white'
+  },
+  focus: {
+    shadowColor1: scales.blue.B7,
+    shadowColor2: scales.blue.B4A
+  }
+}

--- a/src/theme/src/default-theme/component-specific/textDropdownColors.js
+++ b/src/theme/src/default-theme/component-specific/textDropdownColors.js
@@ -1,0 +1,9 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  default: {
+    focus: {
+      shadowColor: scales.blue.B5A
+    }
+  }
+}

--- a/src/theme/src/default-theme/component-specific/textInputColors.js
+++ b/src/theme/src/default-theme/component-specific/textInputColors.js
@@ -1,0 +1,23 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  none: {
+    base: {
+      backgroundColor: 'white'
+    }
+  },
+  default: {
+    base: {
+      backgroundColor: 'white'
+    },
+    focus: {
+      shadowColor1: scales.blue.B7,
+      shadowColor2: scales.blue.B4A
+    }
+  },
+  neutral: {
+    focus: {
+      shadowColor: scales.blue.B6A
+    }
+  }
+}

--- a/src/theme/src/default-theme/component-specific/textareaColors.js
+++ b/src/theme/src/default-theme/component-specific/textareaColors.js
@@ -1,0 +1,23 @@
+import scales from '../foundational-styles/scales'
+
+export default {
+  default: {
+    base: {
+      backgroundColor: 'white'
+    },
+    focus: {
+      shadowColor1: scales.blue.B7,
+      shadowColor2: scales.blue.B4A
+    }
+  },
+  neutral: {
+    focus: {
+      shadowColor: scales.blue.B6A
+    }
+  },
+  editableCell: {
+    focus: {
+      shadowColor: scales.blue.B7
+    }
+  }
+}

--- a/src/theme/src/default-theme/helpers.js
+++ b/src/theme/src/default-theme/helpers.js
@@ -1,6 +1,7 @@
 import tinycolor from 'tinycolor2'
 import { Intent } from '../../../constants'
 import colors from './foundational-styles/colors'
+import buttonColors from './component-specific/buttonColors'
 
 /**
  * @param {String} top - color.
@@ -13,18 +14,20 @@ const linearGradient = (top, bottom) => {
 
 /**
  * @param {Intent} intent
+ * @param {String} defaultColor
+ * @param {Object} theme
  * @return {String} color
  */
-const getTextColorForIntent = (intent, defaultColor) => {
+const getTextColorForIntent = (intent, defaultColor, theme) => {
   switch (intent) {
     case Intent.SUCCESS:
-      return colors.text.success
+      return theme?.colors?.text?.success || colors.text.success
     case Intent.DANGER:
-      return colors.text.danger
+      return theme?.colors?.text?.danger || colors.text.danger
     case Intent.WARNING:
-      return colors.text.warning
+      return theme?.colors?.text?.warning || colors.text.warning
     default:
-      return defaultColor || colors.text.default
+      return defaultColor || theme?.colors?.text?.default || colors.text.default
   }
 }
 
@@ -64,11 +67,15 @@ const getLinearGradientWithStates = (
  * @param {Intent} intent - intent of the gradient.
  * @return {Object} { base, hover, active }
  */
-const getPrimaryButtonStylesForIntent = intent => {
+const getPrimaryButtonStylesForIntent = (intent, theme) => {
   switch (intent) {
     case Intent.SUCCESS: {
-      const startColor = '#23C277'
-      const endColor = '#399D6C'
+      const startColor =
+        theme?.buttonColors?.primary?.success?.gradientStart ||
+        buttonColors.primary.success.gradientStart
+      const endColor =
+        theme?.buttonColors?.primary?.success?.gradientEnd ||
+        buttonColors.primary.success.gradientEnd
       return {
         linearGradient: getLinearGradientWithStates(startColor, endColor),
         focusColor: tinycolor(startColor)
@@ -78,8 +85,12 @@ const getPrimaryButtonStylesForIntent = intent => {
     }
 
     case Intent.WARNING: {
-      const startColor = '#EE9913'
-      const endColor = '#D9822B'
+      const startColor =
+        theme?.buttonColors?.primary?.warning?.gradientStart ||
+        buttonColors.primary.warning.gradientStart
+      const endColor =
+        theme?.buttonColors?.primary?.warning?.gradientEnd ||
+        buttonColors.primary.warning.gradientEnd
       return {
         linearGradient: getLinearGradientWithStates(startColor, endColor),
         focusColor: tinycolor(startColor)
@@ -89,8 +100,12 @@ const getPrimaryButtonStylesForIntent = intent => {
     }
 
     case Intent.DANGER: {
-      const startColor = '#EC4C47'
-      const endColor = '#D64540'
+      const startColor =
+        theme?.buttonColors?.primary?.danger?.gradientStart ||
+        buttonColors.primary.danger.gradientStart
+      const endColor =
+        theme?.buttonColors?.primary?.danger?.gradientEnd ||
+        buttonColors.primary.danger.gradientEnd
       return {
         linearGradient: getLinearGradientWithStates(startColor, endColor),
         focusColor: tinycolor(startColor)
@@ -100,8 +115,12 @@ const getPrimaryButtonStylesForIntent = intent => {
     }
 
     default: {
-      const startColor = '#0788DE'
-      const endColor = '#116AB8'
+      const startColor =
+        theme?.buttonColors?.primary?.default?.gradientStart ||
+        buttonColors.primary.default.gradientStart
+      const endColor =
+        theme?.buttonColors?.primary?.default?.gradientEnd ||
+        buttonColors.primary.default.gradientEnd
       return {
         linearGradient: getLinearGradientWithStates(startColor, endColor),
         focusColor: tinycolor(startColor)

--- a/src/theme/src/default-theme/index.js
+++ b/src/theme/src/default-theme/index.js
@@ -2,7 +2,7 @@
  * Theme
  * ---
  * The theme object is used to style Evergreen.
- * It is passed into the  `<ThemeProvider theme={theme} />`.
+ * It is passed into the  `<ThemeProvider value={theme} />`.
  * ----
  * You can use this as a template for your own themes.
  */
@@ -37,10 +37,23 @@ import { headings, text, fontFamilies, paragraph } from './typography'
 import {
   avatarColors,
   badgeColors,
+  buttonColors,
+  checkboxColors,
+  codeColors,
+  defaultControlColors,
+  rowColors,
   spinnerColor,
+  switchColors,
+  tabColors,
+  tableColors,
+  tagInputColors,
+  textareaColors,
+  textDropdownColors,
+  textInputColors,
   overlayBackgroundColor,
   getBadgeClassName,
   getButtonClassName,
+  getIcon,
   getLinkClassName,
   getCheckboxClassName,
   getRadioClassName,
@@ -86,7 +99,9 @@ import {
   getTextColor
 } from './theme-helpers'
 
-export default {
+import extend from './utils/extend'
+
+const defaultTheme = {
   // Foundational Styles.
   colors,
   elevations,
@@ -97,10 +112,23 @@ export default {
   // Component Specific.
   avatarColors,
   badgeColors,
+  buttonColors,
+  checkboxColors,
+  codeColors,
+  defaultControlColors,
+  rowColors,
   spinnerColor,
+  switchColors,
+  tabColors,
+  tableColors,
+  tagInputColors,
+  textareaColors,
+  textDropdownColors,
+  textInputColors,
   overlayBackgroundColor,
   getBadgeClassName,
   getButtonClassName,
+  getIcon,
   getLinkClassName,
   getCheckboxClassName,
   getRadioClassName,
@@ -146,3 +174,7 @@ export default {
     paragraph
   }
 }
+
+defaultTheme.extend = () => extend(defaultTheme)
+
+export default defaultTheme

--- a/src/theme/src/default-theme/shared.js
+++ b/src/theme/src/default-theme/shared.js
@@ -1,45 +1,64 @@
 import { linearGradient } from './helpers'
+import defaultControlColors from './component-specific/defaultControlColors'
 import scales from './foundational-styles/scales'
 
-const defaultControlStyles = {
-  disabled: {
-    opacity: 0.8,
-    backgroundImage: 'none',
-    backgroundColor: scales.neutral.N2A,
-    boxShadow: 'none',
-    color: scales.neutral.N7A,
-    pointerEvents: 'none'
-  },
-  base: {
-    backgroundColor: 'white',
-    backgroundImage: linearGradient('#FFFFFF', '#F4F5F7'),
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}, inset 0 -1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  },
-  hover: {
-    backgroundImage: linearGradient('#FAFBFB', '#EAECEE')
-  },
-  focus: {
-    boxShadow: `0 0 0 3px ${scales.blue.B4A}, inset 0 0 0 1px ${
-      scales.neutral.N5A
-    }, inset 0 -1px 1px 0 ${scales.neutral.N4A}`
-  },
-  active: {
-    backgroundImage: 'none',
-    backgroundColor: scales.blue.B3A,
-    boxShadow: `inset 0 0 0 1px ${scales.neutral.N4A}, inset 0 1px 1px 0 ${
-      scales.neutral.N2A
-    }`
-  },
-  focusAndActive: {
-    boxShadow: `0 0 0 3px ${scales.blue.B4A}, inset 0 0 0 1px ${
-      scales.neutral.N5A
-    }, inset 0 1px 1px 0 ${scales.neutral.N2A}`
+const getDefaultControlStyles = theme => {
+  const N2A = theme?.scales?.neutral?.N2A || scales.neutral.N2A
+  const N4A = theme?.scales?.neutral?.N4A || scales.neutral.N4A
+  const N5A = theme?.scales?.neutral?.N5A || scales.neutral.N5A
+  const N7A = theme?.scales?.neutral?.N7A || scales.neutral.N7A
+
+  return {
+    disabled: {
+      opacity: 0.8,
+      backgroundImage: 'none',
+      backgroundColor: N2A,
+      boxShadow: 'none',
+      color: N7A,
+      pointerEvents: 'none'
+    },
+    base: {
+      backgroundColor:
+        theme?.defaultControlColors?.base?.backgroundColor ||
+        defaultControlColors.base.backgroundColor,
+      backgroundImage: linearGradient(
+        theme?.defaultControlColors?.base?.gradientStart ||
+          defaultControlColors.base.gradientEnd,
+        theme?.defaultControlColors?.base?.gradientEnd ||
+          defaultControlColors.base.gradientEnd
+      ),
+      boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 -1px 1px 0 ${N2A}`
+    },
+    hover: {
+      backgroundImage: linearGradient(
+        theme?.defaultControlColors?.hover?.gradientStart ||
+          defaultControlColors.hover.gradientStart,
+        theme?.defaultControlColors?.hover?.gradientEnd ||
+          defaultControlColors.hover.gradientEnd
+      )
+    },
+    focus: {
+      boxShadow: `0 0 0 3px ${theme?.defaultControlColors?.focus?.shadowColor ||
+        defaultControlColors.focus
+          .shadowColor}, inset 0 0 0 1px ${N5A}, inset 0 -1px 1px 0 ${N4A}`
+    },
+    active: {
+      backgroundImage: 'none',
+      backgroundColor:
+        theme?.defaultControlColors?.active?.backgroundColor ||
+        defaultControlColors.active.backgroundColor,
+      boxShadow: `inset 0 0 0 1px ${N4A}, inset 0 1px 1px 0 ${N2A}`
+    },
+    focusAndActive: {
+      boxShadow: `0 0 0 3px ${theme?.defaultControlColors?.focusAndActive
+        ?.shadowColor ||
+        defaultControlColors.focusAndActive
+          .shadowColor}, inset 0 0 0 1px ${N5A}, inset 0 1px 1px 0 ${N2A}`
+    }
   }
 }
 
 // Can't figure out to disable rule for xo linter.
 const ignore = null
 
-export { defaultControlStyles, ignore }
+export { getDefaultControlStyles, ignore }

--- a/src/theme/src/default-theme/theme-helpers/index.js
+++ b/src/theme/src/default-theme/theme-helpers/index.js
@@ -9,9 +9,10 @@ import { fontFamilies, headings, paragraph, text } from '../typography'
  * - IconButton
  * - TextInput
  * @param {number} height
+ * @param {Object} theme - the theme object
  * @return {number} border radius
  */
-const getBorderRadiusForControlHeight = height => {
+const getBorderRadiusForControlHeight = (height, _) => {
   if (height <= 40) return 3
   return 4
 }
@@ -19,9 +20,10 @@ const getBorderRadiusForControlHeight = height => {
 /**
  * Get the text size for a control with a certain height.
  * @param {number} height
+ * @param {Object} theme - the theme object
  * @return {number} text size of the control height.
  */
-const getTextSizeForControlHeight = height => {
+const getTextSizeForControlHeight = (height, _) => {
   if (height <= 24) return 300
   if (height <= 28) return 300
   if (height <= 32) return 300
@@ -33,9 +35,10 @@ const getTextSizeForControlHeight = height => {
 /**
  * Get the size for a icon in a Button with a certain height.
  * @param {number} height
+ * @param {Object} theme - the theme object
  * @return {number} icon size
  */
-const getIconSizeForButton = height => {
+const getIconSizeForButton = (height, _) => {
   if (height <= 28) return 12
   if (height <= 32) return 12
   if (height <= 40) return 16
@@ -50,9 +53,10 @@ const getIconSizeForSelect = getIconSizeForButton
 /**
  * Get the size for a icon in a IconButton with a certain height.
  * @param {number} height
+ * @param {Object} theme - the theme object
  * @return {number} icon size
  */
-const getIconSizeForIconButton = height => {
+const getIconSizeForIconButton = (height, _) => {
   if (height <= 28) return 12
   if (height <= 32) return 14 // Slightly bigger than getIconSizeForButton
   if (height <= 40) return 16
@@ -63,45 +67,56 @@ const getIconSizeForIconButton = height => {
 /**
  * Get background property.
  * @param {string} background
+ * @param {Object} theme - the theme object
  * @return {string} background property.
  */
-const getBackground = background => {
+const getBackground = (background, theme) => {
+  const search =
+    theme && theme.colors && theme.colors && theme.colors.background
+      ? theme.colors.background
+      : colors.background
   /**
    * Return one of theme presets or the original value.
    */
-  return themedProperty(colors.background, background)
+  return themedProperty(search, background)
 }
 
 /**
  * Get box-shadow (elevation).
  * @param {string} level — level of elevation.
+ * @param {Object} theme - the theme object
  * @return {string} elevation box-shadow.
  */
-const getElevation = level => {
+const getElevation = (level, theme) => {
+  const search = theme && theme.elevations ? theme.elevations : elevations
   /**
    * There is no fallback, undefined will be returned.
    */
-  return elevations[level]
+  return search[level]
 }
 
 /**
  * Get the color for an icon.
  * @param {string} color
+ * @param {Object} theme - the theme object
  * @return {string} color of the icon
  */
-const getIconColor = color => {
+const getIconColor = (color, theme) => {
+  const search =
+    theme && theme.colors && theme.colors.icon ? theme.colors.icon : colors.icon
   /**
    * Check if there is a preset in the theme for the icon color.
    */
-  return themedProperty(colors.icon, color)
+  return themedProperty(search, color)
 }
 
 /**
  * Get the properties for an icon based on the intent.
  * @param {Intent} intent
+ * @param {Object} theme - the theme object
  * @return {Object} properties
  */
-const getIconForIntent = intent => {
+const getIconForIntent = (intent, _) => {
   switch (intent) {
     case Intent.SUCCESS:
       return { icon: 'tick-circle', color: 'success' }
@@ -118,10 +133,15 @@ const getIconForIntent = intent => {
 /**
  * Heading styles.
  * @param {number} size - 100–900. 500 is default.
+ * @param {Object} theme - the theme object
  * @return {Object} heading style.
  */
-const getHeadingStyle = size => {
-  return themedProperty(headings, String(size))
+const getHeadingStyle = (size, theme) => {
+  const search =
+    theme && theme.typography && theme.typography.headings
+      ? theme.typography.headings
+      : headings
+  return themedProperty(search, String(size))
 }
 
 /**
@@ -133,44 +153,62 @@ const getHeadingStyle = size => {
  * - ListItem
  * - Label
  * @param {number} size - 300–500. 400 is default.
+ * @param {Object} theme - the theme object
  * @return {Object} text style.
  */
-const getTextStyle = size => {
-  return themedProperty(text, String(size))
+const getTextStyle = (size, theme) => {
+  const search =
+    theme && theme.typography && theme.typography.text
+      ? theme.typography.text
+      : text
+  return themedProperty(search, String(size))
 }
 
 /**
  * Text styles for paragraphs (multi line text).
  * This is used in the Paragraph.
  * @param {number} size - 300–500. 400 is default.
+ * @param {Object} theme - the theme object
  * @return {Object} text style.
  */
-const getParagraphStyle = size => {
-  return themedProperty(paragraph, String(size))
+const getParagraphStyle = (size, theme) => {
+  const search =
+    theme && theme.typography && theme.typography.paragraph
+      ? theme.typography.paragraph
+      : paragraph
+  return themedProperty(search, String(size))
 }
 
 /**
  * Get the font family. This is used to override the font family.
  * @param {string} fontFamily
+ * @param {Object} theme - the theme object
  * @return {string} font family
  */
-const getFontFamily = fontFamily => {
+const getFontFamily = (fontFamily, theme) => {
+  const search =
+    theme && theme.typography && theme.typography.fontFamilies
+      ? theme.typography.fontFamilies
+      : fontFamilies
   /**
    * Allow for passing in a custom fontFamily not in the theme.
    */
-  return themedProperty(fontFamilies, fontFamily)
+  return themedProperty(search, fontFamily)
 }
 
 /**
  * Get the text color. This is used to override the color.
- * @param {string} fontFamily
- * @return {string} font family
+ * @param {string} color
+ * @param {Object} theme - the theme object
+ * @return {string} color
  */
-const getTextColor = color => {
+const getTextColor = (color, theme) => {
+  const search =
+    theme && theme.colors && theme.colors.text ? theme.colors.text : colors.text
   /**
    * Allow for passing in a custom text color not in the theme.
    */
-  return themedProperty(colors.text, color)
+  return themedProperty(search, color)
 }
 
 export {

--- a/src/theme/src/default-theme/utils/extend.js
+++ b/src/theme/src/default-theme/utils/extend.js
@@ -1,0 +1,9 @@
+import cloneDeep from 'lodash.clonedeep'
+
+const extend = theme => {
+  const clone = cloneDeep(theme)
+  clone.extend = () => extend(clone)
+  return clone
+}
+
+export default extend

--- a/src/theme/src/default-theme/utils/memoizeClassName.js
+++ b/src/theme/src/default-theme/utils/memoizeClassName.js
@@ -1,5 +1,18 @@
 import { css } from 'glamor'
 
+let ids = 0
+const idOf = o => {
+  if (typeof o.__evergreen_uniqueid === 'undefined') {
+    Object.defineProperty(o, '__evergreen_uniqueid', {
+      value: ++ids,
+      enumerable: false,
+      writable: false
+    })
+  }
+
+  return o.__evergreen_uniqueid
+}
+
 /**
  * Memoize a function that takes N number of strings as arguments and returns
  * a CSS-in-JS object.
@@ -27,7 +40,9 @@ const memoizeClassName = fn => {
   // Return the wrapped function.
   return (...args) => {
     // Create a key by joining all args.
-    const key = args.join('_') || '__no_args__'
+    const key =
+      args.map(o => (typeof o === 'object' ? idOf(o) : o)).join('_') ||
+      '__no_args__'
 
     // Check if is already memoized, if so return the result.
     if (memo[key]) return memo[key]

--- a/src/theme/stories/index.stories.js
+++ b/src/theme/stories/index.stories.js
@@ -1,0 +1,51 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import Box from 'ui-box'
+
+import { Text } from '../../typography'
+import { Button } from '../../buttons'
+import { Pane } from '../../layers'
+import { ThemeProvider } from '../src/ThemeContext'
+import defaultTheme from '../src/default-theme'
+
+// This theme sets the default text color to pink, and button hovers to purple
+const customTheme = defaultTheme.extend()
+customTheme.colors.text.default = 'pink'
+customTheme.buttonColors.minimal.hoverBackground = 'purple'
+
+// This theme is going to be nested, but changes the minimal text to purple
+const nestedTheme = defaultTheme.extend()
+nestedTheme.buttonColors.minimal.default = 'purple'
+
+// This theme changes icons to output their text value, though you could get any kind of icon
+const getIconVariant = defaultTheme.extend()
+getIconVariant.getIcon = icon => ({ size, ...rest }) => {
+  return (
+    <Pane width={size} height={size} lineHeight="1" {...rest}>
+      {icon}
+    </Pane>
+  )
+}
+
+storiesOf('theme', module).add('custom themes', () => (
+  <>
+    <ThemeProvider value={customTheme}>
+      <Box padding={48}>
+        <Text>Custom default text using defaultTheme.extend()</Text>
+      </Box>
+
+      <Box padding={48}>
+        <Button appearance="minimal">Purple background on hover</Button>
+      </Box>
+
+      <Box padding={48}>
+        <ThemeProvider value={nestedTheme}>
+          <Button appearance="minimal">Purple text, nested theme</Button>
+        </ThemeProvider>
+      </Box>
+    </ThemeProvider>
+    <ThemeProvider value={getIconVariant}>
+      <Button iconBefore="!!!">Custom icon</Button>
+    </ThemeProvider>
+  </>
+))

--- a/src/tooltip/src/TooltipStateless.js
+++ b/src/tooltip/src/TooltipStateless.js
@@ -21,7 +21,7 @@ class TooltipStateless extends PureComponent {
 
   render() {
     const { theme, children, appearance, ...props } = this.props
-    const { color, ...themedProps } = theme.getTooltipProps(appearance)
+    const { color, ...themedProps } = theme.getTooltipProps(appearance, theme)
 
     let child
     if (typeof children === 'string') {

--- a/src/typography/src/Code.js
+++ b/src/typography/src/Code.js
@@ -35,7 +35,7 @@ class Code extends PureComponent {
     const {
       className: themedClassName = '',
       ...themeProps
-    } = theme.getCodeProps(appearance)
+    } = theme.getCodeProps(appearance, theme)
 
     return (
       <Text

--- a/src/typography/src/Heading.js
+++ b/src/typography/src/Heading.js
@@ -40,7 +40,7 @@ class Heading extends PureComponent {
     const {
       marginTop: defaultMarginTop,
       ...headingStyle
-    } = theme.getHeadingStyle(size)
+    } = theme.getHeadingStyle(size, theme)
 
     let finalMarginTop = marginTop
     if (marginTop === 'default') {

--- a/src/typography/src/Link.js
+++ b/src/typography/src/Link.js
@@ -48,7 +48,7 @@ class Link extends PureComponent {
   render() {
     const { theme, className, color, ...props } = this.props
 
-    const themedClassName = theme.getLinkClassName(color)
+    const themedClassName = theme.getLinkClassName(color, theme)
 
     return (
       <Text

--- a/src/typography/src/Paragraph.js
+++ b/src/typography/src/Paragraph.js
@@ -40,7 +40,7 @@ class Paragraph extends PureComponent {
     const {
       marginTop: defaultMarginTop,
       ...textStyle
-    } = theme.getParagraphStyle(size)
+    } = theme.getParagraphStyle(size, theme)
 
     const finalMarginTop =
       marginTop === 'default' ? defaultMarginTop : marginTop
@@ -48,8 +48,8 @@ class Paragraph extends PureComponent {
     return (
       <Box
         is="p"
-        color={theme.getTextColor(color)}
-        fontFamily={theme.getFontFamily(fontFamily)}
+        color={theme.getTextColor(color, theme)}
+        fontFamily={theme.getFontFamily(fontFamily, theme)}
         marginTop={finalMarginTop || 0}
         marginBottom={0}
         {...textStyle}

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -49,7 +49,8 @@ class Text extends PureComponent {
     } = this.props
 
     const { marginTop: defaultMarginTop, ...textStyle } = theme.getTextStyle(
-      size
+      size,
+      theme
     )
 
     const finalMarginTop =
@@ -58,8 +59,8 @@ class Text extends PureComponent {
     return (
       <Box
         is="span"
-        color={theme.getTextColor(color)}
-        fontFamily={theme.getFontFamily(fontFamily)}
+        color={theme.getTextColor(color, theme)}
+        fontFamily={theme.getFontFamily(fontFamily, theme)}
         marginTop={finalMarginTop}
         {...textStyle}
         className={cx(className, css ? glamorCss(css).toString() : undefined)}

--- a/tools/component-stories-template.js
+++ b/tools/component-stories-template.js
@@ -3,13 +3,15 @@
 function storyTemplate(componentName) {
   return `
   .add('${componentName}', () => (
-    <Box padding={40}>
-      {(() => {
-        document.body.style.margin = '0'
-        document.body.style.height = '100vh'
-      })()}
-      <${componentName}>${componentName}</${componentName}>
-    </Box>
+    <ThemeProvider value={defaultTheme}>
+      <Box padding={40}>
+        {(() => {
+          document.body.style.margin = '0'
+          document.body.style.height = '100vh'
+        })()}
+        <${componentName}>${componentName}</${componentName}>
+      </Box>
+    </ThemeProvider>
   ))`
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,10 +37,10 @@
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-"@babel/cli@^7.1.2":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.3.tgz#121beb7c273e0521eb2feeb3883a2b7435d12328"
-  integrity sha512-K2UXPZCKMv7KwWy9Bl4sa6+jTNP7JyDiHKzoOiUUygaEDbC60vaargZDnO9oFMvlq8pIKOOyUUgeMYrsaN9djA==
+"@babel/cli@^7.8.3":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.4.tgz#505fb053721a98777b2b175323ea4f090b7d3c1c"
+  integrity sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==
   dependencies:
     commander "^4.0.1"
     convert-source-map "^1.1.0"
@@ -60,16 +60,16 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
-"@babel/compat-data@^7.8.0", "@babel/compat-data@^7.8.1":
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.1.tgz#fc0bbbb7991e4fb2b47e168e60f2cc2c41680be9"
-  integrity sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==
+"@babel/compat-data@^7.8.4":
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.8.5.tgz#d28ce872778c23551cbb9432fc68d28495b613b9"
+  integrity sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==
   dependencies:
-    browserslist "^4.8.2"
+    browserslist "^4.8.5"
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.2", "@babel/core@^7.4.0":
+"@babel/core@^7.4.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.3.tgz#30b0ebb4dd1585de6923a0b4d179e0b9f5d82941"
   integrity sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==
@@ -90,10 +90,41 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.4.0", "@babel/generator@^7.8.3":
+"@babel/core@^7.8.3":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.4.tgz#d496799e5c12195b3602d0fddd77294e3e38e80e"
+  integrity sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.4"
+    "@babel/helpers" "^7.8.4"
+    "@babel/parser" "^7.8.4"
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
+    "@babel/types" "^7.8.3"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.0.0", "@babel/generator@^7.4.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.3.tgz#0e22c005b0a94c1c74eafe19ef78ce53a4d45c03"
   integrity sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+  dependencies:
+    "@babel/types" "^7.8.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.8.3", "@babel/generator@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.4.tgz#35bbc74486956fe4251829f9f6c48330e8d0985e"
+  integrity sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==
   dependencies:
     "@babel/types" "^7.8.3"
     jsesc "^2.5.1"
@@ -132,15 +163,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-compilation-targets@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz#2deedc816fd41dca7355ef39fd40c9ea69f0719a"
-  integrity sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==
+"@babel/helper-compilation-targets@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz#03d7ecd454b7ebe19a254f76617e61770aed2c88"
+  integrity sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==
   dependencies:
-    "@babel/compat-data" "^7.8.1"
-    browserslist "^4.8.2"
+    "@babel/compat-data" "^7.8.4"
+    browserslist "^4.8.5"
     invariant "^2.2.4"
-    levenary "^1.1.0"
+    levenary "^1.1.1"
     semver "^5.5.0"
 
 "@babel/helper-create-class-features-plugin@^7.8.3":
@@ -294,13 +325,13 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helpers@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.3.tgz#382fbb0382ce7c4ce905945ab9641d688336ce85"
-  integrity sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
+"@babel/helpers@^7.8.3", "@babel/helpers@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
+  integrity sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
   dependencies:
     "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.8.3"
+    "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
 
 "@babel/highlight@^7.8.3":
@@ -312,10 +343,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.3", "@babel/parser@^7.8.3":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
+
+"@babel/parser@^7.8.3", "@babel/parser@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
+  integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.0.0", "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -326,7 +362,7 @@
     "@babel/helper-remap-async-to-generator" "^7.8.3"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@^7.1.0":
+"@babel/plugin-proposal-class-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz#5e06654af5cd04b608915aada9b2a6788004464e"
   integrity sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==
@@ -535,10 +571,10 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-for-of@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz#15f17bce2fc95c7d59a24b299e83e81cedc22e18"
-  integrity sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==
+"@babel/plugin-transform-for-of@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz#6fe8eae5d6875086ee185dd0b098a8513783b47d"
+  integrity sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -623,10 +659,10 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/helper-replace-supers" "^7.8.3"
 
-"@babel/plugin-transform-parameters@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz#7890576a13b17325d8b7d44cb37f21dc3bbdda59"
-  integrity sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==
+"@babel/plugin-transform-parameters@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz#1d5155de0b65db0ccf9971165745d3bb990d77d3"
+  integrity sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==
   dependencies:
     "@babel/helper-call-delegate" "^7.8.3"
     "@babel/helper-get-function-arity" "^7.8.3"
@@ -685,7 +721,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-runtime@^7.1.0":
+"@babel/plugin-transform-runtime@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz#c0153bc0a5375ebc1f1591cb7eea223adea9f169"
   integrity sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==
@@ -725,10 +761,10 @@
     "@babel/helper-annotate-as-pure" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-typeof-symbol@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz#5cffb216fb25c8c64ba6bf5f76ce49d3ab079f4d"
-  integrity sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==
+"@babel/plugin-transform-typeof-symbol@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz#ede4062315ce0aaf8a657a920858f1a2f35fc412"
+  integrity sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -740,13 +776,13 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/preset-env@^7.1.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.3.tgz#dc0fb2938f52bbddd79b3c861a4b3427dd3a6c54"
-  integrity sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==
+"@babel/preset-env@^7.8.3":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.4.tgz#9dac6df5f423015d3d49b6e9e5fa3413e4a72c4e"
+  integrity sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==
   dependencies:
-    "@babel/compat-data" "^7.8.0"
-    "@babel/helper-compilation-targets" "^7.8.3"
+    "@babel/compat-data" "^7.8.4"
+    "@babel/helper-compilation-targets" "^7.8.4"
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-proposal-async-generator-functions" "^7.8.3"
@@ -775,7 +811,7 @@
     "@babel/plugin-transform-dotall-regex" "^7.8.3"
     "@babel/plugin-transform-duplicate-keys" "^7.8.3"
     "@babel/plugin-transform-exponentiation-operator" "^7.8.3"
-    "@babel/plugin-transform-for-of" "^7.8.3"
+    "@babel/plugin-transform-for-of" "^7.8.4"
     "@babel/plugin-transform-function-name" "^7.8.3"
     "@babel/plugin-transform-literals" "^7.8.3"
     "@babel/plugin-transform-member-expression-literals" "^7.8.3"
@@ -786,7 +822,7 @@
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.8.3"
     "@babel/plugin-transform-new-target" "^7.8.3"
     "@babel/plugin-transform-object-super" "^7.8.3"
-    "@babel/plugin-transform-parameters" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.8.4"
     "@babel/plugin-transform-property-literals" "^7.8.3"
     "@babel/plugin-transform-regenerator" "^7.8.3"
     "@babel/plugin-transform-reserved-words" "^7.8.3"
@@ -794,16 +830,16 @@
     "@babel/plugin-transform-spread" "^7.8.3"
     "@babel/plugin-transform-sticky-regex" "^7.8.3"
     "@babel/plugin-transform-template-literals" "^7.8.3"
-    "@babel/plugin-transform-typeof-symbol" "^7.8.3"
+    "@babel/plugin-transform-typeof-symbol" "^7.8.4"
     "@babel/plugin-transform-unicode-regex" "^7.8.3"
     "@babel/types" "^7.8.3"
-    browserslist "^4.8.2"
+    browserslist "^4.8.5"
     core-js-compat "^3.6.2"
     invariant "^2.2.2"
-    levenary "^1.1.0"
+    levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-react@^7.0.0":
+"@babel/preset-react@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.8.3.tgz#23dc63f1b5b0751283e04252e78cf1d6589273d2"
   integrity sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==
@@ -814,7 +850,7 @@
     "@babel/plugin-transform-react-jsx-self" "^7.8.3"
     "@babel/plugin-transform-react-jsx-source" "^7.8.3"
 
-"@babel/register@^7.0.0":
+"@babel/register@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.8.3.tgz#5d5d30cfcc918437535d724b8ac1e4a60c5db1f8"
   integrity sha512-t7UqebaWwo9nXWClIPLPloa5pN33A2leVs8Hf0e9g9YwUP8/H9NeR7DJU+4CXo23QtjChQv5a3DjEtT83ih1rg==
@@ -825,10 +861,17 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
   integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.8.3":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -841,7 +884,7 @@
     "@babel/parser" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.8.3":
+"@babel/traverse@^7.0.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.3.tgz#a826215b011c9b4f73f3a893afbc05151358bf9a"
   integrity sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
@@ -851,6 +894,21 @@
     "@babel/helper-function-name" "^7.8.3"
     "@babel/helper-split-export-declaration" "^7.8.3"
     "@babel/parser" "^7.8.3"
+    "@babel/types" "^7.8.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.4.tgz#f0845822365f9d5b0e312ed3959d3f827f869e3c"
+  integrity sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.8.4"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.8.4"
     "@babel/types" "^7.8.3"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -3323,14 +3381,14 @@ browserslist@^4.0.0:
     electron-to-chromium "^1.3.338"
     node-releases "^1.1.46"
 
-browserslist@^4.8.2, browserslist@^4.8.3:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.4.tgz#b0cf2470ce928ce86b546217f70825577bb01c3a"
-  integrity sha512-3qv/Ar3nRnRTpwGD+LZc7F4YHDBb3NAEIn+DesNa8TcBhyxf8eDqYwTOa70kiWXwvFjQQz+abbykJcyOlfBfNg==
+browserslist@^4.8.3, browserslist@^4.8.5:
+  version "4.8.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
+  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
   dependencies:
-    caniuse-lite "^1.0.30001021"
-    electron-to-chromium "^1.3.338"
-    node-releases "^1.1.46"
+    caniuse-lite "^1.0.30001023"
+    electron-to-chromium "^1.3.341"
+    node-releases "^1.1.47"
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -3545,10 +3603,15 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001022.tgz#a7721c26a4af4d8420680079dcd27754be84daf6"
   integrity sha512-2RQQgO+yDEaqF4ltwrCja7oZst+FVnXHQLSJgZ678tausEljBq3/U20Fedvze+Hxqm8XLV+9OgGbtdgS7ksnRw==
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001021, caniuse-lite@^1.0.30001022:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001022:
   version "1.0.30001022"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz#9eeffe580c3a8f110b7b1742dcf06a395885e4c6"
   integrity sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==
+
+caniuse-lite@^1.0.30001023:
+  version "1.0.30001025"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz#30336a8aca7f98618eb3cf38e35184e13d4e5fe6"
+  integrity sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -3973,9 +4036,9 @@ commander@^2.15.0, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
-  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -4995,10 +5058,15 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.338, electron-to-chromium@^1.3.47:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.338"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.338.tgz#4f33745aed599dfa0fd7b388bf754c164e915168"
   integrity sha512-wlmfixuHEc9CkfOKgcqdtzBmRW4NStM9ptl5oPILY2UDyHuSXb3Yit+yLVyLObTgGuMMU36hhnfs2GDJId7ctA==
+
+electron-to-chromium@^1.3.338, electron-to-chromium@^1.3.341:
+  version "1.3.345"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz#2569d0d54a64ef0f32a4b7e8c80afa5fe57c5d98"
+  integrity sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -8008,10 +8076,10 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levenary@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.0.tgz#fc146fe75f32dc483a0a2c64aef720f602cd6210"
-  integrity sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==
+levenary@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.1.tgz#842a9ee98d2075aa7faeedbe32679e9205f46f77"
+  integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   dependencies:
     leven "^3.1.0"
 
@@ -9061,10 +9129,10 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.46:
-  version "1.1.46"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.46.tgz#6b262afef1bdc9a950a96df2e77e0d2290f484bf"
-  integrity sha512-YOjdx+Uoh9FbRO7yVYbnbt1puRWPQMemR3SutLeyv2XfxKs1ihpe0OLAUwBPEP2ImNH/PZC7SEiC6j32dwRZ7g==
+node-releases@^1.1.46, node-releases@^1.1.47:
+  version "1.1.48"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.48.tgz#7f647f0c453a0495bcd64cbd4778c26035c2f03a"
+  integrity sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==
   dependencies:
     semver "^6.3.0"
 
@@ -11459,7 +11527,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.8.1:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
   integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
@@ -11470,6 +11538,13 @@ resolve@^1.11.0, resolve@^1.11.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.3.2:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
+  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
## Theming Support in Evergreen 🌲
_note: I apologize for the size of this pull request. Getting all of the components updated to support theming beyond the `theme.get___` convention ended up being a lot of work. However, there's no really effective way to change a single intent's color in the theme._

# Problem Statement
I found that it was incredibly difficult to change only small pieces of Evergreen's theme. Specifically, I couldn't update `theme.colors.intent` for a specific project. Everything else about the theme was awesome. The `primary` button just needed to be purple, not blue.

Unfortunately, v5's [create theme branch](https://github.com/segmentio/evergreen/tree/v5-create-theme) was last updated October 2018.

## Summary of Changes/Commits
These changes introduce complete theming to all v4 Evergreen components in a **backwards compatible** manner. We do this by passing the `theme` object into all of our theme helpers. Since this is adding functionality by passing an additional argument, it only results in a bump to **minor**. 🎉

## New Features
* **defaultTheme.extend()** - You can create your own custom theme by importing the defaultTheme from evergreen and calling the new `extend()` method. `extend` will create a copy of the theme using `lodash.deepclone`. The resulting theme can be passed into Evergreen's `ThemeProvider`. If you don't use Evergreen's `ThemeProvider`, Evergreen will fall back to the default styles.

## New Stories
* A new story was created for `theme` which demonstrates the use of a custom theme without affecting the main storybook site.

## Related Issues
* #379 (v5 roadmap) may be impacted by this, but it's more likely that if theming goes a different direction in v5, things would be backwards incompatible anyway
* #542, #179, #470  (custom theme properties) are solved with this approach to theming using `const customTheme = defaultTheme.extend()`
* #688 (remove blueprint) this is a first step. Since icons are not explicitly bound anymore, we can explore making blueprint a peerDependency and throw an error if (A) blueprint is missing and (B) getIcon is unchanged
* #617 (custom icons) are now supported. Obviously most icons not custom-built for evergreen will need some adjustments. I've put an example in a comment further down on `getIcon` usage.

## Todo Tracking
* [x] ~Currently the lodash.deepclone addition puts us at 215.65, which is over the self-imposed bundle limit of 212k. We could go with a shallow copy approach, but that can cause issues if someone uses multiple `ThemeProvider` objects in the React tree. Additional bloat came from needing to create objects for all of our colors in the theme.~ **The size limit was increased to 220kb in this PR**
* [x] ~`Themer` continues to be a challenge. When we're using the neutral scales for shadowing, but `Button` makes use of `scales.blue.*` for minimal buttons and color specific linear gradients. These colors probably need to be moved into the `theme` object as something like `colors.button.minimal`. The same is true for the linear gradients.~ We split all the colors out and attached them to the main `defaultTheme` object.
* [x] ~The memoizer needs to handle objects if they are passed in. This is because many of our theme functions will now receive `theme` as their third parameter. The most efficient way is to keep an ID property attached to the object. While these _should_ only be evergreen objects passed in, better safe than sorry.~ The `__evergreen_uniqueid` property allows us to tell theme objects apart during memoization. An additional story was added to show how evergereen can tell themes apart with multiple theme objects.
* [x] ~Custom icons aren't a great story yet~ Custom icons are supported by overriding `theme.getIcon(icon, theme)`. If not defined we return `DefaultIcon`, which is the regular evergreen icon suite. This doesn't unbundle icons, but it does get people unblocked.

I know this is a huge PR for a first time contributor. I'm happy to make adjustments or talk through anything that seems gnarly. ❤️  We love how much time Evergreen and ui-box has saved us and this felt like a great way to give back.