### PR TITLE
only postpublish from master

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "clean": "git clean -Xdf",
     "release": "np",
     "deploy-docs": "cd docs && yarn install && yarn deploy",
-    "postpublish": "yarn deploy-docs"
+    "postpublish": "yarn git-branch-is master && yarn deploy-docs"
   },
   "engines": {
     "node": ">=10"
@@ -103,6 +103,7 @@
     "faker": "^4.1.0",
     "file-loader": "^2.0.0",
     "fs-extra": "^7.0.0",
+    "git-branch-is": "^3.1.0",
     "husky": "^4.0.10",
     "jest": "^25.3.0",
     "jscodeshift": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4799,7 +4799,7 @@ commander@^2.15.0, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1:
+commander@^4.0.0, commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -7311,6 +7311,13 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+git-branch-is@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/git-branch-is/-/git-branch-is-3.1.0.tgz#ec029ca77fff3dc1a3b31f15520b00de7016676d"
+  integrity sha512-Lmqr7r2qJn5m7r8gNk9wGeF4C+y8ZyPypa8YLrNNc25qStKqrAg+uRpRZpXK9/TjPMAlY8MjDZW52OAG6RIG8w==
+  dependencies:
+    commander "^4.0.0"
 
 github-url-from-git@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
This will exit if attempting to publish from branches other than master – we don't want to overwrite the docsite from prereleases, etc.