### PR TITLE
Migrates Spinner component to hooks

### DIFF
--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -2,7 +2,7 @@ import { css } from 'glamor'
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
 const loadingKeyframes = css.keyframes('loading', {
   '0%': {
@@ -38,7 +38,8 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-const Spinner = ({ delay, theme, size, ...props }) => {
+const Spinner = ({ delay, size, ...props }) => {
+  const theme = useTheme()
   const [isVisible, setIsVisible] = useState(delay === 0)
   const [delayTimer, setDelayTimer] = useState(null)
 
@@ -94,12 +95,7 @@ Spinner.propTypes = {
   /**
    * The size of the spinner.
    */
-  size: PropTypes.number.isRequired,
-
-  /**
-   * Theme provided by ThemeProvider.
-   */
-  theme: PropTypes.object.isRequired
+  size: PropTypes.number.isRequired
 }
 
 Spinner.defaultProps = {
@@ -107,4 +103,4 @@ Spinner.defaultProps = {
   delay: 0
 }
 
-export default withTheme(Spinner)
+export default Spinner

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -2,7 +2,7 @@ import { css } from 'glamor'
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
 const loadingKeyframes = css.keyframes('loading', {
   '0%': {
@@ -38,7 +38,8 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-function Spinner({ delay, size, theme, ...props }) {
+function Spinner({ delay, size, ...props }) {
+  const theme = useTheme()
   const [isVisible, setIsVisible] = useState(delay === 0)
   const [delayTimer, setDelayTimer] = useState(null)
 
@@ -94,12 +95,7 @@ Spinner.propTypes = {
   /**
    * The size of the spinner.
    */
-  size: PropTypes.number.isRequired,
-
-  /**
-   * Theme provided by ThemeProvider.
-   */
-  theme: PropTypes.object.isRequired
+  size: PropTypes.number.isRequired
 }
 
 Spinner.defaultProps = {
@@ -107,4 +103,4 @@ Spinner.defaultProps = {
   delay: 0
 }
 
-export default withTheme(Spinner)
+export default Spinner

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -38,16 +38,12 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-function Spinner({
-  delay = 0,
-  size = 40,
-  ...props
-}, ref) {
+function Spinner({ delay = 0, size = 40, ...props }, ref) {
   const theme = useTheme()
   const [isVisible, setIsVisible] = useState(delay === 0)
 
   useEffect(() => {
-    let delayTimer = null;
+    let delayTimer = null
     if (delay > 0) {
       delayTimer = setTimeout(() => {
         setIsVisible(true)

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -2,7 +2,7 @@ import { css } from 'glamor'
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { useTheme } from '../../theme'
+import { withTheme } from '../../theme'
 
 const loadingKeyframes = css.keyframes('loading', {
   '0%': {
@@ -38,8 +38,7 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-const Spinner = ({ delay, size, ...props }) => {
-  const theme = useTheme()
+const Spinner = ({ delay, size, theme, ...props }) => {
   const [isVisible, setIsVisible] = useState(delay === 0)
   const [delayTimer, setDelayTimer] = useState(null)
 
@@ -95,7 +94,12 @@ Spinner.propTypes = {
   /**
    * The size of the spinner.
    */
-  size: PropTypes.number.isRequired
+  size: PropTypes.number.isRequired,
+
+  /**
+   * Theme provided by ThemeProvider.
+   */
+  theme: PropTypes.object.isRequired
 }
 
 Spinner.defaultProps = {
@@ -103,4 +107,4 @@ Spinner.defaultProps = {
   delay: 0
 }
 
-export default Spinner
+export default withTheme(Spinner)

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -1,5 +1,5 @@
 import { css } from 'glamor'
-import React, { PureComponent } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { withTheme } from '../../theme'
@@ -38,84 +38,73 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-class Spinner extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Box component as the base.
-     */
-    ...Box.propTypes,
+const Spinner = ({ delay, theme, size, ...props }) => {
+  const [isVisible, setIsVisible] = useState(delay === 0)
+  const [delayTimer, setDelayTimer] = useState(null)
 
-    /**
-     * Delay after which spinner should be visible.
-     */
-    delay: PropTypes.number,
-
-    /**
-     * The size of the spinner.
-     */
-    size: PropTypes.number.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    size: 40,
-    delay: 0
-  }
-
-  constructor({ delay }) {
-    super()
-
-    this.state = {
-      isVisible: delay === 0
-    }
-  }
-
-  render() {
-    if (!this.state.isVisible) {
-      return null
-    }
-
-    const { theme, size, ...props } = this.props
-    return (
-      <Box width={size} height={size} lineHeight={0} {...props}>
-        <Box
-          is="svg"
-          className={outerClass}
-          x="0px"
-          y="0px"
-          viewBox="0 0 150 150"
-        >
-          <Box
-            is="circle"
-            className={innerClass(theme.spinnerColor)}
-            cx="75"
-            cy="75"
-            r="60"
-          />
-        </Box>
-      </Box>
-    )
-  }
-
-  componentDidMount() {
-    const { delay } = this.props
-
+  useEffect(() => {
     if (delay > 0) {
-      this.delayTimer = setTimeout(() => {
-        this.setState({
-          isVisible: true
-        })
+      const newDelayTimer = setTimeout(() => {
+        setIsVisible(true)
       }, delay)
+      setDelayTimer(newDelayTimer)
     }
+
+    return function() {
+      clearTimeout(delayTimer)
+    }
+  }, [])
+
+  if (!isVisible) {
+    return null
   }
 
-  componentWillUnmount() {
-    clearTimeout(this.delayTimer)
-  }
+  return (
+    <Box width={size} height={size} lineHeight={0} {...props}>
+      <Box
+        is="svg"
+        className={outerClass}
+        x="0px"
+        y="0px"
+        viewBox="0 0 150 150"
+      >
+        <Box
+          is="circle"
+          className={innerClass(theme.spinnerColor)}
+          cx="75"
+          cy="75"
+          r="60"
+        />
+      </Box>
+    </Box>
+  )
+}
+
+Spinner.propTypes = {
+  /**
+   * Composes the Box component as the base.
+   */
+  ...Box.propTypes,
+
+  /**
+   * Delay after which spinner should be visible.
+   */
+  delay: PropTypes.number,
+
+  /**
+   * The size of the spinner.
+   */
+  size: PropTypes.number.isRequired,
+
+  /**
+   * Theme provided by ThemeProvider.
+   */
+  theme: PropTypes.object.isRequired
+}
+
+Spinner.defaultProps = {
+  size: 40,
+  delay: 0
 }
 
 export default withTheme(Spinner)

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -1,5 +1,5 @@
+import React, { useState, useEffect, forwardRef, memo } from 'react'
 import { css } from 'glamor'
-import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { useTheme } from '../../theme'
@@ -38,17 +38,20 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-function Spinner({ delay, size, ...props }) {
+function Spinner({
+  delay = 0,
+  size = 40,
+  ...props
+}, ref) {
   const theme = useTheme()
   const [isVisible, setIsVisible] = useState(delay === 0)
-  const [delayTimer, setDelayTimer] = useState(null)
 
   useEffect(() => {
+    let delayTimer = null;
     if (delay > 0) {
-      const newDelayTimer = setTimeout(() => {
+      delayTimer = setTimeout(() => {
         setIsVisible(true)
       }, delay)
-      setDelayTimer(newDelayTimer)
     }
 
     return function() {
@@ -61,7 +64,7 @@ function Spinner({ delay, size, ...props }) {
   }
 
   return (
-    <Box width={size} height={size} lineHeight={0} {...props}>
+    <Box width={size} height={size} lineHeight={0} {...props} innerRef={ref}>
       <Box
         is="svg"
         className={outerClass}
@@ -98,9 +101,4 @@ Spinner.propTypes = {
   size: PropTypes.number.isRequired
 }
 
-Spinner.defaultProps = {
-  size: 40,
-  delay: 0
-}
-
-export default Spinner
+export default memo(forwardRef(Spinner))

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -38,47 +38,49 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-function Spinner({ delay = 0, size = 40, ...props }, ref) {
-  const theme = useTheme()
-  const [isVisible, setIsVisible] = useState(delay === 0)
+const Spinner = memo(
+  forwardRef(({ delay = 0, size = 40, ...props }, ref) => {
+    const theme = useTheme()
+    const [isVisible, setIsVisible] = useState(delay === 0)
 
-  useEffect(() => {
-    let delayTimer = null
-    if (delay > 0) {
-      delayTimer = setTimeout(() => {
-        setIsVisible(true)
-      }, delay)
+    useEffect(() => {
+      let delayTimer = null
+      if (delay > 0) {
+        delayTimer = setTimeout(() => {
+          setIsVisible(true)
+        }, delay)
+      }
+
+      return function() {
+        clearTimeout(delayTimer)
+      }
+    }, [])
+
+    if (!isVisible) {
+      return null
     }
 
-    return function() {
-      clearTimeout(delayTimer)
-    }
-  }, [])
-
-  if (!isVisible) {
-    return null
-  }
-
-  return (
-    <Box width={size} height={size} lineHeight={0} {...props} innerRef={ref}>
-      <Box
-        is="svg"
-        className={outerClass}
-        x="0px"
-        y="0px"
-        viewBox="0 0 150 150"
-      >
+    return (
+      <Box width={size} height={size} lineHeight={0} {...props} innerRef={ref}>
         <Box
-          is="circle"
-          className={innerClass(theme.spinnerColor)}
-          cx="75"
-          cy="75"
-          r="60"
-        />
+          is="svg"
+          className={outerClass}
+          x="0px"
+          y="0px"
+          viewBox="0 0 150 150"
+        >
+          <Box
+            is="circle"
+            className={innerClass(theme.spinnerColor)}
+            cx="75"
+            cy="75"
+            r="60"
+          />
+        </Box>
       </Box>
-    </Box>
-  )
-}
+    )
+  })
+)
 
 Spinner.propTypes = {
   /**
@@ -97,4 +99,4 @@ Spinner.propTypes = {
   size: PropTypes.number.isRequired
 }
 
-export default memo(forwardRef(Spinner))
+export default Spinner

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -38,7 +38,7 @@ const innerClass = color =>
     fill: 'transparent'
   }).toString()
 
-const Spinner = ({ delay, size, theme, ...props }) => {
+function Spinner({ delay, size, theme, ...props }) {
   const [isVisible, setIsVisible] = useState(delay === 0)
   const [delayTimer, setDelayTimer] = useState(null)
 

--- a/src/theme/src/useTheme.js
+++ b/src/theme/src/useTheme.js
@@ -1,8 +1,8 @@
 import { useContext } from 'react'
-import ThemeContext from './ThemeContext'
+import { ThemeProvider, ThemeConsumer } from './ThemeContext'
 
 function useTheme() {
-  return useContext(ThemeContext)
+  return useContext({ Consumer: ThemeConsumer, Provider: ThemeProvider })
 }
 
 export default useTheme

--- a/src/theme/src/useTheme.js
+++ b/src/theme/src/useTheme.js
@@ -1,8 +1,8 @@
 import { useContext } from 'react'
-import { ThemeProvider, ThemeConsumer } from './ThemeContext'
+import ThemeContext from './ThemeContext'
 
 function useTheme() {
-  return useContext({ Consumer: ThemeConsumer, Provider: ThemeProvider })
+  return useContext(ThemeContext)
 }
 
 export default useTheme


### PR DESCRIPTION
Pretty straight forward port from `PureComponent` to `hooks`

Just make sure it works in storybook + docs. 

Not much savings here
**Before ~10kb**
<img width="260" alt="Screen Shot 2020-01-28 at 22 54 26" src="https://user-images.githubusercontent.com/13311268/73334312-3cd27180-4221-11ea-8f79-541eb3e2187a.png">

**After ~9kb**
<img width="260" alt="Screen Shot 2020-01-28 at 22 54 26" src="https://user-images.githubusercontent.com/13311268/73334336-4eb41480-4221-11ea-9cc8-deca4525c7cd.png">
