### PR TITLE
"disabled" property for MenuItem

### DIFF
--- a/docs/src/pages/components/menu.mdx
+++ b/docs/src/pages/components/menu.mdx
@@ -242,6 +242,33 @@ The focus styles are currently not working in the docs, sorry for the inconvenie
 </Popover>
 ```
 
+## Menu with disabled items
+
+```
+  <Popover
+  position={Position.BOTTOM_LEFT}
+  content={
+    <Menu>
+      <Menu.Group>
+        <Menu.Item icon="people">Share...</Menu.Item>
+        <Menu.Item icon="circle-arrow-right" disabled>Move...</Menu.Item>
+        <Menu.Item icon="edit" secondaryText="⌘R">
+          Rename...
+        </Menu.Item>
+      </Menu.Group>
+      <Menu.Divider />
+      <Menu.Group>
+        <Menu.Item icon="trash" intent="danger">
+          Delete...
+        </Menu.Item>
+      </Menu.Group>
+    </Menu>
+  }
+>
+  <Button marginRight={16}>With Disabled Items</Button>
+</Popover>
+```
+
 <PropsTable of="Menu" />
 <PropsTable of="MenuItem" />
 <PropsTable of="MenuGroup" />

--- a/index.d.ts
+++ b/index.d.ts
@@ -1106,6 +1106,7 @@ export interface MenuItemProps extends PaneProps {
   secondaryText?: JSX.Element
   appearance?: DefaultAppearance
   intent?: IntentTypes
+  disabled?: boolean
 }
 
 export interface MenuGroupProps extends Omit<PaneProps, 'title'> {

--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -39,6 +39,9 @@ export default class Menu extends React.PureComponent {
     this.firstItem = this.menuItems[0]
     this.lastItem = this.menuItems[this.menuItems.length - 1]
 
+    const isMenuItemDisabled = menuItem =>
+      menuItem.disabled || menuItem.tabIndex === -1
+
     const focusNext = (currentItem, startItem) => {
       // Determine which item is the startItem (first or last)
       const goingDown = startItem === this.firstItem
@@ -66,7 +69,7 @@ export default class Menu extends React.PureComponent {
       let nextItem = move(currentItem)
 
       // If the menuitem is disabled move on
-      while (nextItem.disabled) {
+      while (isMenuItemDisabled(nextItem)) {
         nextItem = move(nextItem)
       }
 

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -50,13 +50,19 @@ class MenuItem extends React.PureComponent {
     /**
      * Theme provided by ThemeProvider.
      */
-    theme: PropTypes.object.isRequired
+    theme: PropTypes.object.isRequired,
+
+    /**
+     * Flag to indicate whether the menu item is disabled or not
+     */
+    disabled: PropTypes.bool
   }
 
   static defaultProps = {
     is: 'div',
     intent: 'none',
     appearance: 'default',
+    disabled: false,
     onSelect: () => {}
   }
 
@@ -88,6 +94,7 @@ class MenuItem extends React.PureComponent {
       secondaryText,
       intent,
       icon,
+      disabled,
       ...passthroughProps
     } = this.props
 
@@ -102,36 +109,43 @@ class MenuItem extends React.PureComponent {
 
     return (
       <Pane
-        is={is}
-        role="menuitem"
-        className={themedClassName}
-        onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
-        height={icon ? 40 : 32}
-        tabIndex={0}
-        data-isselectable="true"
-        display="flex"
-        alignItems="center"
-        {...passthroughProps}
+        is="div"
+        pointerEvents={disabled ? 'none' : 'auto'}
+        opacity={disabled ? 0.4 : 1}
       >
-        {icon && (
-          <Icon
-            color={intent === 'none' ? 'default' : intent}
-            icon={icon}
-            marginLeft={16}
-            marginRight={-4}
-            size={16}
-            flexShrink={0}
-          />
-        )}
-        <Text color={intent} marginLeft={16} marginRight={16} flex={1}>
-          {children}
-        </Text>
-        {secondaryText && (
-          <Text marginRight={16} color="muted">
-            {secondaryText}
+        <Pane
+          is={is}
+          role="menuitem"
+          className={themedClassName}
+          onClick={this.handleClick}
+          onKeyPress={this.handleKeyPress}
+          height={icon ? 40 : 32}
+          tabIndex={disabled ? -1 : 0}
+          data-isselectable="true"
+          display="flex"
+          alignItems="center"
+          disabled={disabled}
+          {...passthroughProps}
+        >
+          {icon && (
+            <Icon
+              color={intent === 'none' ? 'default' : intent}
+              icon={icon}
+              marginLeft={16}
+              marginRight={-4}
+              size={16}
+              flexShrink={0}
+            />
+          )}
+          <Text color={intent} marginLeft={16} marginRight={16} flex={1}>
+            {children}
           </Text>
-        )}
+          {secondaryText && (
+            <Text marginRight={16} color="muted">
+              {secondaryText}
+            </Text>
+          )}
+        </Pane>
       </Pane>
     )
   }

--- a/src/menu/stories/index.stories.js
+++ b/src/menu/stories/index.stories.js
@@ -170,7 +170,32 @@ storiesOf('menu', module)
           </Menu>
         }
       >
-        <Button>Hover menus</Button>
+        <Button marginRight={16}>Hover menus</Button>
+      </Popover>
+
+      <Popover
+        position={Position.BOTTOM_LEFT}
+        content={
+          <Menu>
+            <Menu.Group title="Actions">
+              <Menu.Item icon="people">Share...</Menu.Item>
+              <Menu.Item icon="circle-arrow-right" disabled>
+                Move...
+              </Menu.Item>
+              <Menu.Item icon="edit" secondaryText="⌘R">
+                Rename...
+              </Menu.Item>
+            </Menu.Group>
+            <Menu.Divider />
+            <Menu.Group title="destructive">
+              <Menu.Item icon="trash" intent="danger">
+                Delete...
+              </Menu.Item>
+            </Menu.Group>
+          </Menu>
+        }
+      >
+        <Button>With Disabled Items</Button>
       </Popover>
 
       <UnorderedList marginTop={24}>


### PR DESCRIPTION
## Overview 
According to this opened [issue](https://github.com/segmentio/evergreen/issues/796), there is no possibility to disable a menu item, but the [documentation](https://evergreen.segment.com/components/menu) states that the disabled items are skipped regarding the focus management.

I added a new property for MenuItem named "disabled". It is a flag (default value is false) used to disable a menu item by adding a wrapper which has "pointerEvents" disabled (set to "none"), and the opacity is lowered. The implementation is also safe for TAB key due to the lower "tabindex" set for the Pane.

The implementation is still gonna work with the workaround suggested by the user who opened the issue (use custom menu items, and create a disabled button to emulate a disabled item), because the condition who checks whether an item is disabled or not, looks for either "disabled" property of dom element or "tabindex" value.

## Screenshots
![image](https://user-images.githubusercontent.com/13217082/80591683-610b3d80-8a1e-11ea-997d-8569241c0d7f.png)

## Testing
- Updated TypeScript Component props
- Included an example with a disabled menu item in component docs.
- Modified storybooks as well.
