### PR TITLE
convert badge and pill to react.fc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -530,8 +530,7 @@ export interface BadgeProps extends StrongProps {
   isSolid?: boolean
 }
 
-export class Badge extends React.PureComponent<BadgeProps> {
-}
+export declare const Badge: ForwardRefComponent<BadgeProps>
 
 export interface ButtonProps extends React.ComponentPropsWithoutRef<typeof Text> {
   intent?: IntentTypes
@@ -1143,8 +1142,7 @@ export declare const Pane: ForwardRefComponent<PaneProps>
 
 export type PillProps = BadgeProps
 
-export class Pill extends React.PureComponent<PillProps> {
-}
+export declare const Pill: ForwardRefComponent<PillProps>
 
 export type PopoverStatelessProps = React.ComponentPropsWithoutRef<typeof Box>
 

--- a/src/badges/src/Badge.js
+++ b/src/badges/src/Badge.js
@@ -1,78 +1,64 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { Strong } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Badge extends PureComponent {
-  static propTypes = {
-    ...Strong.propTypes,
+const styles = {
+  display: 'inline-block',
+  boxSizing: 'border-box',
+  height: 16,
+  paddingTop: 0,
+  paddingRight: 6,
+  paddingBottom: 0,
+  paddingLeft: 6,
+  borderRadius: 2,
+  textAlign: 'center',
+  textDecoration: 'none',
+  textTransform: 'uppercase'
+}
 
-    /**
-     * The color used for the badge.
-     */
-    color: PropTypes.string.isRequired,
+const Badge = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
 
-    /**
-     * Whether or not to apply hover/focus/active styles
-     */
-    isInteractive: PropTypes.bool,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    color: 'neutral',
-    isInteractive: false,
-    isSolid: false
-  }
-
-  static styles = {
-    display: 'inline-block',
-    boxSizing: 'border-box',
-    height: 16,
-    paddingTop: 0,
-    paddingRight: 6,
-    paddingBottom: 0,
-    paddingLeft: 6,
-    borderRadius: 2,
-    textAlign: 'center',
-    textDecoration: 'none',
-    textTransform: 'uppercase'
-  }
-
-  render() {
     const {
-      theme,
       className,
-      color: propsColor,
-      isInteractive,
-      isSolid,
-      ...props
-    } = this.props
+      color = 'neutral',
+      isInteractive = false,
+      isSolid = false,
+      ...restProps
+    } = props
 
-    const { color, backgroundColor } = theme.getBadgeProps({
-      color: propsColor,
-      isSolid
-    })
-
+    const themeProps = theme.getBadgeProps({ color, isSolid })
     const appearance = isInteractive ? 'interactive' : 'default'
     const classNames = cx(className, theme.getBadgeClassName(appearance))
 
     return (
       <Strong
+        ref={ref}
         size={300}
-        {...Badge.styles}
-        color={color}
-        backgroundColor={backgroundColor}
-        {...props}
+        {...styles}
+        {...themeProps}
+        {...restProps}
         className={classNames}
       />
     )
-  }
+  })
+)
+
+Badge.propTypes = {
+  ...Strong.propTypes,
+
+  /**
+   * The color used for the badge.
+   */
+  color: PropTypes.string,
+
+  /**
+   * Whether or not to apply hover/focus/active styles
+   */
+  isInteractive: PropTypes.bool
 }
 
-export default withTheme(Badge)
+export default Badge

--- a/src/badges/src/Pill.js
+++ b/src/badges/src/Pill.js
@@ -1,12 +1,12 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import Badge from './Badge'
 
-export default class Pill extends PureComponent {
-  static propTypes = {
-    ...Badge.propTypes
-  }
+const Pill = memo(
+  forwardRef((props, ref) => {
+    return <Badge borderRadius={999} ref={ref} {...props} />
+  })
+)
 
-  render() {
-    return <Badge borderRadius={999} {...this.props} />
-  }
-}
+Pill.propTypes = Badge.propTypes
+
+export default Pill


### PR DESCRIPTION
## Overview 
This PR converts Badge and Pill to memo + forwardRef
 
## Screenshots (if applicable) 
<img width="1792" alt="Screen Shot 2020-05-13 at 12 24 03 PM" src="https://user-images.githubusercontent.com/710752/81844501-cc700780-9514-11ea-906d-a08878c448a0.png">
<img width="1792" alt="Screen Shot 2020-05-13 at 12 24 01 PM" src="https://user-images.githubusercontent.com/710752/81844507-d0038e80-9514-11ea-9a48-82502d08422b.png">


## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Added / modified component docs 
- [x] Added / modified Storybook stories
