### PR TITLE
Prevents error message render for empty values

### DIFF
--- a/src/form-field/src/FormField.js
+++ b/src/form-field/src/FormField.js
@@ -66,6 +66,22 @@ export default class FormField extends PureComponent {
     }
   }
 
+  renderValidationMessage = () => {
+    const { validationMessage } = this.props
+
+    if (!validationMessage) {
+      return null
+    }
+
+    return typeof validationMessage === 'string' ? (
+      <FormFieldValidationMessage marginTop={8}>
+        {validationMessage}
+      </FormFieldValidationMessage>
+    ) : (
+      validationMessage
+    )
+  }
+
   render() {
     const {
       hint,
@@ -75,7 +91,6 @@ export default class FormField extends PureComponent {
       isRequired,
       labelProps,
       description,
-      validationMessage,
       ...props
     } = this.props
 
@@ -97,13 +112,7 @@ export default class FormField extends PureComponent {
           description
         )}
         {children}
-        {typeof validationMessage === 'string' ? (
-          <FormFieldValidationMessage marginTop={8}>
-            {validationMessage}
-          </FormFieldValidationMessage>
-        ) : (
-          validationMessage
-        )}
+        {this.renderValidationMessage()}
         {typeof hint === 'string' ? (
           <FormFieldHint marginTop={6}>{hint}</FormFieldHint>
         ) : (


### PR DESCRIPTION
fix issue #780 

## Before
<img width="847" alt="Screen Shot 2020-04-16 at 18 02 29" src="https://user-images.githubusercontent.com/13311268/79520960-d6354680-800c-11ea-8269-6a8821392819.png">

## After
<img width="847" alt="Screen Shot 2020-04-16 at 18 04 09" src="https://user-images.githubusercontent.com/13311268/79521015-0250c780-800d-11ea-8dd8-0256dfd6d005.png">

