### PR TITLE
[Docs] Recursively un-nest `arrayOf`, `shape`, and `union` types

### DIFF
--- a/docs/src/components/prop-types-table/PropTypeHeading.js
+++ b/docs/src/components/prop-types-table/PropTypeHeading.js
@@ -1,11 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
-/**
- * In some cases, the generated `value` from react-docgen
- * is a nested type -- meaning that proptype information
- * comes in the form of
- */
 const getSpecificPropTypes = ({ name, value }) => {
   switch (name) {
     // Enums are treated as just having simple values, so no recursive step needed.
@@ -16,8 +11,6 @@ const getSpecificPropTypes = ({ name, value }) => {
     case 'arrayOf':
       return `Array<${getSpecificPropTypes(value)}>`
     case 'shape':
-      // In the case of an object type, recurse on the nested types and display
-      // themselves.
       return `{ ${Object.keys(value)
         .map(
           key =>


### PR DESCRIPTION
This builds off of #769 and uncovers a bit more specific type information, especially with regards to `arrayOf` and `shape` types.

For example: 
![image](https://user-images.githubusercontent.com/5349500/78171394-358a3880-7409-11ea-82ef-574c69f03c91.png)
