### PR TITLE
Sync Popover internal open/close state to prop "isShown"

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -133,6 +133,19 @@ export default class Popover extends Component {
     document.body.removeEventListener('keydown', this.onEsc, false)
   }
 
+  componentDidUpdate(prevProps) {
+    const { isShown } = this.props
+    // If `isShown` is a boolean, popover is controlled manually.
+    // In that case, ensure that `open` or `close` functionality is applied
+    if (typeof isShown === 'boolean' && isShown !== prevProps.isShown) {
+      if (isShown) {
+        this.open()
+      } else {
+        this.close()
+      }
+    }
+  }
+
   /**
    * Methods borrowed from BlueprintJS
    * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx


### PR DESCRIPTION
## Motivation
We are using an evergreen popover to create an address search component. We want the ability to control when the popover is open / closed - for example when a user selects an option, we close the dropdown. We can achieve this via the `isShown` prop, _but_ in doing so we lose 'click outside' and 'close on escape' functionality - because these are only applied when the component is internally controlled.

In the render method popover currently checks whether `isShown` is a boolean - indicating the component is controlled. This change follows the same pattern, syncing the internal state with the prop.

## Changes
Adds check on component did update - if popover is controlled manually, call open / close to ensure event listeners are correctly managed