### PR TITLE
[Docs] Map over and display specific `union` and `enum` types

### DIFF
--- a/docs/src/components/prop-types-table/PropTypeHeading.js
+++ b/docs/src/components/prop-types-table/PropTypeHeading.js
@@ -1,6 +1,19 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
+const getSpecificPropTypes = ({ name, value }) => {
+  switch (name) {
+    case 'enum':
+      return value.map(val => val.value).join(' | ')
+    case 'union':
+      return value.map(val => val.name).join(' | ')
+    // In the case that the type isn't one of these "nested" types,
+    // i.e. it's just a primitive value, just return the name
+    default:
+      return name
+  }
+}
+
 export default class PropTypeHeading extends PureComponent {
   static propTypes = {
     defaultValue: PropTypes.any,
@@ -17,7 +30,9 @@ export default class PropTypeHeading extends PureComponent {
       <div className="PropTypeHeading">
         <code>
           <span className="PropTypeHeading-name">{name}</span>
-          <span className="PropTypeHeading-propType">{type.name}</span>
+          <span className="PropTypeHeading-propType">
+            {getSpecificPropTypes(type)}
+          </span>
           {isArrayOf && (
             <span className="PropTypeHeading-arrayOf">{isArrayOf}</span>
           )}


### PR DESCRIPTION
As I was glancing over the docs, I noticed that there's a lot of `enum` and `union` types that were masking the specific values that the props actually take. This diff brings forward the specific union and enum types so that the information is displayed up-front.

For example -- now in the `Popover` docs:
![image](https://user-images.githubusercontent.com/5349500/78059575-f0013900-733e-11ea-8f0c-bb98cfc35d80.png)