### PR TITLE
Update typedefs to be more specific about icon types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -445,7 +445,7 @@ declare module 'evergreen-ui' {
   interface OptionProps extends TableRowProps {
     height?: number | string
     label: string
-    icon?: string
+    icon?: IconName
     disabled?: boolean
   }
 
@@ -2170,7 +2170,7 @@ declare module 'evergreen-ui' {
      * When passed, adds a icon before each list item in the list
      * You can override this on a individual list item.
      */
-    icon?: string
+    icon?: IconName
     /**
      * The color of the icon in each list item in the list.
      */


### PR DESCRIPTION
I was trying to use `<UnorderedList />` and lamented the fact that I couldn't get Intellisense to autocomplete the list of possible icon names for the underlying `<ListItem />` elements. This fixes the remaining cases where we have `icon?: string` to instead be bound to the Blueprint icon names. 

This shouldn't be a breaking change for consumers, since any invalid icon strings that are passed through would just render nothing.