### PR TITLE
switch component-template script to function components

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Please respect our Code of Conduct, in short:
 - Gracefully accepting constructive criticism.
 - Focusing on what is best for the community.
 - Showing empathy towards other community members.
- -->
+-->
 
 ## Overview
 

--- a/tools/component-template.js
+++ b/tools/component-template.js
@@ -2,18 +2,24 @@
 
 module.exports = ({ componentName }) => {
   return `
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 
-export default class ${componentName} extends PureComponent {
-  static propTypes = {}
+const ${componentName} = memo(forwardRef((props, ref) => {
+  const { ...restProps } = props
 
-  render() {
-    const { ...props } = this.props
+  return (
+    <Box innerRef={ref} {...restProps}>
+      ${componentName}
+    </Box>
+  )
+}))
 
-    return <Box {...props}>${componentName}</Box>
-  }
+${componentName}.propTypes = {
+
 }
+
+export default ${componentName}
 `.trim()
 }


### PR DESCRIPTION
## Overview 
This PR updates the `component-template` script to spit out function components with memo + forwardRef instead of `PureComponent`.
 
## Screenshots (if applicable) 
NA

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Added / modified component docs 
- [x] Added / modified Storybook stories
