### PR TITLE
mark backwards compat classname file as sideEffect, include export + types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@ import { BoxProps } from 'ui-box/dist/types/box-types'
 import { StyleAttribute, CSSProperties } from 'glamor'
 import { DownshiftProps } from 'downshift'
 
+export { configureSafeHref, setClassNamePrefix } from 'ui-box'
+
 type PositionTypes = 'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'
 type IntentTypes = 'none' | 'success' | 'warning' | 'danger'
 type DefaultAppearance = 'default'

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "index.d.ts",
     "codemods"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./commonjs/backwards-compat-classname.js",
+    "./esm/backwards-compat-classname.js"
+  ],
   "scripts": {
     "test": "xo && jest --bail && ava",
     "prepublishOnly": "rm -rf esm commonjs umd && yarn build",

--- a/src/backwards-compat-classname.js
+++ b/src/backwards-compat-classname.js
@@ -1,0 +1,4 @@
+import { setClassNamePrefix } from 'ui-box'
+
+/** Set the classname for backwards compatibility */
+setClassNamePrefix('📦')

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
-import { setClassNamePrefix } from 'ui-box'
+// eslint-disable-next-line import/no-unassigned-import
+import './backwards-compat-classname'
 import { autoHydrate } from './ssr'
-
-setClassNamePrefix('📦')
 autoHydrate()
 
-export { configureSafeHref } from 'ui-box'
+export { configureSafeHref, setClassNamePrefix } from 'ui-box'
 export { Alert, InlineAlert } from './alert'
 export { Autocomplete, AutocompleteItem } from './autocomplete'
 export { Avatar } from './avatar'


### PR DESCRIPTION
When we upgraded ui-box and applied `setClassNamePrefix` to match the old classname for compatibility reasons, we forgot to include it as a sideEffect, so bundlers like webpack would strip it out.

I've also re-exported it and added it to the types.

I noticed it only in production builds:
<img width="371" alt="Screen Shot 2020-04-21 at 9 35 31 PM" src="https://user-images.githubusercontent.com/710752/80024748-26952400-84a5-11ea-964c-b45e727df3ee.png">
