### PR TITLE
fix checkbox types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -576,7 +576,7 @@ declare module 'evergreen-ui' {
   export class Card extends React.PureComponent<CardProps> {
   }
 
-  export interface CheckboxProps extends BoxProps<'input'> {
+  export interface CheckboxProps extends Omit<BoxProps<'input'>, 'innerRef'> {
     /**
      * The id attribute of the checkbox.
      */


### PR DESCRIPTION
This fixes a bug in our type definitions for the Checkbox component. When we added `innerRef` we failed to omit the BoxProps.innerRef type (it is different in this case).