### PR TITLE
Fixed table TextCell incorrect props for text size (documentation)

### DIFF
--- a/docs/src/pages/components/table.mdx
+++ b/docs/src/pages/components/table.mdx
@@ -178,9 +178,9 @@ This can be used as a base to build more complex table cells.
 
 ```jsx
 <Table.Row>
-  <Table.TextCell size={500}>You want to use this component</Table.TextCell>
-  <Table.TextCell size={500}>When you are using text</Table.TextCell>
-  <Table.TextCell size={500}>In your table cell</Table.TextCell>
+  <Table.TextCell textProps={{size: 500}}>You want to use this component</Table.TextCell>
+  <Table.TextCell textProps={{size: 500}}>When you are using text</Table.TextCell>
+  <Table.TextCell textProps={{size: 500}}>In your table cell</Table.TextCell>
 </Table.Row>
 ```
 


### PR DESCRIPTION
`size` needs to be a property on an object passed to `textProps`.