### PR TITLE
Removes text decoration for menu items

### DIFF
--- a/src/theme/src/default-theme/component-specific/getRowClassName.js
+++ b/src/theme/src/default-theme/component-specific/getRowClassName.js
@@ -7,7 +7,9 @@ import palette from '../foundational-styles/palette'
 const Appearances = {}
 
 Appearances.default = Themer.createRowAppearance({
-  base: {},
+  base: {
+    color: palette.neutral.base
+  },
 
   hover: {
     backgroundColor: scales.neutral.N1A

--- a/src/themer/src/createRowAppearance.js
+++ b/src/themer/src/createRowAppearance.js
@@ -10,7 +10,8 @@ const baseStyle = {
   '&[data-isselectable="true"]': {
     cursor: 'pointer'
   },
-  outline: 'none'
+  outline: 'none',
+  textDecoration: 'none'
 }
 
 /**


### PR DESCRIPTION
<img width="251" alt="Screen Shot 2020-02-04 at 08 18 57" src="https://user-images.githubusercontent.com/13311268/73764172-5a26a480-4727-11ea-8860-34c19ab55fd8.png">

Fixes #2 in #728 

The Delete button in the picture `is={Link}` to test I added `react-router-dom` and set the `is` prop as the `Link` component. 
