### PR TITLE
SelectMenu: Allow to customize size of option item

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1590,6 +1590,10 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
     * When true, menu closes on option selection.
     */
   closeOnSelect?: boolean
+  /*
+   * Size of option item.
+   */
+  optionSize?: number
 }
 
 export class SelectMenu extends React.PureComponent<SelectMenuProps> {

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -110,7 +110,12 @@ export default class SelectMenu extends PureComponent {
     /*
      * When true, menu closes on option selection.
      */
-    closeOnSelect: PropTypes.bool
+    closeOnSelect: PropTypes.bool,
+    
+    /*
+     * Size of option item.
+     */
+    optionSize: PropTypes.number
   }
 
   static defaultProps = {
@@ -170,6 +175,7 @@ export default class SelectMenu extends PureComponent {
       titleView,
       isMultiSelect,
       closeOnSelect,
+      optionSize,
       ...props
     } = this.props
 
@@ -190,6 +196,7 @@ export default class SelectMenu extends PureComponent {
             hasTitle={hasTitle}
             isMultiSelect={isMultiSelect}
             titleView={titleView}
+            optionSize={optionSize}
             listProps={{
               onSelect: item => {
                 this.props.onSelect(item)

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -111,7 +111,7 @@ export default class SelectMenu extends PureComponent {
      * When true, menu closes on option selection.
      */
     closeOnSelect: PropTypes.bool,
-    
+
     /*
      * Size of option item.
      */
@@ -196,8 +196,8 @@ export default class SelectMenu extends PureComponent {
             hasTitle={hasTitle}
             isMultiSelect={isMultiSelect}
             titleView={titleView}
-            optionSize={optionSize}
             listProps={{
+              optionSize,
               onSelect: item => {
                 this.props.onSelect(item)
               },

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -169,5 +169,18 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
     >
       <Button>Empty state</Button>
     </SelectMenu>
+    <Manager>
+      {({ setState, state }) => (
+        <SelectMenu
+          title="Select name"
+          options={optionsWithIcons}
+          selected={state.selected}
+          onSelect={item => setState({ selected: item.value })}
+          optionSize={42}
+        >
+          <Button height={42}>Size large</Button>
+        </SelectMenu>
+      )}
+    </Manager>
   </Box>
 ))


### PR DESCRIPTION
## Overview 

Expose prop `optionSize` of `OptionList` to customize size of option item.
 
## Screenshots (if applicable) 

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [x] Added / modified Storybook stories
