### PR TITLE
Update theming docs

### DIFF
--- a/docs/src/pages/get-started/theming.mdx
+++ b/docs/src/pages/get-started/theming.mdx
@@ -1,4 +1,3 @@
-import ThemeObjectAttributes from '../../components/ThemeObjectAttributes'
 import ThemeLayout from '../../components/ThemeLayout'
 
 export default ThemeLayout
@@ -8,7 +7,9 @@ export default ThemeLayout
 In order to style your app, you must wrap it in the `ThemeProvider` component.
 This component uses the `React.Context` API under the hood.
 
-In order to use the `ThemeProvider` component, you must pass it a value prop that is a `Theme` object.
+In order to use the `ThemeProvider` component, you must pass it a value prop that is a `Theme` object. 
+
+Please note: at this moment in time, theming isn't fully supported yet! There are certain attributes of the `Theme` object that are required so please be sure you have them when providing a custom theme.
 
 ## Simple theming
 
@@ -127,7 +128,6 @@ const ThemedApp = ({ children }) => (
 )
 
 const MyNewThemedButton = () => {
-  // Requires PR #699 to work
   const theme = useTheme()
 
   return (
@@ -139,9 +139,7 @@ const MyNewThemedButton = () => {
 
 render(
   <ThemedApp>
-    { /* <MyNewThemedButton /> */ }
+    <MyNewThemedButton />
   </ThemedApp>
 )
 ```
-
-<ThemeObjectAttributes />


### PR DESCRIPTION
Adds some updates I wanted to make in the last pr for this.

1. Remove the list of `ThemeObjectAttributes` (for now) I don't know exactly how useful they'd be especially if a `createTheme` function was added. On top of that it was over 100 different attributes and it'd take me a very long time to make it complete :/
2. Since hooks now work in storybook, show the `useTheme` hook working
3. Add a copy saying theme isn't fully supported