### PR TITLE
fix touch events for autocomplete

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -176,9 +176,9 @@ export default class Autocomplete extends PureComponent {
     width,
     inputValue,
     highlightedIndex,
-    selectItemAtIndex,
     selectedItem,
-    getItemProps
+    getItemProps,
+    getMenuProps
   }) => {
     const {
       title,
@@ -199,8 +199,13 @@ export default class Autocomplete extends PureComponent {
 
     if (items.length === 0) return null
 
+    // Pass the actual DOM ref to downshift, this fixes touch support
+    const menuProps = getMenuProps()
+    menuProps.innerRef = menuProps.ref
+    delete menuProps.ref
+
     return (
-      <Pane width={width}>
+      <Pane width={width} {...menuProps}>
         {title && (
           <Pane padding={8} borderBottom="muted">
             <Heading size={100}>{title}</Heading>
@@ -218,9 +223,6 @@ export default class Autocomplete extends PureComponent {
             renderItem={({ index, style }) => {
               const item = items[index]
               const itemString = itemToString(item)
-              const onSelect = () => {
-                selectItemAtIndex(index)
-              }
 
               return renderItem(
                 getItemProps({
@@ -229,8 +231,6 @@ export default class Autocomplete extends PureComponent {
                   index,
                   style,
                   children: itemString,
-                  onMouseUp: onSelect,
-                  onTouchEnd: onSelect,
                   isSelected: itemToString(selectedItem) === itemString,
                   isHighlighted: highlightedIndex === index
                 })
@@ -273,9 +273,9 @@ export default class Autocomplete extends PureComponent {
           isOpen: isShown,
           inputValue,
           getItemProps,
+          getMenuProps,
           selectedItem,
           highlightedIndex,
-          selectItemAtIndex,
           getRootProps,
           ...restDownshiftProps
         }) => (
@@ -295,9 +295,9 @@ export default class Autocomplete extends PureComponent {
                   width: Math.max(this.state.targetWidth, popoverMinWidth),
                   inputValue,
                   getItemProps,
+                  getMenuProps,
                   selectedItem,
-                  highlightedIndex,
-                  selectItemAtIndex
+                  highlightedIndex
                 })
               }}
               minHeight={0}
@@ -315,7 +315,6 @@ export default class Autocomplete extends PureComponent {
                   inputValue,
                   selectedItem,
                   highlightedIndex,
-                  selectItemAtIndex,
                   ...restDownshiftProps
                 })
               }


### PR DESCRIPTION
This fixes autocomplete touch events (so you can scroll on touch devices without closing/selecting something).