### PR TITLE
npx react-codemod pure-component src/

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -564,8 +564,7 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<typeof Text>
   className?: string
 }
 
-export class Button extends React.PureComponent<ButtonProps> {
-}
+export declare const Button: ForwardRefComponent<ButtonProps>
 
 export type CardProps = React.ComponentProps<typeof Pane>
 
@@ -628,8 +627,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps> {
 export type CodeProps = TextProps
 
 
-export class Code extends React.PureComponent<CodeProps> {
-}
+export declare const Code: ForwardRefComponent<CodeProps>
 
 export interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof Box> {
   /**
@@ -959,15 +957,13 @@ export class FormFieldLabel extends React.PureComponent<FormFieldLabelProps> {
 export interface FormFieldValidationMessageProps extends PaneProps {
 }
 
-export class FormFieldValidationMessage extends React.PureComponent<FormFieldValidationMessageProps> {
-}
+export declare const FormFieldValidationMessage: ForwardRefComponent<FormFieldValidationMessageProps>
 
 export interface HeadingProps extends React.ComponentPropsWithoutRef<typeof Box> {
   size?: keyof Typography['headings']
 }
 
-export class Heading extends React.PureComponent<HeadingProps> {
-}
+export declare const Heading: ForwardRefComponent<HeadingProps>
 
 export interface IconButtonProps extends ButtonProps {
   /**
@@ -1002,8 +998,7 @@ export interface IconButtonProps extends ButtonProps {
   className?: string
 }
 
-export class IconButton extends React.PureComponent<IconButtonProps> {
-}
+export declare const IconButton: ForwardRefComponent<IconButtonProps>
 
 export interface ImageProps extends BoxProps<'img'> {
   src?: string
@@ -1057,8 +1052,7 @@ export interface LinkProps extends TextProps {
   className?: string
 }
 
-export class Link extends React.PureComponent<LinkProps> {
-}
+export declare const Link: ForwardRefComponent<LinkProps>
 
 export interface ListItemProps extends TextProps {
   /**
@@ -1176,8 +1170,7 @@ export type ParagraphProps = React.ComponentPropsWithoutRef<typeof Box> & {
   fontFamily?: FontFamily
 }
 
-export class Paragraph extends React.PureComponent<ParagraphProps> {
-}
+export declare const Paragraph: ForwardRefComponent<ParagraphProps>
 
 export interface PositionerProps {
   position?: PositionTypes
@@ -1347,8 +1340,7 @@ export interface SearchInputProps extends TextInputProps {
   height?: number
 }
 
-export class SearchInput extends React.PureComponent<SearchInputProps> {
-}
+export declare const SearchInput: ForwardRefComponent<SearchInputProps>
 
 export interface SearchTableHeaderCellProps extends Omit<TableHeaderCellProps, 'onChange'> {
   /**
@@ -1429,8 +1421,7 @@ export interface SelectProps extends Omit<React.ComponentPropsWithoutRef<typeof 
   onChange?(event: React.ChangeEvent<HTMLSelectElement>): void
 }
 
-export class Select extends React.PureComponent<SelectProps> {
-}
+export declare const Select: ForwardRefComponent<SelectProps>
 
 export type SelectFieldProps = FormFieldProps
 
@@ -1569,8 +1560,7 @@ export interface SideSheetProps {
   preventBodyScrolling?: boolean
 }
 
-export class SideSheet extends React.PureComponent<SideSheetProps> {
-}
+export declare const SideSheet: ForwardRefComponent<SideSheetProps>
 
 export type SidebarTabProps = TabProps
 
@@ -1581,8 +1571,7 @@ export interface SmallProps extends BoxProps<'small'> {
 
 }
 
-export class Small extends React.PureComponent<SmallProps> {
-}
+export declare const Small: ForwardRefComponent<SmallProps>
 
 export interface SpinnerProps extends React.ComponentPropsWithoutRef<typeof Box> {
   /**
@@ -1954,8 +1943,7 @@ export interface TextareaProps extends TextProps {
   className?: string
 }
 
-export class Textarea extends React.PureComponent<TextareaProps> {
-}
+export declare const Textarea: ForwardRefComponent<TextareaProps>
 
 export interface TextareaFieldProps extends TextareaProps {
   /**
@@ -2017,8 +2005,7 @@ export interface TextDropdownButtonProps extends TextProps {
   className?: string
 }
 
-export class TextDropdownButton extends React.PureComponent<TextDropdownButtonProps> {
-}
+export declare const TextDropdownButton: ForwardRefComponent<TextDropdownButtonProps>
 
 export interface TextTableCellProps extends TableCellProps {
   /**
@@ -2046,8 +2033,7 @@ export type TextProps = React.ComponentPropsWithoutRef<typeof Box> & {
   fontFamily?: FontFamily | string
 }
 
-export class Text extends React.PureComponent<TextProps> {
-}
+export declare const Text: ForwardRefComponent<TextProps>
 
 export type TextInputProps = React.ComponentProps<typeof Text> & {
   /**

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -1,11 +1,11 @@
-import React, { PureComponent, memo } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { dimensions, spacing, position, layout } from 'ui-box'
 import { IconWrapper } from '../../icons/src/IconWrapper'
 import { Text } from '../../typography'
 import { Spinner } from '../../spinner'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
 /* eslint-disable-next-line react/prop-types */
 const Icon = memo(({ icon, size, spacing, edge }) => {
@@ -24,99 +24,11 @@ const Icon = memo(({ icon, size, spacing, edge }) => {
   )
 })
 
-class Button extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the dimensions spec from the Box primitive.
-     */
-    ...dimensions.propTypes,
+const Button = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
 
-    /**
-     * Composes the spacing spec from the Box primitive.
-     */
-    ...spacing.propTypes,
-
-    /**
-     * Composes the position spec from the Box primitive.
-     */
-    ...position.propTypes,
-
-    /**
-     * Composes the layout spec from the Box primitive.
-     */
-    ...layout.propTypes,
-
-    /**
-     * The intent of the button.
-     */
-    intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
-
-    /**
-     * The appearance of the button.
-     */
-    appearance: PropTypes.oneOf(['default', 'minimal', 'primary']).isRequired,
-
-    /**
-     * When true, show a loading spinner before the children.
-     * This also disables the button.
-     */
-    isLoading: PropTypes.bool,
-
-    /**
-     * Forcefully set the active state of a button.
-     * Useful in conjuction with a Popover.
-     */
-    isActive: PropTypes.bool,
-
-    /**
-     * Sets an icon before the text. Can be any icon from Evergreen or a custom element.
-     */
-    iconBefore: PropTypes.node,
-
-    /**
-     * Sets an icon after the text. Can be any icon from Evergreen or a custom element.
-     */
-    iconAfter: PropTypes.node,
-
-    /**
-     * When true, the button is disabled.
-     * isLoading also sets the button to disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the button.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    appearance: 'default',
-    height: 32,
-    intent: 'none',
-    isActive: false,
-    paddingBottom: 0,
-    paddingTop: 0
-  }
-
-  static styles = {
-    position: 'relative',
-    fontFamily: 'ui',
-    fontWeight: 500,
-    display: 'inline-flex',
-    alignItems: 'center',
-    flexWrap: 'nowrap'
-  }
-
-  render() {
     const {
-      theme,
       className,
 
       intent,
@@ -137,8 +49,8 @@ class Button extends PureComponent {
       iconBefore,
       iconAfter,
 
-      ...props
-    } = this.props
+      ...restProps
+    } = props
 
     const themedClassName = theme.getButtonClassName(appearance, intent)
     const textSize = theme.getTextSizeForControlHeight(height)
@@ -153,6 +65,7 @@ class Button extends PureComponent {
     return (
       <Text
         is="button"
+        ref={ref}
         className={cx(themedClassName, className)}
         borderTopRightRadius={borderRadius}
         borderBottomRightRadius={borderRadius}
@@ -172,7 +85,7 @@ class Button extends PureComponent {
         lineHeight={`${height}px`}
         {...(isActive ? { 'data-active': true } : {})}
         {...Button.styles}
-        {...props}
+        {...restProps}
         disabled={disabled || isLoading}
       >
         {isLoading && (
@@ -187,7 +100,91 @@ class Button extends PureComponent {
         <Icon icon={iconAfter} size={iconSize} spacing={pr} edge="end" />
       </Text>
     )
-  }
+  })
+)
+
+Button.propTypes = {
+  /**
+   * Composes the dimensions spec from the Box primitive.
+   */
+  ...dimensions.propTypes,
+
+  /**
+   * Composes the spacing spec from the Box primitive.
+   */
+  ...spacing.propTypes,
+
+  /**
+   * Composes the position spec from the Box primitive.
+   */
+  ...position.propTypes,
+
+  /**
+   * Composes the layout spec from the Box primitive.
+   */
+  ...layout.propTypes,
+
+  /**
+   * The intent of the button.
+   */
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+
+  /**
+   * The appearance of the button.
+   */
+  appearance: PropTypes.oneOf(['default', 'minimal', 'primary']).isRequired,
+
+  /**
+   * When true, show a loading spinner before the children.
+   * This also disables the button.
+   */
+  isLoading: PropTypes.bool,
+
+  /**
+   * Forcefully set the active state of a button.
+   * Useful in conjuction with a Popover.
+   */
+  isActive: PropTypes.bool,
+
+  /**
+   * Sets an icon before the text. Can be any icon from Evergreen or a custom element.
+   */
+  iconBefore: PropTypes.node,
+
+  /**
+   * Sets an icon after the text. Can be any icon from Evergreen or a custom element.
+   */
+  iconAfter: PropTypes.node,
+
+  /**
+   * When true, the button is disabled.
+   * isLoading also sets the button to disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Class name passed to the button.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(Button)
+Button.defaultProps = {
+  appearance: 'default',
+  height: 32,
+  intent: 'none',
+  isActive: false,
+  paddingBottom: 0,
+  paddingTop: 0
+}
+
+Button.styles = {
+  position: 'relative',
+  fontFamily: 'ui',
+  fontWeight: 500,
+  display: 'inline-flex',
+  alignItems: 'center',
+  flexWrap: 'nowrap'
+}
+
+export default Button

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -1,84 +1,13 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { dimensions, spacing, position, layout } from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import Button from './Button'
 
-class IconButton extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the dimensions spec from the Box primitive.
-     */
-    ...dimensions.propTypes,
-
-    /**
-     * Composes the spacing spec from the Box primitive.
-     */
-    ...spacing.propTypes,
-
-    /**
-     * Composes the position spec from the Box primitive.
-     */
-    ...position.propTypes,
-
-    /**
-     * Composes the layout spec from the Box primitive.
-     */
-    ...layout.propTypes,
-
-    /**
-     * The Evergreen icon or custom icon to render
-     */
-    icon: PropTypes.node,
-
-    /**
-     * Specifies an explicit icon size instead of the default value
-     */
-    iconSize: PropTypes.number,
-
-    /**
-     * The intent of the button.
-     */
-    intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger'])
-      .isRequired,
-
-    /**
-     * The appearance of the button.
-     */
-    appearance: PropTypes.oneOf(['default', 'minimal', 'primary']).isRequired,
-
-    /**
-     * Forcefully set the active state of a button.
-     * Useful in conjuction with a Popover.
-     */
-    isActive: PropTypes.bool,
-
-    /**
-     * When true, the button is disabled.
-     * isLoading also sets the button to disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the button.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    intent: 'none',
-    appearance: 'default',
-    height: 32
-  }
-
-  render() {
-    const { theme, icon, iconSize, height, intent, ...props } = this.props
+const IconButton = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { icon, iconSize, height, intent, ...restProps } = props
 
     let iconWithProps
     if (icon && React.isValidElement(icon)) {
@@ -91,6 +20,7 @@ class IconButton extends PureComponent {
 
     return (
       <Button
+        ref={ref}
         intent={intent}
         height={height}
         width={height}
@@ -98,12 +28,78 @@ class IconButton extends PureComponent {
         paddingRight={0}
         display="flex"
         justifyContent="center"
-        {...props}
+        {...restProps}
       >
         {iconWithProps}
       </Button>
     )
-  }
+  })
+)
+
+IconButton.propTypes = {
+  /**
+   * Composes the dimensions spec from the Box primitive.
+   */
+  ...dimensions.propTypes,
+
+  /**
+   * Composes the spacing spec from the Box primitive.
+   */
+  ...spacing.propTypes,
+
+  /**
+   * Composes the position spec from the Box primitive.
+   */
+  ...position.propTypes,
+
+  /**
+   * Composes the layout spec from the Box primitive.
+   */
+  ...layout.propTypes,
+
+  /**
+   * The Evergreen icon or custom icon to render
+   */
+  icon: PropTypes.node,
+
+  /**
+   * Specifies an explicit icon size instead of the default value
+   */
+  iconSize: PropTypes.number,
+
+  /**
+   * The intent of the button.
+   */
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+
+  /**
+   * The appearance of the button.
+   */
+  appearance: PropTypes.oneOf(['default', 'minimal', 'primary']).isRequired,
+
+  /**
+   * Forcefully set the active state of a button.
+   * Useful in conjuction with a Popover.
+   */
+  isActive: PropTypes.bool,
+
+  /**
+   * When true, the button is disabled.
+   * isLoading also sets the button to disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Class name passed to the button.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(IconButton)
+IconButton.defaultProps = {
+  intent: 'none',
+  appearance: 'default',
+  height: 32
+}
+
+export default IconButton

--- a/src/buttons/src/TextDropdownButton.js
+++ b/src/buttons/src/TextDropdownButton.js
@@ -1,82 +1,17 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { dimensions, spacing, position, layout } from 'ui-box'
 import { IconWrapper } from '../../icons/src/IconWrapper'
 import { CaretDownIcon } from '../../icons'
 import { Text } from '../../typography'
 import { Spinner } from '../../spinner'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class TextDropdownButton extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the dimensions spec from the Box primitive.
-     */
-    ...dimensions.propTypes,
-
-    /**
-     * Composes the spacing spec from the Box primitive.
-     */
-    ...spacing.propTypes,
-
-    /**
-     * Composes the position spec from the Box primitive.
-     */
-    ...position.propTypes,
-
-    /**
-     * Composes the layout spec from the Box primitive.
-     */
-    ...layout.propTypes,
-
-    /**
-     * Forcefully set the active state of a button.
-     * Useful in conjuction with a Popover.
-     */
-    isActive: PropTypes.bool,
-
-    /**
-     * When true, the button is disabled.
-     * isLoading also sets the button to disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * An Evergreen icon or custom icon node. By default it uses <CaretDownIcon />
-     */
-    icon: PropTypes.node,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the button.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    isActive: false,
-    icon: <CaretDownIcon />
-  }
-
-  static styles = {
-    position: 'relative',
-    fontFamily: 'ui',
-    fontWeight: 500,
-    display: 'inline-flex',
-    alignItems: 'center',
-    flexWrap: 'nowrap'
-  }
-
-  render() {
+const TextDropdownButton = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
     const {
-      theme,
       className,
-
       intent,
       height,
       isActive,
@@ -94,14 +29,15 @@ class TextDropdownButton extends PureComponent {
       // Icons
       icon,
 
-      ...props
-    } = this.props
+      ...restProps
+    } = props
 
     const themedClassName = theme.getTextDropdownButtonClassName()
 
     return (
       <Text
         is="button"
+        ref={ref}
         className={themedClassName}
         paddingX={4}
         marginX={-4}
@@ -110,7 +46,7 @@ class TextDropdownButton extends PureComponent {
         size={300}
         data-active={isActive}
         {...TextDropdownButton.styles}
-        {...props}
+        {...restProps}
         disabled={disabled}
       >
         {isLoading && (
@@ -124,7 +60,66 @@ class TextDropdownButton extends PureComponent {
         <IconWrapper icon={icon} marginLeft={2} color="default" size={12} />
       </Text>
     )
-  }
+  })
+)
+
+TextDropdownButton.propTypes = {
+  /**
+   * Composes the dimensions spec from the Box primitive.
+   */
+  ...dimensions.propTypes,
+
+  /**
+   * Composes the spacing spec from the Box primitive.
+   */
+  ...spacing.propTypes,
+
+  /**
+   * Composes the position spec from the Box primitive.
+   */
+  ...position.propTypes,
+
+  /**
+   * Composes the layout spec from the Box primitive.
+   */
+  ...layout.propTypes,
+
+  /**
+   * Forcefully set the active state of a button.
+   * Useful in conjuction with a Popover.
+   */
+  isActive: PropTypes.bool,
+
+  /**
+   * When true, the button is disabled.
+   * isLoading also sets the button to disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * An Evergreen icon or custom icon node. By default it uses <CaretDownIcon />
+   */
+  icon: PropTypes.node,
+
+  /**
+   * Class name passed to the button.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(TextDropdownButton)
+TextDropdownButton.defaultProps = {
+  isActive: false,
+  icon: <CaretDownIcon />
+}
+
+TextDropdownButton.styles = {
+  position: 'relative',
+  fontFamily: 'ui',
+  fontWeight: 500,
+  display: 'inline-flex',
+  alignItems: 'center',
+  flexWrap: 'nowrap'
+}
+
+export default TextDropdownButton

--- a/src/colors/stories/ColorExamples.js
+++ b/src/colors/stories/ColorExamples.js
@@ -8,58 +8,58 @@ function capitalize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase()
 }
 
-export default class ColorExamples extends React.Component {
-  render() {
-    return (
-      <ThemeConsumer>
-        {theme => (
-          <Pane {...this.props}>
-            <Pane clearfix>
-              <Heading size={800}>Palette</Heading>
-              {Object.keys(theme.palette).map(key => {
-                return (
-                  <ColorGroup
-                    key={key}
-                    title={capitalize(key)}
-                    colorGroup={theme.palette[key]}
-                    name={childKey => `theme.palette.${key}.${childKey}`}
-                  />
-                )
-              })}
-            </Pane>
-            <Pane clearfix>
-              <Heading size={800} marginTop="default">
-                Functional Colors
-              </Heading>
-              {Object.keys(theme.colors).map(key => {
-                return (
-                  <ColorGroup
-                    key={key}
-                    title={capitalize(key)}
-                    colorGroup={theme.colors[key]}
-                    name={childKey => `theme.colors.${key}.${childKey}`}
-                  />
-                )
-              })}
-            </Pane>
-            <Pane clearfix>
-              <Heading size={800} marginTop="default">
-                Scales
-              </Heading>
-              {Object.keys(theme.scales).map(key => {
-                return (
-                  <ColorGroup
-                    key={key}
-                    title={capitalize(key)}
-                    colorGroup={theme.scales[key]}
-                    name={childKey => `theme.scales.${key}.${childKey}`}
-                  />
-                )
-              })}
-            </Pane>
+const ColorExamples = props => {
+  return (
+    <ThemeConsumer>
+      {theme => (
+        <Pane {...props}>
+          <Pane clearfix>
+            <Heading size={800}>Palette</Heading>
+            {Object.keys(theme.palette).map(key => {
+              return (
+                <ColorGroup
+                  key={key}
+                  title={capitalize(key)}
+                  colorGroup={theme.palette[key]}
+                  name={childKey => `theme.palette.${key}.${childKey}`}
+                />
+              )
+            })}
           </Pane>
-        )}
-      </ThemeConsumer>
-    )
-  }
+          <Pane clearfix>
+            <Heading size={800} marginTop="default">
+              Functional Colors
+            </Heading>
+            {Object.keys(theme.colors).map(key => {
+              return (
+                <ColorGroup
+                  key={key}
+                  title={capitalize(key)}
+                  colorGroup={theme.colors[key]}
+                  name={childKey => `theme.colors.${key}.${childKey}`}
+                />
+              )
+            })}
+          </Pane>
+          <Pane clearfix>
+            <Heading size={800} marginTop="default">
+              Scales
+            </Heading>
+            {Object.keys(theme.scales).map(key => {
+              return (
+                <ColorGroup
+                  key={key}
+                  title={capitalize(key)}
+                  colorGroup={theme.scales[key]}
+                  name={childKey => `theme.scales.${key}.${childKey}`}
+                />
+              )
+            })}
+          </Pane>
+        </Pane>
+      )}
+    </ThemeConsumer>
+  )
 }
+
+export default ColorExamples

--- a/src/form-field/src/FormFieldValidationMessage.js
+++ b/src/form-field/src/FormFieldValidationMessage.js
@@ -1,40 +1,26 @@
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
+import React, { memo, forwardRef } from 'react'
 import { Paragraph } from '../../typography'
-import { withTheme } from '../../theme'
 import { ErrorIcon } from '../../icons'
 import { Pane } from '../../layers'
 
-class FormFieldValidationMessage extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Pane component as the base.
-     */
-    ...Pane.propTypes,
-
-    /**
-     * The contents of the validation message.
-     * This is wrapped in a paragraph, use a string.
-     */
-    children: PropTypes.node,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  render() {
-    const { theme, children, ...props } = this.props
+const FormFieldValidationMessage = memo(
+  forwardRef(({ children, ...props }, ref) => {
     return (
-      <Pane display="flex" {...props}>
+      <Pane ref={ref} display="flex" {...props}>
         <ErrorIcon color="danger" marginTop={1} size={14} marginRight={8} />
         <Paragraph marginTop={0} size={300} color="danger" role="alert">
           {children}
         </Paragraph>
       </Pane>
     )
-  }
+  })
+)
+
+FormFieldValidationMessage.propTypes = {
+  /**
+   * Composes the Pane component as the base.
+   */
+  ...Pane.propTypes
 }
 
-export default withTheme(FormFieldValidationMessage)
+export default FormFieldValidationMessage

--- a/src/menu/src/MenuDivider.js
+++ b/src/menu/src/MenuDivider.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Pane } from '../../layers'
 
-export default class MenuDivider extends React.PureComponent {
-  render() {
-    return <Pane borderBottom />
-  }
+const MenuDivider = () => {
+  return <Pane borderBottom />
 }
+
+export default MenuDivider

--- a/src/menu/src/MenuOptionsGroup.js
+++ b/src/menu/src/MenuOptionsGroup.js
@@ -1,45 +1,22 @@
-import React from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Heading } from '../../typography'
-import { withTheme } from '../../theme'
 import MenuOption from './MenuOption'
 
-class MenuOptionsGroup extends React.PureComponent {
-  static propTypes = {
-    /**
-     * Title of the menu group.
-     */
-    title: PropTypes.node,
-
-    /**
-     * The current value of the option group.
-     */
-    selected: PropTypes.any,
-
-    /**
-     * Function called when selection changes.
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * List of options rendered in the group.
-     */
-    options: PropTypes.array
-  }
-
-  render() {
-    const { title, options, selected, onChange } = this.props
+const MenuOptionsGroup = memo(
+  forwardRef((props, ref) => {
+    const { title, options, selected, onChange } = props
 
     return (
-      <Pane paddingY={8}>
+      <Pane ref={ref} paddingY={8}>
         {title && (
           <Heading size={100} marginLeft={44} marginRight={16} marginY={8}>
             {title}
           </Heading>
         )}
         <Pane>
-          {options.map((option) => {
+          {options.map(option => {
             return (
               <MenuOption
                 key={option.value}
@@ -53,7 +30,29 @@ class MenuOptionsGroup extends React.PureComponent {
         </Pane>
       </Pane>
     )
-  }
+  })
+)
+
+MenuOptionsGroup.propTypes = {
+  /**
+   * Title of the menu group.
+   */
+  title: PropTypes.node,
+
+  /**
+   * The current value of the option group.
+   */
+  selected: PropTypes.any,
+
+  /**
+   * Function called when selection changes.
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * List of options rendered in the group.
+   */
+  options: PropTypes.array
 }
 
-export default withTheme(MenuOptionsGroup)
+export default MenuOptionsGroup

--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -1,26 +1,15 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import Box, { splitBoxProps } from 'ui-box'
 import { SearchIcon } from '../../icons'
 import { TextInput } from '../../text-input'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import { StackingOrder } from '../../constants'
 
-class SearchInput extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the TextInput component as the base.
-     */
-    ...TextInput.propTypes
-  }
-
-  static defaultProps = {
-    height: 32,
-    appearance: 'default'
-  }
-
-  render() {
-    const { theme, appearance, disabled, height, ...props } = this.props
-    const { matchedProps, remainingProps } = splitBoxProps(props)
+const SearchInput = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { appearance, disabled, height, ...restProps } = props
+    const { matchedProps, remainingProps } = splitBoxProps(restProps)
     const { width } = matchedProps
     const iconSize = theme.getIconSizeForInput(height)
 
@@ -29,6 +18,7 @@ class SearchInput extends PureComponent {
         position="relative"
         display="inline-flex"
         height={height}
+        innerRef={ref}
         {...matchedProps}
       >
         <Box
@@ -57,7 +47,19 @@ class SearchInput extends PureComponent {
         />
       </Box>
     )
-  }
+  })
+)
+
+SearchInput.propTypes = {
+  /**
+   * Composes the TextInput component as the base.
+   */
+  ...TextInput.propTypes
 }
 
-export default withTheme(SearchInput)
+SearchInput.defaultProps = {
+  height: 32,
+  appearance: 'default'
+}
+
+export default SearchInput

--- a/src/segmented-control/src/SegmentedControlRadio.js
+++ b/src/segmented-control/src/SegmentedControlRadio.js
@@ -1,10 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { css } from 'glamor'
 import cx from 'classnames'
 import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
 const labelClass = css({
   display: 'flex',
@@ -41,73 +41,11 @@ const offscreenCss = css({
   clip: 'rect(0 0 0 0)'
 })
 
-class SegmentedControlRadio extends PureComponent {
-  static propTypes = {
-    /**
-     * The name attribute of the radio input.
-     */
-    name: PropTypes.string.isRequired,
+const SegmentedControlRadio = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
 
-    /**
-     * The label used for the radio.
-     */
-    label: PropTypes.node.isRequired,
-
-    /**
-     * The value attribute of the radio input.
-     */
-    value: PropTypes.string.isRequired,
-
-    /**
-     * The height of the control.
-     */
-    height: PropTypes.number.isRequired,
-
-    /**
-     * When true, the radio input is checked.
-     */
-    checked: PropTypes.bool.isRequired,
-
-    /**
-     * Function called when the state changes.
-     */
-    onChange: PropTypes.func.isRequired,
-
-    /**
-     * The appearance of the control. Currently only `default` is possible.
-     */
-    appearance: PropTypes.string.isRequired,
-
-    /**
-     * When true, this item is the first item.
-     */
-    isFirstItem: PropTypes.bool,
-
-    /**
-     * When true, this item is the last item.
-     */
-    isLastItem: PropTypes.bool,
-
-    /**
-     * The unique id of the radio option.
-     */
-    id: PropTypes.string,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * When true, the input is disabled.
-     */
-    disabled: PropTypes.bool
-  }
-
-  render() {
     const {
-      theme,
-
       id,
       name,
       label,
@@ -119,7 +57,7 @@ class SegmentedControlRadio extends PureComponent {
       isFirstItem,
       isLastItem,
       disabled
-    } = this.props
+    } = props
 
     const themedClassName = theme.getSegmentedControlRadioClassName(appearance)
     const textSize = theme.getTextSizeForControlHeight(height)
@@ -127,6 +65,7 @@ class SegmentedControlRadio extends PureComponent {
 
     return (
       <Box
+        innerRef={ref}
         className={cx(wrapperClass.toString(), themedClassName)}
         data-active={checked}
         {...(isFirstItem
@@ -165,7 +104,64 @@ class SegmentedControlRadio extends PureComponent {
         </Text>
       </Box>
     )
-  }
+  })
+)
+
+SegmentedControlRadio.propTypes = {
+  /**
+   * The name attribute of the radio input.
+   */
+  name: PropTypes.string.isRequired,
+
+  /**
+   * The label used for the radio.
+   */
+  label: PropTypes.node.isRequired,
+
+  /**
+   * The value attribute of the radio input.
+   */
+  value: PropTypes.string.isRequired,
+
+  /**
+   * The height of the control.
+   */
+  height: PropTypes.number.isRequired,
+
+  /**
+   * When true, the radio input is checked.
+   */
+  checked: PropTypes.bool.isRequired,
+
+  /**
+   * Function called when the state changes.
+   */
+  onChange: PropTypes.func.isRequired,
+
+  /**
+   * The appearance of the control. Currently only `default` is possible.
+   */
+  appearance: PropTypes.string.isRequired,
+
+  /**
+   * When true, this item is the first item.
+   */
+  isFirstItem: PropTypes.bool,
+
+  /**
+   * When true, this item is the last item.
+   */
+  isLastItem: PropTypes.bool,
+
+  /**
+   * The unique id of the radio option.
+   */
+  id: PropTypes.string,
+
+  /**
+   * When true, the input is disabled.
+   */
+  disabled: PropTypes.bool
 }
 
-export default withTheme(SegmentedControlRadio)
+export default SegmentedControlRadio

--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -1,98 +1,14 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box, { dimensions, spacing, position, layout } from 'ui-box'
 import { Text } from '../../typography'
 import { CaretDownIcon } from '../../icons'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Select extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the dimensions spec from the Box primitive.
-     */
-    ...dimensions.propTypes,
-
-    /**
-     * Composes the spacing spec from the Box primitive.
-     */
-    ...spacing.propTypes,
-
-    /**
-     * Composes the position spec from the Box primitive.
-     */
-    ...position.propTypes,
-
-    /**
-     * Composes the layout spec from the Box primitive.
-     */
-    ...layout.propTypes,
-
-    /**
-     * The id attribute for the select.
-     */
-    id: PropTypes.string,
-
-    /**
-     * The name attribute for the select.
-     */
-    name: PropTypes.string,
-
-    /**
-     * The options that are passed to the select.
-     */
-    children: PropTypes.node,
-
-    /**
-     * The initial value of an uncontrolled select
-     */
-    defaultValue: PropTypes.any,
-
-    /**
-     * Function called when value changes.
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * The value of the select.
-     */
-    value: PropTypes.any,
-
-    /**
-     * When true, the select is required.
-     */
-    required: PropTypes.bool,
-
-    /**
-     * When true, the select should auto focus.
-     */
-    autoFocus: PropTypes.bool,
-
-    /**
-     * When true, the select is invalid.
-     */
-    isInvalid: PropTypes.bool,
-
-    /**
-     * The appearance of the select. The default theme only supports default.
-     */
-    appearance: PropTypes.string.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    appearance: 'default',
-    height: 32,
-    isInvalid: false
-  }
-
-  render() {
+const Select = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
     const {
-      theme,
-
       id,
       name,
       height,
@@ -105,8 +21,8 @@ class Select extends PureComponent {
       autoFocus,
       isInvalid,
       appearance,
-      ...props
-    } = this.props
+      ...restProps
+    } = props
 
     const themedClassName = theme.getSelectClassName(appearance)
     const textSize = theme.getTextSizeForControlHeight(height)
@@ -116,12 +32,13 @@ class Select extends PureComponent {
 
     return (
       <Box
+        innerRef={ref}
         display="inline-flex"
         flex={1}
         position="relative"
         width="auto"
         height={height}
-        {...props}
+        {...restProps}
       >
         <Text
           is="select"
@@ -155,7 +72,85 @@ class Select extends PureComponent {
         />
       </Box>
     )
-  }
+  })
+)
+
+Select.propTypes = {
+  /**
+   * Composes the dimensions spec from the Box primitive.
+   */
+  ...dimensions.propTypes,
+
+  /**
+   * Composes the spacing spec from the Box primitive.
+   */
+  ...spacing.propTypes,
+
+  /**
+   * Composes the position spec from the Box primitive.
+   */
+  ...position.propTypes,
+
+  /**
+   * Composes the layout spec from the Box primitive.
+   */
+  ...layout.propTypes,
+
+  /**
+   * The id attribute for the select.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The name attribute for the select.
+   */
+  name: PropTypes.string,
+
+  /**
+   * The options that are passed to the select.
+   */
+  children: PropTypes.node,
+
+  /**
+   * The initial value of an uncontrolled select
+   */
+  defaultValue: PropTypes.any,
+
+  /**
+   * Function called when value changes.
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * The value of the select.
+   */
+  value: PropTypes.any,
+
+  /**
+   * When true, the select is required.
+   */
+  required: PropTypes.bool,
+
+  /**
+   * When true, the select should auto focus.
+   */
+  autoFocus: PropTypes.bool,
+
+  /**
+   * When true, the select is invalid.
+   */
+  isInvalid: PropTypes.bool,
+
+  /**
+   * The appearance of the select. The default theme only supports default.
+   */
+  appearance: PropTypes.string.isRequired
 }
 
-export default withTheme(Select)
+Select.defaultProps = {
+  appearance: 'default',
+  height: 32,
+  isInvalid: false
+}
+
+export default Select

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -1,5 +1,5 @@
+import React, { memo, forwardRef } from 'react'
 import { css } from 'glamor'
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Overlay } from '../../overlay'
@@ -62,14 +62,10 @@ const ANIMATION_DURATION = 240
 const withAnimations = (animateIn, animateOut) => {
   return {
     '&[data-state="entering"], &[data-state="entered"]': {
-      animation: `${animateIn} ${ANIMATION_DURATION}ms ${
-        animationEasing.deceleration
-      } both`
+      animation: `${animateIn} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
     },
     '&[data-state="exiting"]': {
-      animation: `${animateOut} ${ANIMATION_DURATION}ms ${
-        animationEasing.acceleration
-      } both`
+      animation: `${animateOut} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
     }
   }
 }
@@ -129,81 +125,8 @@ const animationStylesClass = {
   }
 }
 
-class SideSheet extends React.Component {
-  static propTypes = {
-    /**
-     * Children can be a string, node or a function accepting `({ close })`.
-     */
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-
-    /**
-     * When true, the Side Sheet is shown.
-     */
-    isShown: PropTypes.bool,
-
-    /**
-     * Function that will be called when the exit transition is complete.
-     */
-    onCloseComplete: PropTypes.func,
-
-    /**
-     * Function that will be called when the enter transition is complete.
-     */
-    onOpenComplete: PropTypes.func,
-
-    /**
-     * Function called when overlay is about to close.
-     * Return `false` to prevent the sheet from closing.
-     * type: `Function -> Boolean`
-     */
-    onBeforeClose: PropTypes.func,
-
-    /**
-     * Boolean indicating if clicking the overlay should close the overlay.
-     */
-    shouldCloseOnOverlayClick: PropTypes.bool,
-
-    /**
-     * Boolean indicating if pressing the esc key should close the overlay.
-     */
-    shouldCloseOnEscapePress: PropTypes.bool,
-
-    /**
-     * Width of the SideSheet.
-     */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-
-    /**
-     * Properties to pass through the SideSheet container Pane.
-     */
-    containerProps: PropTypes.object,
-
-    /**
-     * Positions the sheet to the top, left, right, or bottom of the screen.
-     */
-    position: PropTypes.oneOf([
-      Position.TOP,
-      Position.BOTTOM,
-      Position.LEFT,
-      Position.RIGHT
-    ]).isRequired,
-
-    /**
-     * Whether or not to prevent scrolling in the outer body
-     */
-    preventBodyScrolling: PropTypes.bool
-  }
-
-  static defaultProps = {
-    width: 620,
-    onCloseComplete: () => {},
-    onOpenComplete: () => {},
-    shouldCloseOnOverlayClick: true,
-    shouldCloseOnEscapePress: true,
-    position: Position.RIGHT
-  }
-
-  render() {
+const SideSheet = memo(
+  forwardRef((props, ref) => {
     const {
       width,
       isShown,
@@ -216,10 +139,11 @@ class SideSheet extends React.Component {
       shouldCloseOnEscapePress,
       position,
       preventBodyScrolling
-    } = this.props
+    } = props
 
     return (
       <Overlay
+        ref={ref}
         isShown={isShown}
         shouldCloseOnClick={shouldCloseOnOverlayClick}
         shouldCloseOnEscapePress={shouldCloseOnEscapePress}
@@ -257,7 +181,80 @@ class SideSheet extends React.Component {
         )}
       </Overlay>
     )
-  }
+  })
+)
+
+SideSheet.propTypes = {
+  /**
+   * Children can be a string, node or a function accepting `({ close })`.
+   */
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+  /**
+   * When true, the Side Sheet is shown.
+   */
+  isShown: PropTypes.bool,
+
+  /**
+   * Function that will be called when the exit transition is complete.
+   */
+  onCloseComplete: PropTypes.func,
+
+  /**
+   * Function that will be called when the enter transition is complete.
+   */
+  onOpenComplete: PropTypes.func,
+
+  /**
+   * Function called when overlay is about to close.
+   * Return `false` to prevent the sheet from closing.
+   * type: `Function -> Boolean`
+   */
+  onBeforeClose: PropTypes.func,
+
+  /**
+   * Boolean indicating if clicking the overlay should close the overlay.
+   */
+  shouldCloseOnOverlayClick: PropTypes.bool,
+
+  /**
+   * Boolean indicating if pressing the esc key should close the overlay.
+   */
+  shouldCloseOnEscapePress: PropTypes.bool,
+
+  /**
+   * Width of the SideSheet.
+   */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+
+  /**
+   * Properties to pass through the SideSheet container Pane.
+   */
+  containerProps: PropTypes.object,
+
+  /**
+   * Positions the sheet to the top, left, right, or bottom of the screen.
+   */
+  position: PropTypes.oneOf([
+    Position.TOP,
+    Position.BOTTOM,
+    Position.LEFT,
+    Position.RIGHT
+  ]).isRequired,
+
+  /**
+   * Whether or not to prevent scrolling in the outer body
+   */
+  preventBodyScrolling: PropTypes.bool
+}
+
+SideSheet.defaultProps = {
+  width: 620,
+  onCloseComplete: () => {},
+  onOpenComplete: () => {},
+  shouldCloseOnOverlayClick: true,
+  shouldCloseOnEscapePress: true,
+  position: Position.RIGHT
 }
 
 export default SideSheet

--- a/src/tag-input/src/Tag.js
+++ b/src/tag-input/src/Tag.js
@@ -1,28 +1,15 @@
 /**
  * @overview TagInput accepts multiple values that can be individually removed
  */
-
-import React from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { Badge } from '../../badges'
 import { CrossIcon } from '../../icons'
 import { minorScale } from '../../scales'
 
-class Tag extends React.PureComponent {
-  static propTypes = {
-    /** The badge content */
-    children: PropTypes.node,
-    /**
-     * Callback invoked when the removal icon is clicked.
-     * (event) => void
-     */
-    onRemove: PropTypes.func,
-    /** Whether or not the tag can be removed. */
-    isRemovable: PropTypes.bool
-  }
-
-  render() {
-    const { children, onRemove, isRemovable, ...props } = this.props
+const Tag = memo(
+  forwardRef((props, ref) => {
+    const { children, onRemove, isRemovable, ...restProps } = props
 
     const badgeStyles = {
       alignItems: 'center',
@@ -36,7 +23,7 @@ class Tag extends React.PureComponent {
     }
 
     return (
-      <Badge isInteractive {...badgeStyles} {...props}>
+      <Badge ref={ref} isInteractive {...badgeStyles} {...restProps}>
         {children}
         {isRemovable && (
           <CrossIcon
@@ -47,7 +34,20 @@ class Tag extends React.PureComponent {
         )}
       </Badge>
     )
-  }
+  })
+)
+
+Tag.propTypes = {
+  /** The tag content */
+  children: PropTypes.node,
+
+  /**
+   * Callback invoked when the removal icon is clicked.
+   * (event) => void
+   */
+  onRemove: PropTypes.func,
+  /** Whether or not the tag can be removed. */
+  isRemovable: PropTypes.bool
 }
 
 export default Tag

--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -1,89 +1,14 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Textarea extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Text component as the base.
-     */
-    ...Text.propTypes,
-
-    /**
-     * Makes the textarea element required.
-     */
-    required: PropTypes.bool,
-
-    /**
-     * Makes the textarea element disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * Sets visual styling of _only_ the text area to be "invalid".
-     * Note that this does not effect any `validationMessage`.
-     */
-    isInvalid: PropTypes.bool,
-
-    /**
-     * Use the native spell check functionality of the browser.
-     */
-    spellCheck: PropTypes.bool,
-
-    /**
-     * Allow the Grammarly browser extension to attach to the backing textarea.
-     */
-    grammarly: PropTypes.bool,
-
-    /**
-     * The placeholder text when there is no value present.
-     */
-    placeholder: PropTypes.string,
-
-    /**
-     * The appearance of the TextInput.
-     */
-    appearance: PropTypes.string,
-
-    /**
-     * The width of the TextInput.
-     */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the button.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    appearance: 'default',
-    width: '100%',
-    disabled: false,
-    isInvalid: false,
-    spellCheck: true,
-    grammarly: false
-  }
-
-  static styles = {
-    minHeight: 80,
-    paddingX: 10,
-    paddingY: 8
-  }
-
-  render() {
+const Textarea = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
     const {
-      theme,
       className,
-
       width,
       height,
       disabled,
@@ -93,13 +18,14 @@ class Textarea extends PureComponent {
       placeholder,
       spellCheck,
       grammarly,
-      ...props
-    } = this.props
+      ...restProps
+    } = props
     const themedClassName = theme.getTextareaClassName(appearance)
 
     return (
       <Text
         is="textarea"
+        ref={ref}
         className={cx(themedClassName, className)}
         size={400}
         width={width}
@@ -115,10 +41,79 @@ class Textarea extends PureComponent {
         data-gramm_editor={grammarly}
         {...(disabled ? { color: 'muted' } : {})}
         {...Textarea.styles}
-        {...props}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Textarea.propTypes = {
+  /**
+   * Composes the Text component as the base.
+   */
+  ...Text.propTypes,
+
+  /**
+   * Makes the textarea element required.
+   */
+  required: PropTypes.bool,
+
+  /**
+   * Makes the textarea element disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Sets visual styling of _only_ the text area to be "invalid".
+   * Note that this does not effect any `validationMessage`.
+   */
+  isInvalid: PropTypes.bool,
+
+  /**
+   * Use the native spell check functionality of the browser.
+   */
+  spellCheck: PropTypes.bool,
+
+  /**
+   * Allow the Grammarly browser extension to attach to the backing textarea.
+   */
+  grammarly: PropTypes.bool,
+
+  /**
+   * The placeholder text when there is no value present.
+   */
+  placeholder: PropTypes.string,
+
+  /**
+   * The appearance of the TextInput.
+   */
+  appearance: PropTypes.string,
+
+  /**
+   * The width of the TextInput.
+   */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Class name passed to the button.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(Textarea)
+Textarea.defaultProps = {
+  appearance: 'default',
+  width: '100%',
+  disabled: false,
+  isInvalid: false,
+  spellCheck: true,
+  grammarly: false
+}
+
+Textarea.styles = {
+  minHeight: 80,
+  paddingX: 10,
+  paddingY: 8
+}
+
+export default Textarea

--- a/src/tooltip/src/TooltipStateless.js
+++ b/src/tooltip/src/TooltipStateless.js
@@ -1,26 +1,13 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Paragraph } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class TooltipStateless extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-
-    /**
-     * The appearance of the tooltip.
-     */
-    appearance: PropTypes.oneOf(['default', 'card']).isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  render() {
-    const { theme, children, appearance, ...props } = this.props
+const TooltipStateless = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { children, appearance, ...restProps } = props
     const { color, ...themedProps } = theme.getTooltipProps(appearance)
 
     let child
@@ -36,17 +23,27 @@ class TooltipStateless extends PureComponent {
 
     return (
       <Pane
+        ref={ref}
         borderRadius={3}
         paddingX={8}
         paddingY={4}
         maxWidth={240}
         {...themedProps}
-        {...props}
+        {...restProps}
       >
         {child}
       </Pane>
     )
-  }
+  })
+)
+
+TooltipStateless.propTypes = {
+  children: PropTypes.node,
+
+  /**
+   * The appearance of the tooltip.
+   */
+  appearance: PropTypes.oneOf(['default', 'card']).isRequired
 }
 
-export default withTheme(TooltipStateless)
+export default TooltipStateless

--- a/src/typography/src/Code.js
+++ b/src/typography/src/Code.js
@@ -1,36 +1,13 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import Text from './Text'
 
-class Code extends PureComponent {
-  static propTypes = {
-    ...Text.propTypes,
-
-    /**
-     * The appearance of the code.
-     */
-    appearance: PropTypes.oneOf(['default', 'minimal']).isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the button.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    appearance: 'default'
-  }
-
-  render() {
-    const { theme, className, appearance, ...props } = this.props
+const Code = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { className, appearance, ...restProps } = props
 
     const {
       className: themedClassName = '',
@@ -40,13 +17,33 @@ class Code extends PureComponent {
     return (
       <Text
         is="code"
+        ref={ref}
         className={cx(className, themedClassName)}
         fontFamily="mono"
         {...themeProps}
-        {...props}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Code.propTypes = {
+  ...Text.propTypes,
+
+  /**
+   * The appearance of the code.
+   */
+  appearance: PropTypes.oneOf(['default', 'minimal']),
+
+  /**
+   * Class name passed to the button.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(Code)
+Code.defaultProps = {
+  appearance: 'default'
+}
+
+export default Code

--- a/src/typography/src/Heading.js
+++ b/src/typography/src/Heading.js
@@ -1,42 +1,12 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Heading extends PureComponent {
-  static propTypes = {
-    /**
-     * Heading composes Box as the base.
-     */
-    ...Box.propTypes,
-
-    /**
-     * The size of the heading.
-     */
-    size: PropTypes.oneOf([100, 200, 300, 400, 500, 600, 700, 800, 900])
-      .isRequired,
-
-    /**
-     * Pass `default` to use the default margin top for that size.
-     */
-    marginTop: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.number,
-      PropTypes.string
-    ]),
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    size: 500
-  }
-
-  render() {
-    const { theme, marginTop, size, ...props } = this.props
+const Heading = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { marginTop, size, ...restProps } = props
     const {
       marginTop: defaultMarginTop,
       ...headingStyle
@@ -50,13 +20,39 @@ class Heading extends PureComponent {
     return (
       <Box
         is="h2"
+        innerRef={ref}
         marginTop={finalMarginTop || 0}
         marginBottom={0}
         {...headingStyle}
-        {...props}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Heading.propTypes = {
+  /**
+   * Heading composes Box as the base.
+   */
+  ...Box.propTypes,
+
+  /**
+   * The size of the heading.
+   */
+  size: PropTypes.oneOf([100, 200, 300, 400, 500, 600, 700, 800, 900]),
+
+  /**
+   * Pass `default` to use the default margin top for that size.
+   */
+  marginTop: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string
+  ])
 }
 
-export default withTheme(Heading)
+Heading.defaultProps = {
+  size: 500
+}
+
+export default Heading

--- a/src/typography/src/Link.js
+++ b/src/typography/src/Link.js
@@ -1,65 +1,61 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import Text from './Text'
 
-class Link extends PureComponent {
-  static propTypes = {
-    ...Text.propTypes,
-
-    /**
-     * This attribute names a relationship of the linked document to the current document.
-     * Common use case is: rel="noopener noreferrer".
-     */
-    rel: PropTypes.string,
-
-    /**
-     * Specifies the URL of the linked resource. A URL might be absolute or relative.
-     */
-    href: PropTypes.string,
-
-    /**
-     * Target atrribute, common use case is target="_blank."
-     */
-    target: PropTypes.string,
-
-    /**
-     * The color (and styling) of the Link. Can be default, blue, green or neutral.
-     */
-    color: PropTypes.string.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the link.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    color: 'default'
-  }
-
-  render() {
-    const { theme, className, color, ...props } = this.props
-
+const Link = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { className, color, ...restProps } = props
     const themedClassName = theme.getLinkClassName(color)
 
     return (
       <Text
         is="a"
+        ref={ref}
         className={cx(className, themedClassName)}
         textDecoration="underline"
         color={null}
-        {...props}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Link.propTypes = {
+  ...Text.propTypes,
+
+  /**
+   * This attribute names a relationship of the linked document to the current document.
+   * Common use case is: rel="noopener noreferrer".
+   */
+  rel: PropTypes.string,
+
+  /**
+   * Specifies the URL of the linked resource. A URL might be absolute or relative.
+   */
+  href: PropTypes.string,
+
+  /**
+   * Target atrribute, common use case is target="_blank."
+   */
+  target: PropTypes.string,
+
+  /**
+   * The color (and styling) of the Link. Can be default, blue, green or neutral.
+   */
+  color: PropTypes.string,
+
+  /**
+   * Class name passed to the link.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(Link)
+Link.defaultProps = {
+  color: 'default'
+}
+
+export default Link

--- a/src/typography/src/Paragraph.js
+++ b/src/typography/src/Paragraph.js
@@ -1,41 +1,12 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Paragraph extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Box component as the base.
-     */
-    ...Box.propTypes,
-
-    /**
-     * Size of the text style.
-     * Can be: 300, 400, 500.
-     */
-    size: PropTypes.oneOf([300, 400, 500]).isRequired,
-
-    /**
-     * Font family.
-     * Can be: `ui`, `display` or `mono` or a custom font family.
-     */
-    fontFamily: PropTypes.string.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    size: 400,
-    color: 'default',
-    fontFamily: 'ui'
-  }
-
-  render() {
-    const { theme, size, color, fontFamily, marginTop, ...props } = this.props
+const Paragraph = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
+    const { size, color, fontFamily, marginTop, ...restProps } = props
 
     const {
       marginTop: defaultMarginTop,
@@ -48,15 +19,41 @@ class Paragraph extends PureComponent {
     return (
       <Box
         is="p"
+        innerRef={ref}
         color={theme.getTextColor(color)}
         fontFamily={theme.getFontFamily(fontFamily)}
         marginTop={finalMarginTop || 0}
         marginBottom={0}
         {...textStyle}
-        {...props}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Paragraph.propTypes = {
+  /**
+   * Composes the Box component as the base.
+   */
+  ...Box.propTypes,
+
+  /**
+   * Size of the text style.
+   * Can be: 300, 400, 500.
+   */
+  size: PropTypes.oneOf([300, 400, 500]).isRequired,
+
+  /**
+   * Font family.
+   * Can be: `ui`, `display` or `mono` or a custom font family.
+   */
+  fontFamily: PropTypes.string.isRequired
 }
 
-export default withTheme(Paragraph)
+Paragraph.defaultProps = {
+  size: 400,
+  color: 'default',
+  fontFamily: 'ui'
+}
+
+export default Paragraph

--- a/src/typography/src/Small.js
+++ b/src/typography/src/Small.js
@@ -1,11 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import Box from 'ui-box'
 
-/**
- * Small can only be used inside of Text or Paragraph.
- */
-export default class Small extends PureComponent {
-  render() {
-    return <Box is="small" fontSize="85%" {...this.props} />
-  }
-}
+const Small = memo(
+  forwardRef((props, ref) => {
+    return <Box innerRef={ref} is="small" fontSize="85%" {...props} />
+  })
+)
+
+export default Small

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -1,52 +1,22 @@
+import React, { memo, forwardRef } from 'react'
 import cx from 'classnames'
 import { css as glamorCss } from 'glamor'
-import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Text extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Box component as the base.
-     */
-    ...Box.propTypes,
-
-    /**
-     * Size of the text style.
-     * Can be: 300, 400, 500, 600.
-     */
-    size: PropTypes.oneOf([300, 400, 500, 600]).isRequired,
-
-    /**
-     * Font family.
-     * Can be: `ui`, `display` or `mono` or a custom font family.
-     */
-    fontFamily: PropTypes.string.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    size: 400,
-    color: 'default',
-    fontFamily: 'ui'
-  }
-
-  render() {
+const Text = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
     const {
       className,
       css,
-      theme,
       size,
       color,
       fontFamily,
       marginTop,
-      ...props
-    } = this.props
+      ...restProps
+    } = props
 
     const { marginTop: defaultMarginTop, ...textStyle } = theme.getTextStyle(
       size
@@ -58,15 +28,41 @@ class Text extends PureComponent {
     return (
       <Box
         is="span"
+        innerRef={ref}
         color={theme.getTextColor(color)}
         fontFamily={theme.getFontFamily(fontFamily)}
         marginTop={finalMarginTop}
         {...textStyle}
         className={cx(className, css ? glamorCss(css).toString() : undefined)}
-        {...props}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Text.propTypes = {
+  /**
+   * Composes the Box component as the base.
+   */
+  ...Box.propTypes,
+
+  /**
+   * Size of the text style.
+   * Can be: 300, 400, 500, 600.
+   */
+  size: PropTypes.oneOf([300, 400, 500, 600]),
+
+  /**
+   * Font family.
+   * Can be: `ui`, `display` or `mono` or a custom font family.
+   */
+  fontFamily: PropTypes.string
 }
 
-export default withTheme(Text)
+Text.defaultProps = {
+  size: 400,
+  color: 'default',
+  fontFamily: 'ui'
+}
+
+export default Text


### PR DESCRIPTION
## Overview 
This PR codemods a bunch of PureComponents -> React.FC + memo + forwardRef where it could be done automatically. I had to manually switch from `withTheme` to `useTheme`.

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Added / modified component docs 
- [x] Added / modified Storybook stories


## Screenshots (if applicable) 
![Screen Shot 2020-05-13 at 1 53 32 PM](https://user-images.githubusercontent.com/710752/81853160-b7e63c00-9521-11ea-9449-69c88aa6a466.png)
![Screen Shot 2020-05-13 at 1 57 15 PM](https://user-images.githubusercontent.com/710752/81853167-b9afff80-9521-11ea-914c-106edccd6c4a.png)
![Screen Shot 2020-05-13 at 1 57 08 PM](https://user-images.githubusercontent.com/710752/81853168-b9afff80-9521-11ea-8853-c4b13e289462.png)
![Screen Shot 2020-05-13 at 1 57 01 PM](https://user-images.githubusercontent.com/710752/81853169-ba489600-9521-11ea-8ea0-c61ac3b3609a.png)
![Screen Shot 2020-05-13 at 1 56 54 PM](https://user-images.githubusercontent.com/710752/81853170-ba489600-9521-11ea-9950-6cb6973389dc.png)
![Screen Shot 2020-05-13 at 1 56 49 PM](https://user-images.githubusercontent.com/710752/81853171-ba489600-9521-11ea-9f81-50a1507895d3.png)
![Screen Shot 2020-05-13 at 1 56 42 PM](https://user-images.githubusercontent.com/710752/81853174-bae12c80-9521-11ea-808d-46dc0e7fa909.png)
![Screen Shot 2020-05-13 at 1 56 20 PM](https://user-images.githubusercontent.com/710752/81853175-bae12c80-9521-11ea-9b72-43ca666de947.png)
![Screen Shot 2020-05-13 at 1 56 06 PM](https://user-images.githubusercontent.com/710752/81853177-bae12c80-9521-11ea-88e9-521dcf26e234.png)
![Screen Shot 2020-05-13 at 1 55 52 PM](https://user-images.githubusercontent.com/710752/81853178-bb79c300-9521-11ea-873e-dc60f4a12822.png)
![Screen Shot 2020-05-13 at 1 55 40 PM](https://user-images.githubusercontent.com/710752/81853180-bb79c300-9521-11ea-9b27-54dfb1b26c93.png)
![Screen Shot 2020-05-13 at 1 55 25 PM](https://user-images.githubusercontent.com/710752/81853181-bb79c300-9521-11ea-8a27-9e395ed1f601.png)
![Screen Shot 2020-05-13 at 1 55 13 PM](https://user-images.githubusercontent.com/710752/81853182-bc125980-9521-11ea-8503-41fd6cd71c05.png)
![Screen Shot 2020-05-13 at 1 54 47 PM](https://user-images.githubusercontent.com/710752/81853183-bc125980-9521-11ea-8e1e-36000bd8cd72.png)
![Screen Shot 2020-05-13 at 1 54 30 PM](https://user-images.githubusercontent.com/710752/81853184-bc125980-9521-11ea-8ad5-f6a593d85808.png)
![Screen Shot 2020-05-13 at 1 54 28 PM](https://user-images.githubusercontent.com/710752/81853185-bc125980-9521-11ea-8d89-27243503a29c.png)
![Screen Shot 2020-05-13 at 1 54 26 PM](https://user-images.githubusercontent.com/710752/81853186-bcaaf000-9521-11ea-88fe-1ed2f9b1d662.png)
![Screen Shot 2020-05-13 at 1 54 21 PM](https://user-images.githubusercontent.com/710752/81853187-bcaaf000-9521-11ea-9392-91e5e825deae.png)
![Screen Shot 2020-05-13 at 1 53 37 PM](https://user-images.githubusercontent.com/710752/81853188-bcaaf000-9521-11ea-9c79-50d36d50860a.png)
