### PR TITLE
[Docs] Fix un-nesting of shape types when shapetype is composed

### DIFF
--- a/docs/src/components/PropsTable.js
+++ b/docs/src/components/PropsTable.js
@@ -11,16 +11,6 @@ export default class PropsTable extends PureComponent {
     rename: PropTypes.string
   }
 
-  getTypeInfo(prop) {
-    if (prop.type && typeof prop.type.value === 'string') {
-      return (
-        <div className="PropTypeTypeValue Content">
-          Value type: <code>{prop.type.value}</code>
-        </div>
-      )
-    }
-  }
-
   isArrayOf = prop => {
     if (
       prop.type &&
@@ -130,7 +120,6 @@ export default class PropsTable extends PureComponent {
                       type={prop.type || {}}
                       isArrayOf={isArrayOf}
                     />
-                    {this.getTypeInfo(prop)}
                     {prop.docblock ? (
                       <PropTypeDescription>{prop.docblock}</PropTypeDescription>
                     ) : null}

--- a/docs/src/components/prop-types-table/PropTypeHeading.js
+++ b/docs/src/components/prop-types-table/PropTypeHeading.js
@@ -11,14 +11,19 @@ const getSpecificPropTypes = ({ name, value }) => {
     case 'arrayOf':
       return `Array<${getSpecificPropTypes(value)}>`
     case 'shape':
-      return `{ ${Object.keys(value)
-        .map(
-          key =>
-            `${key}${value[key].required ? '' : '?'}: ${getSpecificPropTypes(
-              value[key]
-            )}`
-        )
-        .join(', ')} }`
+      if (typeof value === 'object') {
+        return `{ ${Object.keys(value)
+          .map(
+            key =>
+              `${key}${value[key].required ? '' : '?'}: ${getSpecificPropTypes(
+                value[key]
+              )}`
+          )
+          .join(', ')} }`
+      }
+
+      return value
+
     // In the case that the type isn't one of these "nested" types,
     // i.e. it's just a primitive value, just return the name
     default:


### PR DESCRIPTION
## Overview 
This PR fixes an issue on the docs where we were attempting to recurse on a composed `PropTypes.shape()` type. `react-docgen` just extracts theses as strings, so this PR does a `typeof` check for `object` before attempting to gather its keys and recurse, while just displaying a simple displayed type for other properties. 

It also removed the `Value type:` portion of the docs, as we no longer show `object` as a type for `PropTypes.shape()`
 
## Screenshots (if applicable) 
![image](https://user-images.githubusercontent.com/5349500/80640633-89903900-8a18-11ea-9d98-13ded9e49b33.png)

## Testing
N/A -- only affects how component documentation is presented