### PR TITLE
When focusing an EditableCellField, place cursor at the end of the value

### DIFF
--- a/src/table/src/EditableCellField.js
+++ b/src/table/src/EditableCellField.js
@@ -136,6 +136,10 @@ export default class EditableCellField extends React.PureComponent {
     this.textareaRef = ref
   }
 
+  handleFocus = e => {
+    e.target.selectionStart = e.target.value.length
+  }
+
   handleBlur = () => {
     if (this.textareaRef) this.props.onChangeComplete(this.textareaRef.value)
   }
@@ -167,6 +171,7 @@ export default class EditableCellField extends React.PureComponent {
         innerRef={this.onRef}
         onKeyDown={this.handleKeyDown}
         onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
         appearance="editable-cell"
         size={size}
         style={{


### PR DESCRIPTION
This PR updates the `EditableCellField` component (an internal Segment component) so that the cursor is placed at the end of the value, instead of at the beginning.

![2020-03-10 22 21 15](https://user-images.githubusercontent.com/8645285/76384916-8680a280-631d-11ea-9360-de5fd5fd5cbc.gif)

