### PR TITLE
revert circular dep

### DIFF
--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -5,6 +5,7 @@ import { withTheme } from '../../theme'
 import { Pane } from '../../layers'
 import { Heading, Paragraph } from '../../typography'
 import { IconButton } from '../../buttons'
+import { Icon } from '../../icon'
 
 class Alert extends PureComponent {
   static propTypes = {
@@ -71,6 +72,12 @@ class Alert extends PureComponent {
     appearance: 'default'
   }
 
+  getIconForIntent = intent => {
+    const { theme } = this.props
+
+    return <Icon size={14} {...theme.getIconForIntent(intent)} />
+  }
+
   render() {
     const {
       theme,
@@ -116,7 +123,7 @@ class Alert extends PureComponent {
             display="flex"
             alignItems="center"
           >
-            {theme.getIconForIntent(intent, { size: 14 })}
+            {this.getIconForIntent(intent)}
           </Pane>
         )}
         <Pane display="flex" width="100%">

--- a/src/alert/src/InlineAlert.js
+++ b/src/alert/src/InlineAlert.js
@@ -4,6 +4,7 @@ import { spacing, dimensions, position, layout } from 'ui-box'
 import { withTheme } from '../../theme'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
+import { Icon } from '../../icon'
 
 class InlineAlert extends PureComponent {
   static propTypes = {
@@ -49,6 +50,12 @@ class InlineAlert extends PureComponent {
     size: 400
   }
 
+  getIconForIntent = intent => {
+    const { theme } = this.props
+
+    return <Icon size={14} marginTop={2} {...theme.getIconForIntent(intent)} />
+  }
+
   render() {
     const { theme, children, intent, hasIcon, size, ...props } = this.props
 
@@ -56,7 +63,7 @@ class InlineAlert extends PureComponent {
       <Pane alignItems="center" display="flex" {...props}>
         {hasIcon && (
           <Pane display="inline" marginRight={8}>
-            {theme.getIconForIntent(intent, { size: 14, marginTop: 2 })}
+            {this.getIconForIntent(intent)}
           </Pane>
         )}
         <Text size={size} fontWeight={500}>

--- a/src/theme/src/default-theme/theme-helpers/index.js
+++ b/src/theme/src/default-theme/theme-helpers/index.js
@@ -1,14 +1,7 @@
-import React from 'react'
 import { Intent } from '../../../../constants'
 import themedProperty from '../utils/themedProperty'
 import { colors, elevations } from '../foundational-styles'
 import { fontFamilies, headings, paragraph, text } from '../typography'
-import {
-  TickCircleIcon,
-  ErrorIcon,
-  WarningSignIcon,
-  InfoSignIcon
-} from '../../../../icons'
 
 /**
  * Controls include:
@@ -108,17 +101,17 @@ const getIconColor = color => {
  * @param {Intent} intent
  * @return {Object} properties
  */
-const getIconForIntent = (intent, props = {}) => {
+const getIconForIntent = intent => {
   switch (intent) {
     case Intent.SUCCESS:
-      return <TickCircleIcon color="success" {...props} />
+      return { icon: 'tick-circle', color: 'success' }
     case Intent.DANGER:
-      return <ErrorIcon color="danger" {...props} />
+      return { icon: 'error', color: 'danger' }
     case Intent.WARNING:
-      return <WarningSignIcon color="warning" {...props} />
+      return { icon: 'warning-sign', color: 'warning' }
     case Intent.NONE:
     default:
-      return <InfoSignIcon color="info" {...props} />
+      return { icon: 'info-sign', color: 'info' }
   }
 }
 


### PR DESCRIPTION
Using #807 locally to test the production build of evergreen (via yarn link) I was able to narrow in on a circular dependency warnings for Icon and defaultTheme.

