### PR TITLE
Add new <TextareaField /> component, with identical semantics to <TextInputField />

### DIFF
--- a/docs/src/pages/components/textarea.mdx
+++ b/docs/src/pages/components/textarea.mdx
@@ -2,7 +2,10 @@ import PropsTable from 'components/PropsTable'
 
 ## Introduction
 
-The `Textarea` components maps directly to a `textarea` element.
+Similar to text inputs, Evergreen exports two components to create text areas:
+
+* **Textarea**: base text area component. Directly maps to a `textarea` element.
+* **TextareaField**: combines a label, textarea  and validation message in one. Used for traditional forms.
 
 
 ```jsx
@@ -33,7 +36,7 @@ The `Textarea` components maps directly to a `textarea` element.
 ## Controlled usage
 
 The `Textarea` component works the same as using `textarea` directly.
-Use `e.target.value` to get the value of the component on change. 
+Use `e.target.value` to get the value of the component on change.
 
 ```jsx
 <Component initialState={{ value: 'Hello'}}>
@@ -47,3 +50,86 @@ Use `e.target.value` to get the value of the component on change.
 ```
 
 <PropsTable of="Textarea" />
+
+# TextareaField
+
+The `TextareaField` component combines a `Textarea` with a label and optional
+`description`, `validationMessage` and `hint`.
+
+
+## Label and description
+
+```jsx
+<TextareaField
+  label="Default textarea field"
+  description="This is a description."
+  placeholder="Placeholder text"
+/>
+```
+
+## A hint is under the textarea
+
+```jsx
+<TextareaField
+  label="Default textarea field"
+  hint="This is a hint."
+  placeholder="Placeholder text"
+/>
+```
+
+## Required textarea field
+
+```jsx
+<TextareaField
+  id="ids-are-optional"
+  label="A required textarea field"
+  required
+  description="This is a description."
+  placeholder="Placeholder text"
+/>
+```
+
+## Invalid field
+
+```jsx
+<TextareaField
+  isInvalid
+  required
+  label="A required textarea field"
+  description="This is a description."
+  validationMessage="This field is required"
+/>
+```
+
+## Validation message without invalid input
+
+```jsx
+<TextareaField
+  isInvalid={false}
+  required
+  label="A required textarea field"
+  description="This is a description."
+  validationMessage="This field is required"
+/>
+```
+
+## Controlled usage
+
+The `TextareaField` component works the same as using `textarea` directly.
+Use `e.target.value` to get the value of the component on change.
+
+```jsx
+<Component initialState={{ value: '' }}>
+  {({ state, setState }) => (
+    <TextareaField
+      label="A controlled text input field"
+      required
+      description="This is a description."
+      value={state.value}
+      onChange={e => setState({ value: e.target.value })}
+    />
+  )}
+</Component>
+```
+
+<PropsTable of="TextareaField" />

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export {
   useTheme,
   defaultTheme
 } from './theme'
-export { Textarea } from './textarea'
+export { Textarea, TextareaField } from './textarea'
 export { toaster } from './toaster'
 export { Tooltip } from './tooltip'
 export {

--- a/src/textarea/index.js
+++ b/src/textarea/index.js
@@ -1,1 +1,2 @@
 export { default as Textarea } from './src/Textarea'
+export { default as TextareaField } from './src/TextareaField'

--- a/src/textarea/src/TextareaField.js
+++ b/src/textarea/src/TextareaField.js
@@ -1,0 +1,124 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { splitBoxProps } from 'ui-box'
+import { FormField } from '../../form-field'
+import Textarea from './Textarea'
+
+let idCounter = 0
+
+export default class TextareaField extends PureComponent {
+  static propTypes = {
+    /**
+     * Composes the Textarea component as the base.
+     */
+    ...Textarea.propTypes,
+    ...FormField.propTypes,
+
+    /**
+     * The label used above the input element.
+     */
+    label: PropTypes.node.isRequired,
+
+    /**
+     * Whether or not to show an asterix after the label.
+     */
+    required: PropTypes.bool,
+
+    /**
+     * An optional description of the field under the label, above the input element.
+     */
+    description: PropTypes.node,
+
+    /**
+     * An optional hint under the input element.
+     */
+    hint: PropTypes.node,
+
+    /**
+     * If a validation message is passed it is shown under the input element
+     * and above the hint. This is unaffected by `isInvalid`.
+     */
+    validationMessage: PropTypes.node,
+
+    /**
+     * The height of the input element.
+     */
+    inputHeight: PropTypes.number,
+
+    /**
+     * The width of the input width.
+     */
+    inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  }
+
+  static defaultProps = {
+    /**
+     * The input width should be as wide as the form field.
+     */
+    inputWidth: '100%',
+    inputHeight: 80
+  }
+
+  state = {
+    id: (this.props.id || idCounter++).toString()
+  }
+
+  render() {
+    const {
+      // We are using the id from the state
+      id: unusedId,
+
+      // FormField props
+      hint,
+      label,
+      description,
+      validationMessage,
+
+      // Textarea props
+      inputHeight,
+      inputWidth,
+      disabled,
+      required,
+      isInvalid,
+      appearance,
+      placeholder,
+      spellCheck,
+
+      // Rest props are spread on the FormField
+      ...props
+    } = this.props
+
+    const id = `TextareaField-${this.state.id}`
+
+    /**
+     * Split the wrapper props from the input props.
+     */
+    const { matchedProps, remainingProps } = splitBoxProps(props)
+
+    return (
+      <FormField
+        marginBottom={24}
+        label={label}
+        isRequired={required}
+        hint={hint}
+        description={description}
+        validationMessage={validationMessage}
+        labelFor={id}
+        {...matchedProps}
+      >
+        <Textarea
+          id={id}
+          width={inputWidth}
+          height={inputHeight}
+          disabled={disabled}
+          required={required}
+          isInvalid={isInvalid}
+          appearance={appearance}
+          placeholder={placeholder}
+          spellCheck={spellCheck}
+          {...remainingProps}
+        />
+      </FormField>
+    )
+  }
+}

--- a/src/textarea/stories/index.stories.js
+++ b/src/textarea/stories/index.stories.js
@@ -1,40 +1,98 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
+import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { Label, Text } from '../../typography'
-import { Textarea } from '..'
+import { Label, Text, Heading } from '../../typography'
+import { Textarea, TextareaField } from '..'
+
+class Manager extends React.Component {
+  static propTypes = {
+    children: PropTypes.func
+  }
+
+  state = {}
+
+  render() {
+    return this.props.children({
+      setState: (...args) => {
+        this.setState(...args)
+      },
+      state: this.state
+    })
+  }
+}
 
 const Description = props => (
   <Text is="p" marginTop={0} size={300} color="muted" {...props} />
 )
 
-storiesOf('textarea', module).add('overview', () => (
-  <Box padding={48}>
-    <Box marginBottom={24} width={360}>
-      <Label htmlFor={32} size={400} display="block">
-        Default
-      </Label>
-      <Description marginBottom={8}>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit sed do.
-      </Description>
-      <Textarea name={32} id={32} placeholder="With placeholder" />
+storiesOf('textarea', module)
+  .add('overview', () => (
+    <Box padding={48}>
+      <Box marginBottom={24} width={360}>
+        <Label htmlFor={32} size={400} display="block">
+          Default
+        </Label>
+        <Description marginBottom={8}>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit sed do.
+        </Description>
+        <Textarea name={32} id={32} placeholder="With placeholder" />
+      </Box>
+      <Box marginBottom={24} width={360}>
+        <Label htmlFor="disabled" size={400} display="block">
+          Disabled
+        </Label>
+        <Textarea
+          value="This is disabled"
+          name="disabled"
+          id="disabled"
+          disabled
+        />
+      </Box>
+      <Box marginBottom={24} width={360}>
+        <Label htmlFor="isInvalid" size={400} display="block">
+          Is Invalid
+        </Label>
+        <Textarea name="isInvalid" id="isInvalid" isInvalid />
+      </Box>
     </Box>
-    <Box marginBottom={24} width={360}>
-      <Label htmlFor="disabled" size={400} display="block">
-        Disabled
-      </Label>
-      <Textarea
-        value="This is disabled"
-        name="disabled"
-        id="disabled"
-        disabled
+  ))
+  .add('TextareaField', () => (
+    <Box padding={40}>
+      <Heading size={700} marginBottom={40}>
+        TextareaField component
+      </Heading>
+      <TextareaField
+        label="Default textarea field"
+        description="This is a description."
+        placeholder="Placeholder text"
       />
+      <TextareaField
+        id="ids-are-optional"
+        label="A required textarea field"
+        required
+        description="This is a description."
+        placeholder="Placeholder text"
+      />
+      <TextareaField
+        isInvalid
+        required
+        label="A required textarea field"
+        description="This is a description."
+        validationMessage="This field is required"
+      />
+      <Manager>
+        {({ state, setState }) => {
+          return (
+            <TextareaField
+              label="A controlled textarea field"
+              required
+              description="This is a description."
+              value={state.value}
+              onChange={e => setState({ value: e.target.value })}
+            />
+          )
+        }}
+      </Manager>
     </Box>
-    <Box marginBottom={24} width={360}>
-      <Label htmlFor="isInvalid" size={400} display="block">
-        Is Invalid
-      </Label>
-      <Textarea name="isInvalid" id="isInvalid" isInvalid />
-    </Box>
-  </Box>
-))
+  ))


### PR DESCRIPTION
## Overview 
This PR adds a `<TextareaField />` component to be used in forms, in a very similar vein as `<TextInputField />`. In fact, it follows the exact same semantics and styling as `<TextInputField />`. The docs / everything are copied over, just swapping out the underlying component + component references. 

There's probably some room to DRY this up a bit, but I think just having this split (since it's only used in two places) is fine for now until we re-visit semantics around input fields as a whole. 

## Screenshots 
![image](https://user-images.githubusercontent.com/5349500/80234398-f5cffe80-860c-11ea-8754-6ded941b96f9.png)

![image](https://user-images.githubusercontent.com/5349500/80234426-02545700-860d-11ea-9a9c-93e4e2ea7f45.png)
