### PR TITLE
convert Alert and InlineAlert to React.FC

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -415,6 +415,8 @@ export enum Position {
   RIGHT = 'right'
 }
 
+type ForwardRefComponent<P = {}, T = any> = React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>
+
 export interface AlertProps extends Omit<PaneProps, 'title'> {
   intent?: IntentTypes
   title?: React.ReactNode
@@ -437,8 +439,7 @@ export interface AlertProps extends Omit<PaneProps, 'title'> {
   appearance?: AlertAppearance
 }
 
-export class Alert extends React.PureComponent<AlertProps> {
-}
+export declare const Alert: ForwardRefComponent<AlertProps>
 
 interface OptionProps extends TableRowProps {
   height?: number | string
@@ -1026,8 +1027,7 @@ export interface InlineAlertProps extends PaneProps {
   size?: keyof Typography['text']
 }
 
-export class InlineAlert extends React.PureComponent<InlineAlertProps> {
-}
+export declare const InlineAlert: ForwardRefComponent<InlineAlertProps>
 
 export type LabelProps = TextProps
 

--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -1,92 +1,28 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { spacing, dimensions, position, layout } from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import { Pane } from '../../layers'
 import { Heading, Paragraph } from '../../typography'
 import { IconButton } from '../../buttons'
 import { CrossIcon } from '../../icons'
 import { getIconForIntent } from './getIconForIntent'
 
-class Alert extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes some Box APIs.
-     */
-    ...spacing.propTypes,
-    ...position.propTypes,
-    ...layout.propTypes,
-    ...dimensions.propTypes,
-
-    /**
-     * The content of the alert. When a string is passed it is wrapped in a `<Text size={400} />` component.
-     */
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-
-    /**
-     * The intent of the alert.
-     */
-    intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger'])
-      .isRequired,
-
-    /**
-     * The title of the alert.
-     */
-    title: PropTypes.node,
-
-    /**
-     * When true, show a border on the left matching the type.
-     */
-    hasTrim: PropTypes.bool,
-
-    /**
-     * When true, show a icon on the left matching the type,
-     */
-    hasIcon: PropTypes.bool,
-
-    /**
-     * When true, show a remove icon button.
-     */
-    isRemoveable: PropTypes.bool,
-
-    /**
-     * Function called when the remove button is clicked.
-     */
-    onRemove: PropTypes.func,
-
-    /**
-     * The appearance of the alert.
-     */
-    appearance: PropTypes.oneOf(['default', 'card']),
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    intent: 'none',
-    hasTrim: true,
-    hasIcon: true,
-    isRemoveable: false,
-    appearance: 'default'
-  }
-
-  render() {
+const Alert = memo(
+  forwardRef((props, ref) => {
     const {
-      theme,
-
-      title,
-      intent,
-      hasTrim,
-      hasIcon,
+      appearance = 'default',
       children,
-      appearance,
-      isRemoveable,
+      hasIcon = true,
+      hasTrim = true,
+      intent = 'none',
+      isRemoveable = false,
       onRemove,
-      ...props
-    } = this.props
+      title,
+      ...restProps
+    } = props
+
+    const theme = useTheme()
 
     /**
      * Note that Alert return a className and additional properties.
@@ -99,6 +35,7 @@ class Alert extends PureComponent {
 
     return (
       <Pane
+        ref={ref}
         className={className}
         role="alert"
         backgroundColor="white"
@@ -108,7 +45,7 @@ class Alert extends PureComponent {
         paddingY={12}
         paddingX={16}
         {...themeProps}
-        {...props}
+        {...restProps}
       >
         {hasIcon && (
           <Pane
@@ -159,7 +96,57 @@ class Alert extends PureComponent {
         </Pane>
       </Pane>
     )
-  }
+  })
+)
+
+Alert.propTypes = {
+  /**
+   * Composes some Box APIs.
+   */
+  ...spacing.propTypes,
+  ...position.propTypes,
+  ...layout.propTypes,
+  ...dimensions.propTypes,
+
+  /**
+   * The content of the alert. When a string is passed it is wrapped in a `<Text size={400} />` component.
+   */
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+
+  /**
+   * The intent of the alert.
+   */
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+
+  /**
+   * The title of the alert.
+   */
+  title: PropTypes.node,
+
+  /**
+   * When true, show a border on the left matching the type.
+   */
+  hasTrim: PropTypes.bool,
+
+  /**
+   * When true, show a icon on the left matching the type,
+   */
+  hasIcon: PropTypes.bool,
+
+  /**
+   * When true, show a remove icon button.
+   */
+  isRemoveable: PropTypes.bool,
+
+  /**
+   * Function called when the remove button is clicked.
+   */
+  onRemove: PropTypes.func,
+
+  /**
+   * The appearance of the alert.
+   */
+  appearance: PropTypes.oneOf(['default', 'card'])
 }
 
-export default withTheme(Alert)
+export default Alert

--- a/src/alert/src/InlineAlert.js
+++ b/src/alert/src/InlineAlert.js
@@ -1,54 +1,22 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { spacing, dimensions, position, layout } from 'ui-box'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
 import { getIconForIntent } from './getIconForIntent'
 
-class InlineAlert extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes some Box APIs.
-     */
-    ...spacing.propTypes,
-    ...position.propTypes,
-    ...layout.propTypes,
-    ...dimensions.propTypes,
-
-    /**
-     * The content of the alert.
-     */
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-
-    /**
-     * The intent of the alert. This should always be set explicitly.
-     */
-    intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger'])
-      .isRequired,
-
-    /**
-     * When true, show a icon on the left matching the type.
-     * There is no point not showing this.
-     */
-    hasIcon: PropTypes.bool,
-
-    /**
-     * The size of the Text.
-     */
-    size: PropTypes.number
-  }
-
-  static defaultProps = {
-    intent: 'none',
-    hasIcon: true,
-    size: 400
-  }
-
-  render() {
-    const { children, intent, hasIcon, size, ...props } = this.props
+const InlineAlert = memo(
+  forwardRef((props, ref) => {
+    const {
+      children,
+      intent = 'none',
+      hasIcon = true,
+      size = 400,
+      ...restProps
+    } = props
 
     return (
-      <Pane alignItems="center" display="flex" {...props}>
+      <Pane ref={ref} alignItems="center" display="flex" {...restProps}>
         {hasIcon && (
           <Pane display="inline" marginRight={8}>
             {getIconForIntent(intent, { size: 14, marginTop: 2 })}
@@ -59,7 +27,38 @@ class InlineAlert extends PureComponent {
         </Text>
       </Pane>
     )
-  }
+  })
+)
+
+InlineAlert.propTypes = {
+  /**
+   * Composes some Box APIs.
+   */
+  ...spacing.propTypes,
+  ...position.propTypes,
+  ...layout.propTypes,
+  ...dimensions.propTypes,
+
+  /**
+   * The content of the alert.
+   */
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+
+  /**
+   * The intent of the alert. This should always be set explicitly.
+   */
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+
+  /**
+   * When true, show a icon on the left matching the type.
+   * There is no point not showing this.
+   */
+  hasIcon: PropTypes.bool,
+
+  /**
+   * The size of the Text.
+   */
+  size: PropTypes.number
 }
 
 export default InlineAlert


### PR DESCRIPTION
## Overview 
This PR converts Alert and InlineAlert to React.FC

## Screenshots (if applicable) 
<img width="1792" alt="Screen Shot 2020-05-13 at 11 13 09 AM" src="https://user-images.githubusercontent.com/710752/81839209-da218f00-950c-11ea-8085-4143db871997.png">
<img width="1792" alt="Screen Shot 2020-05-13 at 11 13 07 AM" src="https://user-images.githubusercontent.com/710752/81839217-dd1c7f80-950c-11ea-93c7-25b3e2e1a441.png">

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Added / modified component docs 
- [x] Added / modified Storybook stories
