### PR TITLE
rm side effects in v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "index.d.ts",
     "codemods"
   ],
-  "sideEffects": [
-    "./commonjs/backwards-compat-classname.js",
-    "./esm/backwards-compat-classname.js"
-  ],
+  "sideEffects": false,
   "scripts": {
     "test": "xo && jest --bail && ava",
     "prepublishOnly": "rm -rf esm commonjs umd && yarn build",

--- a/src/backwards-compat-classname.js
+++ b/src/backwards-compat-classname.js
@@ -1,4 +1,0 @@
-import { setClassNamePrefix } from 'ui-box'
-
-/** Set the classname for backwards compatibility */
-setClassNamePrefix('📦')

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-unassigned-import
-import './backwards-compat-classname'
 import { autoHydrate } from './ssr'
 autoHydrate()
 


### PR DESCRIPTION
This removes the side effect we introduced to keep 📦  – in v5 ui-box will use the `ub` prefix instead.