### PR TITLE
Update autocomplete docs to be specific about values for `position`

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -91,7 +91,16 @@ export default class Autocomplete extends PureComponent {
     /**
      * The position of the Popover the Autocomplete is rendered in.
      */
-    position: PropTypes.oneOf(Object.keys(Position)),
+    position: PropTypes.oneOf([
+      Position.TOP,
+      Position.TOP_LEFT,
+      Position.TOP_RIGHT,
+      Position.BOTTOM,
+      Position.BOTTOM_LEFT,
+      Position.BOTTOM_RIGHT,
+      Position.LEFT,
+      Position.RIGHT
+    ]),
 
     /**
      * A function that is used to filter the items.


### PR DESCRIPTION
When `react-docgen` statically analyzes the source file, it ends up treating `Object.keys(...)` as a string, instead of eagerly evaluating it (and rightfully so). This uncovered a bug in the `Autocomplete` docs where we were using `Object.keys` to satisfy a `PropType` definition, where instead we can just be explicit about the values that a particular prop takes (as we do elsewhere in the docs)

![image](https://user-images.githubusercontent.com/5349500/78941172-ff356480-7a6b-11ea-93e2-9b7e03851b35.png)
