### PR TITLE
Bump <Textarea /> and <TextareaField /> to memo + forwardRef

### DIFF
--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -1,100 +1,32 @@
-import React, { PureComponent } from 'react'
+import React, { forwardRef, memo } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class Textarea extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Text component as the base.
-     */
-    ...Text.propTypes,
+const styles = {
+  minHeight: 80,
+  paddingX: 10,
+  paddingY: 8
+}
 
-    /**
-     * Makes the textarea element required.
-     */
-    required: PropTypes.bool,
-
-    /**
-     * Makes the textarea element disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * Sets visual styling of _only_ the text area to be "invalid".
-     * Note that this does not effect any `validationMessage`.
-     */
-    isInvalid: PropTypes.bool,
-
-    /**
-     * Use the native spell check functionality of the browser.
-     */
-    spellCheck: PropTypes.bool,
-
-    /**
-     * Allow the Grammarly browser extension to attach to the backing textarea.
-     */
-    grammarly: PropTypes.bool,
-
-    /**
-     * The placeholder text when there is no value present.
-     */
-    placeholder: PropTypes.string,
-
-    /**
-     * The appearance of the TextInput.
-     */
-    appearance: PropTypes.string,
-
-    /**
-     * The width of the TextInput.
-     */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired,
-
-    /**
-     * Class name passed to the button.
-     * Only use if you know what you are doing.
-     */
-    className: PropTypes.string
-  }
-
-  static defaultProps = {
-    appearance: 'default',
-    width: '100%',
-    disabled: false,
-    isInvalid: false,
-    spellCheck: true,
-    grammarly: false
-  }
-
-  static styles = {
-    minHeight: 80,
-    paddingX: 10,
-    paddingY: 8
-  }
-
-  render() {
+const Textarea = memo(
+  forwardRef((props, ref) => {
     const {
-      theme,
       className,
-
-      width,
-      height,
-      disabled,
       required,
-      isInvalid,
-      appearance,
       placeholder,
-      spellCheck,
-      grammarly,
-      ...props
-    } = this.props
+      height,
+      width = 280,
+      disabled = false,
+      isInvalid = false,
+      appearance = 'default',
+      spellCheck = true,
+      grammarly = false,
+      ...restProps
+    } = props
+    const theme = useTheme()
+
     const themedClassName = theme.getTextareaClassName(appearance)
 
     return (
@@ -114,11 +46,71 @@ class Textarea extends PureComponent {
         aria-invalid={isInvalid}
         data-gramm_editor={grammarly}
         {...(disabled ? { color: 'muted' } : {})}
-        {...Textarea.styles}
-        {...props}
+        ref={ref}
+        {...styles}
+        {...restProps}
       />
     )
-  }
+  })
+)
+
+Textarea.propTypes = {
+  /**
+   * Composes the Text component as the base.
+   */
+  ...Text.propTypes,
+
+  /**
+   * Makes the textarea element required.
+   */
+  required: PropTypes.bool,
+
+  /**
+   * Makes the textarea element disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Sets visual styling of _only_ the text area to be "invalid".
+   * Note that this does not effect any `validationMessage`.
+   */
+  isInvalid: PropTypes.bool,
+
+  /**
+   * Use the native spell check functionality of the browser.
+   */
+  spellCheck: PropTypes.bool,
+
+  /**
+   * Allow the Grammarly browser extension to attach to the backing textarea.
+   */
+  grammarly: PropTypes.bool,
+
+  /**
+   * The placeholder text when there is no value present.
+   */
+  placeholder: PropTypes.string,
+
+  /**
+   * The appearance of the TextInput.
+   */
+  appearance: PropTypes.string,
+
+  /**
+   * The width of the TextInput.
+   */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Theme provided by ThemeProvider.
+   */
+  theme: PropTypes.object.isRequired,
+
+  /**
+   * Class name passed to the button.
+   * Only use if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
-export default withTheme(Textarea)
+export default Textarea

--- a/src/textarea/src/TextareaField.js
+++ b/src/textarea/src/TextareaField.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { splitBoxProps } from 'ui-box'
 import { FormField } from '../../form-field'
@@ -6,64 +6,10 @@ import Textarea from './Textarea'
 
 let idCounter = 0
 
-export default class TextareaField extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Textarea component as the base.
-     */
-    ...Textarea.propTypes,
-    ...FormField.propTypes,
+const TextareaField = memo(
+  forwardRef((props, ref) => {
+    const [id] = useState(props.id || `TextareaField-${idCounter++}`)
 
-    /**
-     * The label used above the input element.
-     */
-    label: PropTypes.node.isRequired,
-
-    /**
-     * Whether or not to show an asterix after the label.
-     */
-    required: PropTypes.bool,
-
-    /**
-     * An optional description of the field under the label, above the input element.
-     */
-    description: PropTypes.node,
-
-    /**
-     * An optional hint under the input element.
-     */
-    hint: PropTypes.node,
-
-    /**
-     * If a validation message is passed it is shown under the input element
-     * and above the hint. This is unaffected by `isInvalid`.
-     */
-    validationMessage: PropTypes.node,
-
-    /**
-     * The height of the input element.
-     */
-    inputHeight: PropTypes.number,
-
-    /**
-     * The width of the input width.
-     */
-    inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-  }
-
-  static defaultProps = {
-    /**
-     * The input width should be as wide as the form field.
-     */
-    inputWidth: '100%',
-    inputHeight: 80
-  }
-
-  state = {
-    id: (this.props.id || idCounter++).toString()
-  }
-
-  render() {
     const {
       // We are using the id from the state
       id: unusedId,
@@ -75,20 +21,18 @@ export default class TextareaField extends PureComponent {
       validationMessage,
 
       // Textarea props
-      inputHeight,
-      inputWidth,
       disabled,
       required,
       isInvalid,
       appearance,
       placeholder,
       spellCheck,
+      inputHeight = 80,
+      inputWidth = '100%',
 
       // Rest props are spread on the FormField
-      ...props
-    } = this.props
-
-    const id = `TextareaField-${this.state.id}`
+      ...restProps
+    } = props
 
     /**
      * Split the wrapper props from the input props.
@@ -105,6 +49,7 @@ export default class TextareaField extends PureComponent {
         validationMessage={validationMessage}
         labelFor={id}
         {...matchedProps}
+        {...restProps}
       >
         <Textarea
           id={id}
@@ -116,9 +61,56 @@ export default class TextareaField extends PureComponent {
           appearance={appearance}
           placeholder={placeholder}
           spellCheck={spellCheck}
+          ref={ref}
           {...remainingProps}
         />
       </FormField>
     )
-  }
+  })
+)
+
+TextareaField.propTypes = {
+  /**
+   * Composes the Textarea component as the base.
+   */
+  ...Textarea.propTypes,
+  ...FormField.propTypes,
+
+  /**
+   * The label used above the input element.
+   */
+  label: PropTypes.node.isRequired,
+
+  /**
+   * Whether or not to show an asterix after the label.
+   */
+  required: PropTypes.bool,
+
+  /**
+   * An optional description of the field under the label, above the input element.
+   */
+  description: PropTypes.node,
+
+  /**
+   * An optional hint under the input element.
+   */
+  hint: PropTypes.node,
+
+  /**
+   * If a validation message is passed it is shown under the input element
+   * and above the hint. This is unaffected by `isInvalid`.
+   */
+  validationMessage: PropTypes.node,
+
+  /**
+   * The height of the input element.
+   */
+  inputHeight: PropTypes.number,
+
+  /**
+   * The width of the input width.
+   */
+  inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 }
+
+export default TextareaField


### PR DESCRIPTION
## Overview 
The title of this PR -- keeping chugging along converting stuff to forwardRef + memo + hooks.
 
## Screenshots (if applicable) 
N/A no visual change, just a component change.

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Added / modified component docs 
- [x] Added / modified Storybook stories
