### PR TITLE
[TagInput] Expose `tagSubmitKey` prop 

### DIFF
--- a/docs/src/pages/components/tag-input.mdx
+++ b/docs/src/pages/components/tag-input.mdx
@@ -27,6 +27,27 @@ The `TagInput` component is a text input component that adds values as tags.
 </Component>
 ```
 
+## Custom tag submit key
+
+You can customize the key to submit a new tag by either passing in `space` or `enter`.
+This will be the key by which to submit a tag as a user is typing in the input.
+
+```jsx
+<Component initialState={{ values: ['Kauri', 'Willow'] }}>
+  {({ state, setState }) => (
+    <TagInput
+      inputProps={{ placeholder: 'Add a tree...(then press space)' }}
+      width="100%"
+      tagSubmitKey="space"
+      values={state.values}
+      onChange={values => {
+        setState({ values })
+      }}
+    />
+  )}
+</Component>
+```
+
 ## Full width TagInput
 
 Use the `width` property to control the width of the `TagInput`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1976,6 +1976,7 @@ export interface TagInputProps extends Omit<React.ComponentPropsWithoutRef<typeo
   onInputChange?: (event: React.ChangeEvent) => void
   onRemove?: (value: string | React.ReactNode, index: number) => void
   separator?: string
+  tagSubmitKey?: "enter" | "space"
   tagProps?: any
   values?: string[]
 }

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -15,8 +15,8 @@ import Tag from './Tag'
 let inputId = 1
 
 const GET_KEY_FOR_TAG_DELIMITER = {
-  Enter: 'Enter',
-  Space: ' '
+  enter: 'Enter',
+  space: ' '
 }
 
 class TagInput extends React.Component {
@@ -77,8 +77,8 @@ class TagInput extends React.Component {
     ]),
     /** Provide props to tag component (actually `Badge`, for now). */
     tagProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-    /** Key to press in order to create a new tag when typing.  */
-    tagDelimiterKey: PropTypes.oneOf(['Enter', 'Space']),
+    /** Key to press in order to submit a new tag while typing.  */
+    tagSubmitKey: PropTypes.oneOf(['enter', 'space']),
     /**
      * Theme provided by ThemeProvider.
      */
@@ -93,7 +93,7 @@ class TagInput extends React.Component {
     height: 32,
     separator: /[,\n\r]/,
     values: [],
-    tagDelimiterKey: 'Enter',
+    tagSubmitKey: 'enter',
     tagProps: {}
   }
 
@@ -166,7 +166,7 @@ class TagInput extends React.Component {
   handleKeyDown = event => {
     const { selectionEnd, value } = event.target
 
-    const key = GET_KEY_FOR_TAG_DELIMITER[this.props.tagDelimiterKey]
+    const key = GET_KEY_FOR_TAG_DELIMITER[this.props.tagSubmitKey]
 
     if (event.key === key) {
       console.log(event.key)

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -14,6 +14,11 @@ import Tag from './Tag'
 
 let inputId = 1
 
+const GET_KEY_FOR_TAG_DELIMITER = {
+  Enter: 'Enter',
+  Space: ' '
+}
+
 class TagInput extends React.Component {
   static propTypes = {
     /** Whether or not the inputValue should be added to the tags when the input blurs. */
@@ -72,6 +77,8 @@ class TagInput extends React.Component {
     ]),
     /** Provide props to tag component (actually `Badge`, for now). */
     tagProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    /** Key to press in order to create a new tag when typing.  */
+    tagDelimiterKey: PropTypes.oneOf(['Enter', 'Space']),
     /**
      * Theme provided by ThemeProvider.
      */
@@ -86,6 +93,7 @@ class TagInput extends React.Component {
     height: 32,
     separator: /[,\n\r]/,
     values: [],
+    tagDelimiterKey: 'Enter',
     tagProps: {}
   }
 
@@ -158,7 +166,10 @@ class TagInput extends React.Component {
   handleKeyDown = event => {
     const { selectionEnd, value } = event.target
 
-    if (event.key === 'Enter') {
+    const key = GET_KEY_FOR_TAG_DELIMITER[this.props.tagDelimiterKey]
+
+    if (event.key === key) {
+      console.log(event.key)
       // Prevent Enter keypresses from submitting forms since they have special powers inside TagInput
       event.preventDefault()
       this.addTags(value)

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -169,7 +169,6 @@ class TagInput extends React.Component {
     const key = GET_KEY_FOR_TAG_DELIMITER[this.props.tagSubmitKey]
 
     if (event.key === key) {
-      console.log(event.key)
       // Prevent Enter keypresses from submitting forms since they have special powers inside TagInput
       event.preventDefault()
       this.addTags(value)

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -78,6 +78,22 @@ storiesOf('tag-input', module).add('TagInput', () => (
     </StorySection>
     <StorySection>
       <StoryHeader>
+        <StoryHeading>Changing tag submit key</StoryHeading>
+      </StoryHeader>
+      <StateManager>
+        {({ values, addValues, removeValue }) => (
+          <TagInput
+            inputProps={{ placeholder: 'Enter something...' }}
+            values={values}
+            onAdd={addValues}
+            tagSubmitKey="space"
+            onRemove={removeValue}
+          />
+        )}
+      </StateManager>
+    </StorySection>
+    <StorySection>
+      <StoryHeader>
         <StoryHeading>With tag values</StoryHeading>
       </StoryHeader>
       <StateManager values={initialValues}>


### PR DESCRIPTION
## Overview 
This PR exposes a new `tagSubmitKey` prop which takes in two values either `"enter"` (default), or `"space"`. The motivation behind this is to allow consumers to choose how they let users submit tags as they're typing (with the hunch that `space` has some utility here).
 
## Screenshots (if applicable) 
N/A. Interaction change, not visual.

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Added / modified component docs 
- [x] Added / modified Storybook stories
