### PR TITLE
Convert <Radio />, <Checkbox />, and <Card /> to FC + Hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -597,10 +597,6 @@ export interface CheckboxProps extends Omit<BoxProps<'input'>, 'innerRef'> {
    */
   indeterminate?: boolean
   /**
-   * Function that returns the ref of the checkbox.
-   */
-  innerRef?: (ref: React.RefObject<HTMLElement>) => void,
-  /**
    * When true, the radio is disabled.
    */
   disabled?: boolean
@@ -1219,9 +1215,9 @@ export interface RadioProps extends Omit<BoxProps<'input'>, 'onChange'> {
    */
   value?: string
   /**
-   * Function called when state changes
+   * Function called when state changes.
    */
-  onChange?(event: React.ChangeEvent<HTMLInputElement>, checked: boolean): void
+  onChange?(event: React.ChangeEvent<HTMLInputElement>): void
   /**
    * When true, the radio is disabled.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -568,8 +568,7 @@ export declare const Button: ForwardRefComponent<ButtonProps>
 
 export type CardProps = React.ComponentProps<typeof Pane>
 
-export class Card extends React.PureComponent<CardProps> {
-}
+export declare const Card: ForwardRefComponent<CardProps>
 
 export interface CheckboxProps extends Omit<BoxProps<'input'>, 'innerRef'> {
   /**
@@ -621,8 +620,7 @@ export interface CheckboxProps extends Omit<BoxProps<'input'>, 'innerRef'> {
   onChange?(event: React.ChangeEvent<HTMLInputElement>): void
 }
 
-export class Checkbox extends React.PureComponent<CheckboxProps> {
-}
+export declare const Checkbox: ForwardRefComponent<CheckboxProps>
 
 export type CodeProps = TextProps
 
@@ -1252,8 +1250,7 @@ export interface RadioProps extends Omit<BoxProps<'input'>, 'onChange'> {
   appearance?: DefaultAppearance
 }
 
-export class Radio extends React.PureComponent<RadioProps> {
-}
+export declare const Radio: ForwardRefComponent<RadioProps>
 
 interface RadioGroupOption {
   label: React.ReactNode

--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -49,10 +49,10 @@ const Checkbox = memo(
     } = props
 
     useEffect(() => {
-      if (ref?.current) {
+      if (ref && ref.current) {
         ref.current.indeterminate = indeterminate
       }
-    }, [ref, ref?.current, indeterminate])
+    }, [ref, indeterminate])
 
     const theme = useTheme()
     const themedClassName = theme.getCheckboxClassName(appearance)

--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef } from 'react'
+import React, { memo, forwardRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout, dimensions } from 'ui-box'
 import { Text } from '../../typography'
@@ -45,12 +45,16 @@ const Checkbox = memo(
       onChange,
       value,
       indeterminate,
-      innerRef,
       ...rest
     } = props
 
-    const theme = useTheme()
+    useEffect(() => {
+      if (ref?.current) {
+        ref.current.indeterminate = indeterminate
+      }
+    }, [ref, ref?.current, indeterminate])
 
+    const theme = useTheme()
     const themedClassName = theme.getCheckboxClassName(appearance)
 
     return (
@@ -73,7 +77,7 @@ const Checkbox = memo(
           onChange={onChange}
           disabled={disabled}
           aria-invalid={isInvalid}
-          ref={ref}
+          innerRef={ref}
         />
         <Box
           boxSizing="border-box"

--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -1,8 +1,8 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout, dimensions } from 'ui-box'
 import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
 const CheckIcon = ({ fill = 'currentColor', ...props }) => (
   <svg width={10} height={7} viewBox="0 0 10 7" {...props}>
@@ -32,100 +32,9 @@ MinusIcon.propTypes = {
   fill: PropTypes.string
 }
 
-class Checkbox extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes some Box APIs.
-     */
-    ...spacing.propTypes,
-    ...position.propTypes,
-    ...layout.propTypes,
-    ...dimensions.propTypes,
-
-    /**
-     * The id attribute of the checkbox.
-     */
-    id: PropTypes.string,
-
-    /**
-     * The id attribute of the checkbox.
-     */
-    name: PropTypes.string,
-
-    /**
-     * Label of the checkbox.
-     */
-    label: PropTypes.node,
-
-    /**
-     * The value attribute of the checkbox.
-     */
-    value: PropTypes.string,
-
-    /**
-     * The checked attribute of the checkbox.
-     */
-    checked: PropTypes.bool,
-
-    /**
-     * State in addition to "checked" and "unchecked".
-     * When true, the checkbox displays a "minus" icon.
-     */
-    indeterminate: PropTypes.bool,
-
-    /**
-     * Function that returns the ref of the checkbox.
-     */
-    innerRef: PropTypes.func,
-
-    /**
-     * Function called when state changes.
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * When true, the checkbox is disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * When true, the aria-invalid attribute is true.
-     * Used for accessibility.
-     */
-    isInvalid: PropTypes.bool,
-
-    /**
-     * The appearance of the checkbox.
-     * The default theme only comes with a default style.
-     */
-    appearance: PropTypes.string,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    checked: false,
-    indeterminate: false,
-    innerRef: () => {},
-    onChange: () => {},
-    appearance: 'default'
-  }
-
-  handleInnerRef = el => {
-    if (el) {
-      el.indeterminate = this.props.indeterminate
-    }
-
-    this.props.innerRef(el)
-  }
-
-  render() {
+const Checkbox = memo(
+  forwardRef((props, ref) => {
     const {
-      theme,
-
       id,
       name,
       label,
@@ -137,8 +46,10 @@ class Checkbox extends PureComponent {
       value,
       indeterminate,
       innerRef,
-      ...props
-    } = this.props
+      ...rest
+    } = props
+
+    const theme = useTheme()
 
     const themedClassName = theme.getCheckboxClassName(appearance)
 
@@ -149,7 +60,7 @@ class Checkbox extends PureComponent {
         position="relative"
         display="flex"
         marginY={16}
-        {...props}
+        {...rest}
       >
         <Box
           className={themedClassName}
@@ -162,7 +73,7 @@ class Checkbox extends PureComponent {
           onChange={onChange}
           disabled={disabled}
           aria-invalid={isInvalid}
-          innerRef={this.handleInnerRef}
+          ref={ref}
         />
         <Box
           boxSizing="border-box"
@@ -187,7 +98,83 @@ class Checkbox extends PureComponent {
         )}
       </Box>
     )
-  }
+  })
+)
+
+Checkbox.propTypes = {
+  /**
+   * Composes some Box APIs.
+   */
+  ...spacing.propTypes,
+  ...position.propTypes,
+  ...layout.propTypes,
+  ...dimensions.propTypes,
+
+  /**
+   * The id attribute of the checkbox.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The id attribute of the checkbox.
+   */
+  name: PropTypes.string,
+
+  /**
+   * Label of the checkbox.
+   */
+  label: PropTypes.node,
+
+  /**
+   * The value attribute of the checkbox.
+   */
+  value: PropTypes.string,
+
+  /**
+   * The checked attribute of the checkbox.
+   */
+  checked: PropTypes.bool,
+
+  /**
+   * State in addition to "checked" and "unchecked".
+   * When true, the checkbox displays a "minus" icon.
+   */
+  indeterminate: PropTypes.bool,
+
+  /**
+   * Function that returns the ref of the checkbox.
+   */
+  innerRef: PropTypes.func,
+
+  /**
+   * Function called when state changes.
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * When true, the checkbox is disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * When true, the aria-invalid attribute is true.
+   * Used for accessibility.
+   */
+  isInvalid: PropTypes.bool,
+
+  /**
+   * The appearance of the checkbox.
+   * The default theme only comes with a default style.
+   */
+  appearance: PropTypes.string
 }
 
-export default withTheme(Checkbox)
+Checkbox.defaultProps = {
+  checked: false,
+  indeterminate: false,
+  innerRef: () => {},
+  onChange: () => {},
+  appearance: 'default'
+}
+
+export default Checkbox

--- a/src/checkbox/stories/index.stories.js
+++ b/src/checkbox/stories/index.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import Box from 'ui-box'
 import { Checkbox } from '..'
 
@@ -7,6 +7,25 @@ const innerRef = el => {
   if (el) {
     el.disabled = true
   }
+}
+
+function IndeterminateWithRefExample() {
+  useEffect(() => {
+    if (ref?.current) {
+      innerRef(ref.current)
+    }
+  }, [ref, ref?.current])
+
+  const ref = useRef()
+
+  return (
+    <Checkbox
+      checked
+      indeterminate
+      ref={ref}
+      label="Checkbox checked indeterminate disabled with ref"
+    />
+  )
 }
 
 storiesOf('checkbox', module).add('Checkbox', () => (
@@ -17,11 +36,6 @@ storiesOf('checkbox', module).add('Checkbox', () => (
     <Checkbox disabled checked label="Checkbox checked disabled" />
     <Checkbox indeterminate label="Checkbox indeterminate" />
     <Checkbox checked indeterminate label="Checkbox checked indeterminate" />
-    <Checkbox
-      checked
-      indeterminate
-      innerRef={innerRef}
-      label="Checkbox checked indeterminate disabled with ref"
-    />
+    <IndeterminateWithRefExample />
   </Box>
 ))

--- a/src/checkbox/stories/index.stories.js
+++ b/src/checkbox/stories/index.stories.js
@@ -11,10 +11,10 @@ const innerRef = el => {
 
 function IndeterminateWithRefExample() {
   useEffect(() => {
-    if (ref?.current) {
+    if (ref && ref.current) {
       innerRef(ref.current)
     }
-  }, [ref, ref?.current])
+  }, [ref])
 
   const ref = useRef()
 

--- a/src/layers/src/Card.js
+++ b/src/layers/src/Card.js
@@ -1,12 +1,12 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import Pane from './Pane'
 
-export default class Card extends PureComponent {
-  static propTypes = {
-    ...Pane.propTypes
-  }
+const Card = memo(
+  forwardRef((props, ref) => {
+    return <Pane borderRadius={5} {...props} ref={ref} />
+  })
+)
 
-  render() {
-    return <Pane borderRadius={5} {...this.props} />
-  }
+Card.propTypes = {
+  ...Pane.propTypes
 }

--- a/src/layers/src/Card.js
+++ b/src/layers/src/Card.js
@@ -10,3 +10,5 @@ const Card = memo(
 Card.propTypes = {
   ...Pane.propTypes
 }
+
+export default Card

--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, useCallback } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout, dimensions } from 'ui-box'
 import { Text } from '../../typography'
@@ -31,17 +31,14 @@ const Radio = memo(
       appearance,
       ...rest
     } = props
+
     const theme = useTheme()
     const themedClassName = theme.getRadioClassName(appearance)
 
-    const handleChange = useCallback(
-      event => onChange(event, event.target.checked),
-      [onChange]
-    )
     return (
       <Box
         is="label"
-        ref={ref}
+        innerRef={ref}
         cursor={disabled ? 'not-allowed' : 'pointer'}
         position="relative"
         display="flex"
@@ -56,7 +53,7 @@ const Radio = memo(
           name={name}
           value={value}
           checked={checked}
-          onChange={handleChange}
+          onChange={onChange}
           disabled={disabled}
           aria-invalid={isInvalid}
           required={isRequired}

--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -1,113 +1,23 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout, dimensions } from 'ui-box'
 import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-const CircleIcon = ({ size, fill = 'currentColor', ...props }) => (
+const CircleIcon = memo(({ size, fill = 'currentColor', ...props }) => (
   <svg width={size} height={size} viewBox="0 0 10 10" {...props}>
     <circle fill={fill} cx="5" cy="5" r="5" />
   </svg>
-)
+))
 
 CircleIcon.propTypes = {
   fill: PropTypes.string,
   size: PropTypes.number
 }
 
-class Radio extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes some Box APIs.
-     */
-    ...spacing.propTypes,
-    ...position.propTypes,
-    ...layout.propTypes,
-    ...dimensions.propTypes,
-
-    /**
-     * The id attribute of the radio.
-     */
-    id: PropTypes.string,
-
-    /**
-     * The name attribute of the radio.
-     */
-    name: PropTypes.string,
-
-    /**
-     * Label of the radio.
-     */
-    label: PropTypes.node,
-
-    /**
-     * The value attribute of the radio.
-     */
-    value: PropTypes.string,
-
-    /**
-     * Function called when state changes
-     * Signature:
-     * ```
-     * function(event: object, checked: boolean) => void
-     * ```
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * When true, the radio is disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * When true, the radio is checked.
-     */
-    checked: PropTypes.bool,
-
-    /**
-     * The size of the radio circle. This also informs the text size and spacing.
-     */
-    size: PropTypes.oneOf([12, 16]),
-
-    /**
-     * When true, the radio get the required attribute.
-     */
-    isRequired: PropTypes.bool.isRequired,
-
-    /**
-     * When true, the aria-invalid attribute is true.
-     * Used for accessibility.
-     */
-    isInvalid: PropTypes.bool.isRequired,
-
-    /**
-     * The appearance of the checkbox.
-     * The default theme only comes with a default style.
-     */
-    appearance: PropTypes.string.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    appearance: 'default',
-    onChange: () => {},
-    size: 12,
-    isRequired: false,
-    isInvalid: false
-  }
-
-  handleChange = event => {
-    this.props.onChange(event, event.target.checked)
-  }
-
-  render() {
+const Radio = memo(
+  forwardRef((props, ref) => {
     const {
-      theme,
-
       id,
       name,
       label,
@@ -119,18 +29,24 @@ class Radio extends PureComponent {
       size,
       isRequired,
       appearance,
-      ...props
-    } = this.props
+      ...rest
+    } = props
+    const theme = useTheme()
     const themedClassName = theme.getRadioClassName(appearance)
 
+    const handleChange = useCallback(
+      event => onChange(event, event.target.checked),
+      [onChange]
+    )
     return (
       <Box
         is="label"
+        ref={ref}
         cursor={disabled ? 'not-allowed' : 'pointer'}
         position="relative"
         display="flex"
         marginY={size === 12 ? 8 : 12}
-        {...props}
+        {...rest}
       >
         <Box
           is="input"
@@ -140,7 +56,7 @@ class Radio extends PureComponent {
           name={name}
           value={value}
           checked={checked}
-          onChange={this.handleChange}
+          onChange={handleChange}
           disabled={disabled}
           aria-invalid={isInvalid}
           required={isRequired}
@@ -169,7 +85,86 @@ class Radio extends PureComponent {
         )}
       </Box>
     )
-  }
+  })
+)
+
+Radio.propTypes = {
+  /**
+   * Composes some Box APIs.
+   */
+  ...spacing.propTypes,
+  ...position.propTypes,
+  ...layout.propTypes,
+  ...dimensions.propTypes,
+
+  /**
+   * The id attribute of the radio.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The name attribute of the radio.
+   */
+  name: PropTypes.string,
+
+  /**
+   * Label of the radio.
+   */
+  label: PropTypes.node,
+
+  /**
+   * The value attribute of the radio.
+   */
+  value: PropTypes.string,
+
+  /**
+   * Function called when state changes
+   * Signature:
+   * ```
+   * function(event: object, checked: boolean) => void
+   * ```
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * When true, the radio is disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * When true, the radio is checked.
+   */
+  checked: PropTypes.bool,
+
+  /**
+   * The size of the radio circle. This also informs the text size and spacing.
+   */
+  size: PropTypes.oneOf([12, 16]),
+
+  /**
+   * When true, the radio get the required attribute.
+   */
+  isRequired: PropTypes.bool.isRequired,
+
+  /**
+   * When true, the aria-invalid attribute is true.
+   * Used for accessibility.
+   */
+  isInvalid: PropTypes.bool.isRequired,
+
+  /**
+   * The appearance of the checkbox.
+   * The default theme only comes with a default style.
+   */
+  appearance: PropTypes.string.isRequired
 }
 
-export default withTheme(Radio)
+Radio.defaultProps = {
+  appearance: 'default',
+  onChange: () => {},
+  size: 12,
+  isRequired: false,
+  isInvalid: false
+}
+
+export default Radio


### PR DESCRIPTION
## Overview 
Converts to aforementioned components to use forwardRef + memo + React.FC + useTheme. 

Also, makes the following API modifications: 
* Removes `innerRef` support on `<Checkbox />` (this can be implemented in consumer-space) 
* Removes the additional `onChange` parameter in `<Radio />`
 
## Screenshots (if applicable) 
![image](https://user-images.githubusercontent.com/5349500/82240510-65c16400-98ef-11ea-856f-78d1a84f88c4.png)

![image](https://user-images.githubusercontent.com/5349500/82240532-6e199f00-98ef-11ea-84b0-9b4ae2c7dc1b.png)


## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
