### PR TITLE
fix: minor docs typo issue 734

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -10,22 +10,22 @@ import { withTheme } from '../../theme'
 class Button extends PureComponent {
   static propTypes = {
     /**
-     * Composes the dimensions spec from the Box primitivie.
+     * Composes the dimensions spec from the Box primitive.
      */
     ...dimensions.propTypes,
 
     /**
-     * Composes the spacing spec from the Box primitivie.
+     * Composes the spacing spec from the Box primitive.
      */
     ...spacing.propTypes,
 
     /**
-     * Composes the position spec from the Box primitivie.
+     * Composes the position spec from the Box primitive.
      */
     ...position.propTypes,
 
     /**
-     * Composes the layout spec from the Box primitivie.
+     * Composes the layout spec from the Box primitive.
      */
     ...layout.propTypes,
 

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -8,22 +8,22 @@ import Button from './Button'
 class IconButton extends PureComponent {
   static propTypes = {
     /**
-     * Composes the dimensions spec from the Box primitivie.
+     * Composes the dimensions spec from the Box primitive.
      */
     ...dimensions.propTypes,
 
     /**
-     * Composes the spacing spec from the Box primitivie.
+     * Composes the spacing spec from the Box primitive.
      */
     ...spacing.propTypes,
 
     /**
-     * Composes the position spec from the Box primitivie.
+     * Composes the position spec from the Box primitive.
      */
     ...position.propTypes,
 
     /**
-     * Composes the layout spec from the Box primitivie.
+     * Composes the layout spec from the Box primitive.
      */
     ...layout.propTypes,
 

--- a/src/buttons/src/TextDropdownButton.js
+++ b/src/buttons/src/TextDropdownButton.js
@@ -9,22 +9,22 @@ import { withTheme } from '../../theme'
 class TextDropdownButton extends PureComponent {
   static propTypes = {
     /**
-     * Composes the dimensions spec from the Box primitivie.
+     * Composes the dimensions spec from the Box primitive.
      */
     ...dimensions.propTypes,
 
     /**
-     * Composes the spacing spec from the Box primitivie.
+     * Composes the spacing spec from the Box primitive.
      */
     ...spacing.propTypes,
 
     /**
-     * Composes the position spec from the Box primitivie.
+     * Composes the position spec from the Box primitive.
      */
     ...position.propTypes,
 
     /**
-     * Composes the layout spec from the Box primitivie.
+     * Composes the layout spec from the Box primitive.
      */
     ...layout.propTypes,
 

--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -8,22 +8,22 @@ import { withTheme } from '../../theme'
 class Select extends PureComponent {
   static propTypes = {
     /**
-     * Composes the dimensions spec from the Box primitivie.
+     * Composes the dimensions spec from the Box primitive.
      */
     ...dimensions.propTypes,
 
     /**
-     * Composes the spacing spec from the Box primitivie.
+     * Composes the spacing spec from the Box primitive.
      */
     ...spacing.propTypes,
 
     /**
-     * Composes the position spec from the Box primitivie.
+     * Composes the position spec from the Box primitive.
      */
     ...position.propTypes,
 
     /**
-     * Composes the layout spec from the Box primitivie.
+     * Composes the layout spec from the Box primitive.
      */
     ...layout.propTypes,
 


### PR DESCRIPTION
Fixed minor typo within 4 components:

https://github.com/segmentio/evergreen/issues/734

src/buttons/src/Button.js
src/buttons/src/IconButton.js
src/buttons/src/TextDropdownButton.js
src/select/src/Select.js

Closes 734