### PR TITLE
Removes fixed height on badge

### DIFF
--- a/src/badges/src/Badge.js
+++ b/src/badges/src/Badge.js
@@ -33,7 +33,7 @@ class Badge extends PureComponent {
   static styles = {
     display: 'inline-block',
     boxSizing: 'border-box',
-    height: 16,
+    minHeight: 16,
     paddingTop: 0,
     paddingRight: 6,
     paddingBottom: 0,


### PR DESCRIPTION
Fixes #776 

Allows badge height to grow based on text inside so subscripts and super scripts don't look ugly.

<img width="713" alt="Screen Shot 2020-04-18 at 16 12 06" src="https://user-images.githubusercontent.com/13311268/79673711-03aafd00-8191-11ea-8311-69f4d94fa62b.png">

Only caveat is if you try to mix badges with + without subscripts, it'll look funky due to the height difference.