### PR TITLE
Uses forwardRef in such a way that allows propTypes to be assigned to it

### DIFF
--- a/src/icons/src/Icon.js
+++ b/src/icons/src/Icon.js
@@ -9,53 +9,55 @@ import { useTheme } from '../../theme'
  * Refer to the LICENSE for BlueprintJS here: https://github.com/palantir/blueprint/blob/develop/LICENSE
  */
 
-function TreeShakeableIcon(
-  {
-    color = 'currentColor',
-    size = 16,
-    name,
-    title,
-    style = {},
-    svgPaths16,
-    svgPaths20,
-    ...svgProps
-  },
-  ref
-) {
-  const theme = useTheme()
-  const SIZE_STANDARD = 16
-  const SIZE_LARGE = 20
+const TreeShakeableIcon = forwardRef(
+  (
+    {
+      color = 'currentColor',
+      size = 16,
+      name,
+      title,
+      style = {},
+      svgPaths16,
+      svgPaths20,
+      ...svgProps
+    },
+    ref
+  ) => {
+    const theme = useTheme()
+    const SIZE_STANDARD = 16
+    const SIZE_LARGE = 20
 
-  // Choose which pixel grid is most appropriate for given icon size
-  const pixelGridSize = size >= SIZE_LARGE ? SIZE_LARGE : SIZE_STANDARD
-  const pathStrings = SIZE_STANDARD ? svgPaths16 : svgPaths20
-  const paths = pathStrings.map((d, i) => (
-    // eslint-disable-next-line react/no-array-index-key
-    <path key={i} d={d} fillRule="evenodd" />
-  ))
+    // Choose which pixel grid is most appropriate for given icon size
+    const pixelGridSize = size >= SIZE_LARGE ? SIZE_LARGE : SIZE_STANDARD
+    const pathStrings = SIZE_STANDARD ? svgPaths16 : svgPaths20
+    const paths = pathStrings.map((d, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <path key={i} d={d} fillRule="evenodd" />
+    ))
 
-  const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`
+    const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`
 
-  if (color) {
-    style = { ...style, fill: theme.getIconColor(color) }
+    if (color) {
+      style = { ...style, fill: theme.getIconColor(color) }
+    }
+
+    return (
+      <Box
+        is="svg"
+        {...svgProps}
+        data-icon={name}
+        style={style}
+        width={size}
+        height={size}
+        viewBox={viewBox}
+        innerRef={ref}
+      >
+        {title && <title>{title}</title>}
+        {paths}
+      </Box>
+    )
   }
-
-  return (
-    <Box
-      is="svg"
-      {...svgProps}
-      data-icon={name}
-      style={style}
-      width={size}
-      height={size}
-      viewBox={viewBox}
-      innerRef={ref}
-    >
-      {title && <title>{title}</title>}
-      {paths}
-    </Box>
-  )
-}
+)
 
 TreeShakeableIcon.propTypes = {
   /**
@@ -93,4 +95,4 @@ TreeShakeableIcon.propTypes = {
   svgPaths20: PropTypes.arrayOf(PropTypes.string).isRequired
 }
 
-export default forwardRef(TreeShakeableIcon)
+export default TreeShakeableIcon


### PR DESCRIPTION
When using the latest version of Evergreen, we see the following warning in the console:
```js
Warning: forwardRef render functions do not support propTypes or defaultProps. 
Did you accidentally pass a React component?
```

This appears to be because propTypes are assigned to the internal function (to `forwardRef`) rather than the `forwardRef` wrapped _component_.

Another option is to wrap `TreeShakeableIcon` with forwardRef, then assign propTypes 🤔 

I believe this solution is the recommended solution 👐 


