### PR TITLE
fix export types for ThemeProvider and ThemeConsumer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2316,4 +2316,10 @@ declare module 'evergreen-ui' {
 
   export class Pre extends React.PureComponent<UnknownProps> {
   }
+                                                                      
+  export class ThemeProvider extends React.PureComponent<UnkownProps> {
+  }
+                                                                      
+  export class ThemeConsumer extends React.PureComponent<UnknownProps> {
+  }
 }


### PR DESCRIPTION
## Problem

I have a Typescript project using Evergreen and we want to theme it. `ThemeProvider` and `ThemeContext` are not exported for me to use.

## Solution

Export them! I don't have time to type them exhaustively, but at least now they are usable for Typescript projects.