### PR TITLE
Update title props for Corner Dialog to support React.ReactNode and match docs.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -709,9 +709,9 @@ declare module 'evergreen-ui' {
      */
     isShown?: boolean
     /**
-     * Title of the Dialog. Titles should use Title Case.
+     * Title of the Dialog. The text for the title should use Title Case.
      */
-    title?: string
+    title?: string | React.ReactNode
     /**
      * Function that will be called when the exit transition is complete.
      */


### PR DESCRIPTION
This PR updates our `CornerDialogProps` to support passing in a `React.ReactNode` for the `title`. Our current documentation states that `title` can be a `node` but our type defs were not up to date.

Once such use case would be rendering a `<Badge />`  next to the title to highlight a new feature:
![Screen Shot 2020-03-12 at 5 51 18 PM](https://user-images.githubusercontent.com/312291/76638912-a2ee2c00-6523-11ea-94fb-76fa102c09a3.png)
