### PR TITLE
Adds more control features for corner dialog

### DIFF
--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -39,9 +39,7 @@ const closeAnimation = css.keyframes('closeAnimation', {
 
 const animationStyles = {
   '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.spring
-    } both`
+    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${animationEasing.spring} both`
   },
   '&[data-state="exiting"]': {
     animation: `${closeAnimation} 120ms ${animationEasing.acceleration} both`
@@ -86,6 +84,11 @@ export default class CornerDialog extends PureComponent {
      * When true, the footer with the cancel and confirm button is shown.
      */
     hasFooter: PropTypes.bool,
+
+    /**
+     * When true, the footer with the title and close button are shown.
+     */
+    hasHeader: PropTypes.bool,
 
     /**
      * Function that will be called when the confirm button is clicked.
@@ -135,6 +138,16 @@ export default class CornerDialog extends PureComponent {
     containerProps: PropTypes.object,
 
     /**
+     * Props that are passed to the dialog content body.
+     */
+    contentProps: PropTypes.object,
+
+    /**
+     * Props that are passed to the dialog header.
+     */
+    headerProps: PropTypes.object,
+
+    /**
      * Props that will set position of corner dialog
      */
     position: PropTypes.oneOf([
@@ -149,6 +162,7 @@ export default class CornerDialog extends PureComponent {
     width: 392,
     intent: 'none',
     hasFooter: true,
+    hasHeader: true,
     confirmLabel: 'Learn More',
     hasCancel: true,
     hasClose: true,
@@ -218,12 +232,15 @@ export default class CornerDialog extends PureComponent {
       intent,
       isShown,
       hasFooter,
+      hasHeader,
       hasCancel,
       hasClose,
       cancelLabel,
       confirmLabel,
       onOpenComplete,
       containerProps = {},
+      contentProps = {},
+      headerProps = {},
       position
     } = this.props
 
@@ -257,21 +274,28 @@ export default class CornerDialog extends PureComponent {
               ]}
               {...containerProps}
             >
-              <Pane display="flex" alignItems="center" marginBottom={12}>
-                <Heading is="h4" size={600} flex="1">
-                  {title}
-                </Heading>
-                {hasClose && (
-                  <IconButton
-                    height={32}
-                    icon="cross"
-                    appearance="minimal"
-                    onClick={this.handleClose}
-                  />
-                )}
-              </Pane>
+              {hasHeader && (
+                <Pane
+                  display="flex"
+                  alignItems="center"
+                  marginBottom={12}
+                  {...headerProps}
+                >
+                  <Heading is="h4" size={600} flex="1">
+                    {title}
+                  </Heading>
+                  {hasClose && (
+                    <IconButton
+                      height={32}
+                      icon="cross"
+                      appearance="minimal"
+                      onClick={this.handleClose}
+                    />
+                  )}
+                </Pane>
+              )}
 
-              <Pane overflowY="auto" data-state={state}>
+              <Pane overflowY="auto" data-state={state} {...contentProps}>
                 {this.renderChildren()}
               </Pane>
 

--- a/src/corner-dialog/stories/index.stories.js
+++ b/src/corner-dialog/stories/index.stories.js
@@ -93,6 +93,23 @@ storiesOf('corner-dialog', module).add('CornerDialog', () => (
           <CornerDialog
             title="Please Read License Terms"
             isShown={state.isShown}
+            hasHeader={false}
+            width={492}
+            confirmLabel="View Terms"
+            onCloseComplete={() => setState({ isShown: false })}
+          >
+            MIT License
+          </CornerDialog>
+          <Button onClick={() => setState({ isShown: true })}>No Header</Button>
+        </Box>
+      )}
+    </Manager>
+    <Manager isShown={false}>
+      {({ state, setState }) => (
+        <Box marginTop={24}>
+          <CornerDialog
+            title="Please Read License Terms"
+            isShown={state.isShown}
             hasClose={false}
             hasCancel={false}
             width={492}


### PR DESCRIPTION
Working with this component outside of simple notifications has been a bit of a painpoint in my projects.

One issue: if you have no title and no close icon, the `h4` and `div` are still rendered:

<img width="1440" alt="Screen Shot 2020-04-25 at 11 23 15" src="https://user-images.githubusercontent.com/13311268/80288001-c5aa5d80-86e9-11ea-87ac-22cff4e3b652.png">

The following PR adds the ability to:

1. set props on the header component
2. set props on the content component
3. remove header completely