### PR TITLE
Convert <Dialog /> and <CornerDialog /> to FC + memo + forwardRef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -745,8 +745,7 @@ export interface CornerDialogProps {
   containerProps?: CardProps
 }
 
-export class CornerDialog extends React.PureComponent<CornerDialogProps> {
-}
+export declare const CornerDialog: ForwardRefComponent<CornerDialogProps>
 
 export interface DialogProps {
   /**
@@ -882,8 +881,7 @@ export interface DialogProps {
   preventBodyScrolling?: boolean
 }
 
-export class Dialog extends React.PureComponent<DialogProps> {
-}
+export declare const Dialog: ForwardRefComponent<DialogProps>
 
 export interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Box> {
   /**

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -1,10 +1,4 @@
-import React, {
-  memo,
-  forwardRef,
-  useState,
-  useEffect,
-  useCallback
-} from 'react'
+import React, { memo, useState, useEffect, useCallback } from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import Transition from 'react-transition-group/Transition'
@@ -53,146 +47,143 @@ const animationStyles = {
   }
 }
 
-const CornerDialog = memo(
-  forwardRef((props, ref) => {
-    const {
-      title,
-      width,
-      children,
-      intent,
-      isShown,
-      hasFooter,
-      hasCancel,
-      hasClose,
-      cancelLabel,
-      confirmLabel,
-      onOpenComplete,
-      onCloseComplete,
-      onCancel,
-      onConfirm,
-      containerProps = {},
-      position
-    } = props
+const CornerDialog = memo(props => {
+  const {
+    title,
+    width,
+    children,
+    intent,
+    isShown,
+    hasFooter,
+    hasCancel,
+    hasClose,
+    cancelLabel,
+    confirmLabel,
+    onOpenComplete,
+    onCloseComplete,
+    onCancel,
+    onConfirm,
+    containerProps = {},
+    position
+  } = props
 
-    const [exiting, setExiting] = useState(false)
-    const [exited, setExited] = useState(!props.isShown)
+  const [exiting, setExiting] = useState(false)
+  const [exited, setExited] = useState(!props.isShown)
 
-    useEffect(() => {
-      if (isShown) {
-        setExited(false)
-      }
-    }, [isShown])
+  useEffect(() => {
+    if (isShown) {
+      setExited(false)
+    }
+  }, [isShown])
 
-    const handleExited = useCallback(() => {
-      setExiting(false)
-      setExited(true)
+  const handleExited = useCallback(() => {
+    setExiting(false)
+    setExited(true)
 
-      onCloseComplete()
-    }, [onCloseComplete])
+    onCloseComplete()
+  }, [onCloseComplete])
 
-    const handleClose = useCallback(() => setExiting(true))
+  const handleClose = useCallback(() => setExiting(true))
 
-    const handleCancel = useCallback(() => {
-      onCancel(handleClose)
-    }, [onCancel])
+  const handleCancel = useCallback(() => {
+    onCancel(handleClose)
+  }, [onCancel])
 
-    const handleConfirm = useCallback(() => {
-      onConfirm(handleClose)
-    }, [onConfirm])
+  const handleConfirm = useCallback(() => {
+    onConfirm(handleClose)
+  }, [onConfirm])
 
-    const renderChildren = useCallback(() => {
-      if (typeof children === 'function') {
-        return children({ close: handleClose })
-      }
-
-      if (typeof children === 'string') {
-        return (
-          <Paragraph size={400} color="muted">
-            {children}
-          </Paragraph>
-        )
-      }
-
-      return children
-    }, [children])
-
-    if (exited) {
-      return null
+  const renderChildren = useCallback(() => {
+    if (typeof children === 'function') {
+      return children({ close: handleClose })
     }
 
-    return (
-      <Portal>
-        <Transition
-          appear
-          unmountOnExit
-          timeout={ANIMATION_DURATION}
-          in={isShown && !exiting}
-          onExited={handleExited}
-          onEntered={onOpenComplete}
-        >
-          {state => (
-            <Card
-              role="dialog"
-              backgroundColor="white"
-              elevation={4}
-              ref={ref}
-              width={width}
-              css={animationStyles}
-              data-state={state}
-              padding={32}
-              position="fixed"
-              {...absolutePositions[
-                Object.keys(absolutePositions).includes(position)
-                  ? position
-                  : positions.BOTTOM_RIGHT
-              ]}
-              {...containerProps}
-            >
-              <Pane display="flex" alignItems="center" marginBottom={12}>
-                <Heading is="h4" size={600} flex="1">
-                  {title}
-                </Heading>
-                {hasClose && (
-                  <IconButton
-                    height={32}
-                    icon={<CrossIcon />}
-                    appearance="minimal"
-                    onClick={handleClose}
-                  />
+    if (typeof children === 'string') {
+      return (
+        <Paragraph size={400} color="muted">
+          {children}
+        </Paragraph>
+      )
+    }
+
+    return children
+  }, [children])
+
+  if (exited) {
+    return null
+  }
+
+  return (
+    <Portal>
+      <Transition
+        appear
+        unmountOnExit
+        timeout={ANIMATION_DURATION}
+        in={isShown && !exiting}
+        onExited={handleExited}
+        onEntered={onOpenComplete}
+      >
+        {state => (
+          <Card
+            role="dialog"
+            backgroundColor="white"
+            elevation={4}
+            width={width}
+            css={animationStyles}
+            data-state={state}
+            padding={32}
+            position="fixed"
+            {...absolutePositions[
+              Object.keys(absolutePositions).includes(position)
+                ? position
+                : positions.BOTTOM_RIGHT
+            ]}
+            {...containerProps}
+          >
+            <Pane display="flex" alignItems="center" marginBottom={12}>
+              <Heading is="h4" size={600} flex="1">
+                {title}
+              </Heading>
+              {hasClose && (
+                <IconButton
+                  height={32}
+                  icon={<CrossIcon />}
+                  appearance="minimal"
+                  onClick={handleClose}
+                />
+              )}
+            </Pane>
+
+            <Pane overflowY="auto" data-state={state}>
+              {renderChildren()}
+            </Pane>
+
+            {hasFooter && (
+              <Pane
+                marginTop={24}
+                flexShrink={0}
+                display="flex"
+                flexDirection="row-reverse"
+              >
+                <Button
+                  appearance="primary"
+                  intent={intent}
+                  marginLeft={8}
+                  onClick={handleConfirm}
+                >
+                  {confirmLabel}
+                </Button>
+                {hasCancel && (
+                  <Button onClick={handleCancel}>{cancelLabel}</Button>
                 )}
               </Pane>
-
-              <Pane overflowY="auto" data-state={state}>
-                {renderChildren()}
-              </Pane>
-
-              {hasFooter && (
-                <Pane
-                  marginTop={24}
-                  flexShrink={0}
-                  display="flex"
-                  flexDirection="row-reverse"
-                >
-                  <Button
-                    appearance="primary"
-                    intent={intent}
-                    marginLeft={8}
-                    onClick={handleConfirm}
-                  >
-                    {confirmLabel}
-                  </Button>
-                  {hasCancel && (
-                    <Button onClick={handleCancel}>{cancelLabel}</Button>
-                  )}
-                </Pane>
-              )}
-            </Card>
-          )}
-        </Transition>
-      </Portal>
-    )
-  })
-)
+            )}
+          </Card>
+        )}
+      </Transition>
+    </Portal>
+  )
+})
 
 CornerDialog.propTypes = {
   /**

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -93,11 +93,11 @@ const CornerDialog = memo(
     const handleClose = useCallback(() => setExiting(true))
 
     const handleCancel = useCallback(() => {
-      onConfirm(handleClose)
+      onCancel(handleClose)
     }, [onCancel])
 
     const handleConfirm = useCallback(() => {
-      onCancel(handleClose)
+      onConfirm(handleClose)
     }, [onConfirm])
 
     const renderChildren = useCallback(() => {

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -1,11 +1,10 @@
+import React, { memo, forwardRef } from 'react'
 import { css } from 'glamor'
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Paragraph, Heading } from '../../typography'
 import { Overlay } from '../../overlay'
 import { Button, IconButton } from '../../buttons'
-import { withTheme } from '../../theme'
 import { CrossIcon } from '../../icons'
 
 const animationEasing = {
@@ -46,218 +45,8 @@ const animationStyles = {
   }
 }
 
-class Dialog extends React.Component {
-  static propTypes = {
-    /**
-     * Children can be a string, node or a function accepting `({ close })`.
-     * When passing a string, <Paragraph /> is used to wrap the string.
-     */
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-
-    /**
-     * The intent of the Dialog. Used for the button.
-     */
-    intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger'])
-      .isRequired,
-
-    /**
-     * When true, the dialog is shown.
-     */
-    isShown: PropTypes.bool,
-
-    /**
-     * Title of the Dialog. Titles should use Title Case.
-     */
-    title: PropTypes.node,
-
-    /**
-     * When true, the header with the title and close icon button is shown.
-     */
-    hasHeader: PropTypes.bool,
-
-    /**
-     * You can override the default header with your own custom component.
-     *
-     * This is useful if you want to provide a custom header and footer, while
-     * also enabling your Dialog's content to scroll.
-     *
-     * Header can either be a React node or a function accepting `({ close })`.
-     */
-    header: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-
-    /**
-     * When true, the footer with the cancel and confirm button is shown.
-     */
-    hasFooter: PropTypes.bool,
-
-    /**
-     * You can override the default footer with your own custom component.
-     *
-     * This is useful if you want to provide a custom header and footer, while
-     * also enabling your Dialog's content to scroll.
-     *
-     * Footer can either be a React node or a function accepting `({ close })`.
-     */
-    footer: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-
-    /**
-     * When true, the cancel button is shown.
-     */
-    hasCancel: PropTypes.bool,
-
-    /**
-     * When true, the close button is shown
-     */
-    hasClose: PropTypes.bool,
-
-    /**
-     * Function that will be called when the exit transition is complete.
-     */
-    onCloseComplete: PropTypes.func,
-
-    /**
-     * Function that will be called when the enter transition is complete.
-     */
-    onOpenComplete: PropTypes.func,
-
-    /**
-     * Function that will be called when the confirm button is clicked.
-     * This does not close the Dialog. A close function will be passed
-     * as a paramater you can use to close the dialog.
-     *
-     * `onConfirm={(close) => close()}`
-     */
-    onConfirm: PropTypes.func,
-
-    /**
-     * Label of the confirm button.
-     */
-    confirmLabel: PropTypes.string,
-
-    /**
-     * When true, the confirm button is set to loading.
-     */
-    isConfirmLoading: PropTypes.bool,
-
-    /**
-     * When true, the confirm button is set to disabled.
-     */
-    isConfirmDisabled: PropTypes.bool,
-
-    /**
-     * Function that will be called when the cancel button is clicked.
-     * This closes the Dialog by default.
-     *
-     * `onCancel={(close) => close()}`
-     */
-    onCancel: PropTypes.func,
-
-    /**
-     * Label of the cancel button.
-     */
-    cancelLabel: PropTypes.string,
-
-    /**
-     * Boolean indicating if clicking the overlay should close the overlay.
-     */
-    shouldCloseOnOverlayClick: PropTypes.bool,
-
-    /**
-     * Boolean indicating if pressing the esc key should close the overlay.
-     */
-    shouldCloseOnEscapePress: PropTypes.bool,
-
-    /**
-     * Width of the Dialog.
-     */
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * The space above the dialog.
-     * This offset is also used at the bottom when there is not enough vertical
-     * space available on screen — and the dialog scrolls internally.
-     */
-    topOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * The space on the left/right sides of the dialog when there isn't enough
-     * horizontal space available on screen.
-     */
-    sideOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * The min height of the body content.
-     * Makes it less weird when only showing little content.
-     */
-    minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    /**
-     * Props that are passed to the dialog container.
-     */
-    containerProps: PropTypes.object,
-
-    /**
-     * Props that are passed to the content container.
-     */
-    contentContainerProps: PropTypes.object,
-
-    /**
-     * Whether or not to prevent scrolling in the outer body
-     */
-    preventBodyScrolling: PropTypes.bool,
-
-    /**
-     * Props that are passed to the Overlay component.
-     */
-    overlayProps: PropTypes.object
-  }
-
-  static defaultProps = {
-    isShown: false,
-    hasHeader: true,
-    hasClose: true,
-    hasFooter: true,
-    hasCancel: true,
-    intent: 'none',
-    width: 560,
-    topOffset: '12vmin',
-    sideOffset: '16px',
-    minHeightContent: 80,
-    confirmLabel: 'Confirm',
-    isConfirmLoading: false,
-    isConfirmDisabled: false,
-    cancelLabel: 'Cancel',
-    shouldCloseOnOverlayClick: true,
-    shouldCloseOnEscapePress: true,
-    onCancel: close => close(),
-    onConfirm: close => close(),
-    preventBodyScrolling: false,
-    overlayProps: {}
-  }
-
-  renderNode = (node, close) => {
-    if (typeof node === 'function') {
-      return node({ close })
-    }
-
-    return node
-  }
-
-  renderChildren = close => {
-    const { children } = this.props
-
-    if (typeof children === 'function') {
-      return children({ close })
-    }
-
-    if (typeof children === 'string') {
-      return <Paragraph>{children}</Paragraph>
-    }
-
-    return children
-  }
-
-  render() {
+const Dialog = memo(
+  forwardRef((props, ref) => {
     const {
       title,
       width,
@@ -285,8 +74,9 @@ class Dialog extends React.Component {
       contentContainerProps,
       minHeightContent,
       preventBodyScrolling,
-      overlayProps
-    } = this.props
+      overlayProps,
+      children
+    } = props
 
     const sideOffsetWithUnit = Number.isInteger(sideOffset)
       ? `${sideOffset}px`
@@ -297,6 +87,26 @@ class Dialog extends React.Component {
       ? `${topOffset}px`
       : topOffset
     const maxHeight = `calc(100% - ${topOffsetWithUnit} * 2)`
+
+    const renderChildren = close => {
+      if (typeof children === 'function') {
+        return children({ close })
+      }
+
+      if (typeof children === 'string') {
+        return <Paragraph>{children}</Paragraph>
+      }
+
+      return children
+    }
+
+    const renderNode = (node, close) => {
+      if (typeof node === 'function') {
+        return node({ close })
+      }
+
+      return node
+    }
 
     const renderHeader = close => {
       if (!header && !hasHeader) {
@@ -312,7 +122,7 @@ class Dialog extends React.Component {
           alignItems="center"
         >
           {header ? (
-            this.renderNode(header, close)
+            renderNode(header, close)
           ) : (
             <>
               <Heading is="h4" size={600} flex="1">
@@ -340,7 +150,7 @@ class Dialog extends React.Component {
         <Pane borderTop="muted" clearfix>
           <Pane padding={16} float="right">
             {footer ? (
-              this.renderNode(footer, close)
+              renderNode(footer, close)
             ) : (
               <>
                 {/* Cancel should be first to make sure focus gets on it first. */}
@@ -398,6 +208,7 @@ class Dialog extends React.Component {
             flexDirection="column"
             css={animationStyles}
             data-state={state}
+            ref={ref}
             {...containerProps}
           >
             {renderHeader(close)}
@@ -411,7 +222,7 @@ class Dialog extends React.Component {
               minHeight={minHeightContent}
               {...contentContainerProps}
             >
-              <Pane>{this.renderChildren(close)}</Pane>
+              <Pane>{renderChildren(close)}</Pane>
             </Pane>
 
             {renderFooter(close)}
@@ -419,7 +230,194 @@ class Dialog extends React.Component {
         )}
       </Overlay>
     )
-  }
+  })
+)
+
+Dialog.propTypes = {
+  /**
+   * Children can be a string, node or a function accepting `({ close })`.
+   * When passing a string, <Paragraph /> is used to wrap the string.
+   */
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+  /**
+   * The intent of the Dialog. Used for the button.
+   */
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+
+  /**
+   * When true, the dialog is shown.
+   */
+  isShown: PropTypes.bool,
+
+  /**
+   * Title of the Dialog. Titles should use Title Case.
+   */
+  title: PropTypes.node,
+
+  /**
+   * When true, the header with the title and close icon button is shown.
+   */
+  hasHeader: PropTypes.bool,
+
+  /**
+   * You can override the default header with your own custom component.
+   *
+   * This is useful if you want to provide a custom header and footer, while
+   * also enabling your Dialog's content to scroll.
+   *
+   * Header can either be a React node or a function accepting `({ close })`.
+   */
+  header: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+
+  /**
+   * When true, the footer with the cancel and confirm button is shown.
+   */
+  hasFooter: PropTypes.bool,
+
+  /**
+   * You can override the default footer with your own custom component.
+   *
+   * This is useful if you want to provide a custom header and footer, while
+   * also enabling your Dialog's content to scroll.
+   *
+   * Footer can either be a React node or a function accepting `({ close })`.
+   */
+  footer: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+
+  /**
+   * When true, the cancel button is shown.
+   */
+  hasCancel: PropTypes.bool,
+
+  /**
+   * When true, the close button is shown
+   */
+  hasClose: PropTypes.bool,
+
+  /**
+   * Function that will be called when the exit transition is complete.
+   */
+  onCloseComplete: PropTypes.func,
+
+  /**
+   * Function that will be called when the enter transition is complete.
+   */
+  onOpenComplete: PropTypes.func,
+
+  /**
+   * Function that will be called when the confirm button is clicked.
+   * This does not close the Dialog. A close function will be passed
+   * as a paramater you can use to close the dialog.
+   *
+   * `onConfirm={(close) => close()}`
+   */
+  onConfirm: PropTypes.func,
+
+  /**
+   * Label of the confirm button.
+   */
+  confirmLabel: PropTypes.string,
+
+  /**
+   * When true, the confirm button is set to loading.
+   */
+  isConfirmLoading: PropTypes.bool,
+
+  /**
+   * When true, the confirm button is set to disabled.
+   */
+  isConfirmDisabled: PropTypes.bool,
+
+  /**
+   * Function that will be called when the cancel button is clicked.
+   * This closes the Dialog by default.
+   *
+   * `onCancel={(close) => close()}`
+   */
+  onCancel: PropTypes.func,
+
+  /**
+   * Label of the cancel button.
+   */
+  cancelLabel: PropTypes.string,
+
+  /**
+   * Boolean indicating if clicking the overlay should close the overlay.
+   */
+  shouldCloseOnOverlayClick: PropTypes.bool,
+
+  /**
+   * Boolean indicating if pressing the esc key should close the overlay.
+   */
+  shouldCloseOnEscapePress: PropTypes.bool,
+
+  /**
+   * Width of the Dialog.
+   */
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * The space above the dialog.
+   * This offset is also used at the bottom when there is not enough vertical
+   * space available on screen — and the dialog scrolls internally.
+   */
+  topOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * The space on the left/right sides of the dialog when there isn't enough
+   * horizontal space available on screen.
+   */
+  sideOffset: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * The min height of the body content.
+   * Makes it less weird when only showing little content.
+   */
+  minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Props that are passed to the dialog container.
+   */
+  containerProps: PropTypes.object,
+
+  /**
+   * Props that are passed to the content container.
+   */
+  contentContainerProps: PropTypes.object,
+
+  /**
+   * Whether or not to prevent scrolling in the outer body
+   */
+  preventBodyScrolling: PropTypes.bool,
+
+  /**
+   * Props that are passed to the Overlay component.
+   */
+  overlayProps: PropTypes.object
 }
 
-export default withTheme(Dialog)
+Dialog.defaultProps = {
+  isShown: false,
+  hasHeader: true,
+  hasClose: true,
+  hasFooter: true,
+  hasCancel: true,
+  intent: 'none',
+  width: 560,
+  topOffset: '12vmin',
+  sideOffset: '16px',
+  minHeightContent: 80,
+  confirmLabel: 'Confirm',
+  isConfirmLoading: false,
+  isConfirmDisabled: false,
+  cancelLabel: 'Cancel',
+  shouldCloseOnOverlayClick: true,
+  shouldCloseOnEscapePress: true,
+  onCancel: close => close(),
+  onConfirm: close => close(),
+  preventBodyScrolling: false,
+  overlayProps: {}
+}
+
+export default Dialog

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef } from 'react'
+import React, { memo } from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
@@ -45,193 +45,190 @@ const animationStyles = {
   }
 }
 
-const Dialog = memo(
-  forwardRef((props, ref) => {
-    const {
-      title,
-      width,
-      intent,
-      isShown,
-      topOffset,
-      sideOffset,
-      hasHeader,
-      header,
-      hasClose,
-      hasFooter,
-      footer,
-      hasCancel,
-      onCloseComplete,
-      onOpenComplete,
-      onCancel,
-      onConfirm,
-      confirmLabel,
-      isConfirmLoading,
-      isConfirmDisabled,
-      cancelLabel,
-      shouldCloseOnOverlayClick,
-      shouldCloseOnEscapePress,
-      containerProps = {},
-      contentContainerProps,
-      minHeightContent,
-      preventBodyScrolling,
-      overlayProps,
-      children
-    } = props
+const Dialog = memo(props => {
+  const {
+    title,
+    width,
+    intent,
+    isShown,
+    topOffset,
+    sideOffset,
+    hasHeader,
+    header,
+    hasClose,
+    hasFooter,
+    footer,
+    hasCancel,
+    onCloseComplete,
+    onOpenComplete,
+    onCancel,
+    onConfirm,
+    confirmLabel,
+    isConfirmLoading,
+    isConfirmDisabled,
+    cancelLabel,
+    shouldCloseOnOverlayClick,
+    shouldCloseOnEscapePress,
+    containerProps = {},
+    contentContainerProps,
+    minHeightContent,
+    preventBodyScrolling,
+    overlayProps,
+    children
+  } = props
 
-    const sideOffsetWithUnit = Number.isInteger(sideOffset)
-      ? `${sideOffset}px`
-      : sideOffset
-    const maxWidth = `calc(100% - ${sideOffsetWithUnit} * 2)`
+  const sideOffsetWithUnit = Number.isInteger(sideOffset)
+    ? `${sideOffset}px`
+    : sideOffset
+  const maxWidth = `calc(100% - ${sideOffsetWithUnit} * 2)`
 
-    const topOffsetWithUnit = Number.isInteger(topOffset)
-      ? `${topOffset}px`
-      : topOffset
-    const maxHeight = `calc(100% - ${topOffsetWithUnit} * 2)`
+  const topOffsetWithUnit = Number.isInteger(topOffset)
+    ? `${topOffset}px`
+    : topOffset
+  const maxHeight = `calc(100% - ${topOffsetWithUnit} * 2)`
 
-    const renderChildren = close => {
-      if (typeof children === 'function') {
-        return children({ close })
-      }
-
-      if (typeof children === 'string') {
-        return <Paragraph>{children}</Paragraph>
-      }
-
-      return children
+  const renderChildren = close => {
+    if (typeof children === 'function') {
+      return children({ close })
     }
 
-    const renderNode = (node, close) => {
-      if (typeof node === 'function') {
-        return node({ close })
-      }
-
-      return node
+    if (typeof children === 'string') {
+      return <Paragraph>{children}</Paragraph>
     }
 
-    const renderHeader = close => {
-      if (!header && !hasHeader) {
-        return undefined
-      }
+    return children
+  }
 
-      return (
-        <Pane
-          padding={16}
-          flexShrink={0}
-          borderBottom="muted"
-          display="flex"
-          alignItems="center"
-        >
-          {header ? (
-            renderNode(header, close)
-          ) : (
-            <>
-              <Heading is="h4" size={600} flex="1">
-                {title}
-              </Heading>
-              {hasClose && (
-                <IconButton
-                  appearance="minimal"
-                  icon={<CrossIcon />}
-                  onClick={() => onCancel(close)}
-                />
-              )}
-            </>
-          )}
-        </Pane>
-      )
+  const renderNode = (node, close) => {
+    if (typeof node === 'function') {
+      return node({ close })
     }
 
-    const renderFooter = close => {
-      if (!footer && !hasFooter) {
-        return undefined
-      }
+    return node
+  }
 
-      return (
-        <Pane borderTop="muted" clearfix>
-          <Pane padding={16} float="right">
-            {footer ? (
-              renderNode(footer, close)
-            ) : (
-              <>
-                {/* Cancel should be first to make sure focus gets on it first. */}
-                {hasCancel && (
-                  <Button tabIndex={0} onClick={() => onCancel(close)}>
-                    {cancelLabel}
-                  </Button>
-                )}
-
-                <Button
-                  tabIndex={0}
-                  marginLeft={8}
-                  appearance="primary"
-                  isLoading={isConfirmLoading}
-                  disabled={isConfirmDisabled}
-                  onClick={() => onConfirm(close)}
-                  intent={intent}
-                >
-                  {confirmLabel}
-                </Button>
-              </>
-            )}
-          </Pane>
-        </Pane>
-      )
+  const renderHeader = close => {
+    if (!header && !hasHeader) {
+      return undefined
     }
 
     return (
-      <Overlay
-        isShown={isShown}
-        shouldCloseOnClick={shouldCloseOnOverlayClick}
-        shouldCloseOnEscapePress={shouldCloseOnEscapePress}
-        onExited={onCloseComplete}
-        onEntered={onOpenComplete}
-        containerProps={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          justifyContent: 'center',
-          ...overlayProps
-        }}
-        preventBodyScrolling={preventBodyScrolling}
+      <Pane
+        padding={16}
+        flexShrink={0}
+        borderBottom="muted"
+        display="flex"
+        alignItems="center"
       >
-        {({ state, close }) => (
-          <Pane
-            role="dialog"
-            backgroundColor="white"
-            elevation={4}
-            borderRadius={8}
-            width={width}
-            maxWidth={maxWidth}
-            maxHeight={maxHeight}
-            marginX={sideOffsetWithUnit}
-            marginY={topOffsetWithUnit}
-            display="flex"
-            flexDirection="column"
-            css={animationStyles}
-            data-state={state}
-            ref={ref}
-            {...containerProps}
-          >
-            {renderHeader(close)}
-
-            <Pane
-              data-state={state}
-              display="flex"
-              overflow="auto"
-              padding={16}
-              flexDirection="column"
-              minHeight={minHeightContent}
-              {...contentContainerProps}
-            >
-              <Pane>{renderChildren(close)}</Pane>
-            </Pane>
-
-            {renderFooter(close)}
-          </Pane>
+        {header ? (
+          renderNode(header, close)
+        ) : (
+          <>
+            <Heading is="h4" size={600} flex="1">
+              {title}
+            </Heading>
+            {hasClose && (
+              <IconButton
+                appearance="minimal"
+                icon={<CrossIcon />}
+                onClick={() => onCancel(close)}
+              />
+            )}
+          </>
         )}
-      </Overlay>
+      </Pane>
     )
-  })
-)
+  }
+
+  const renderFooter = close => {
+    if (!footer && !hasFooter) {
+      return undefined
+    }
+
+    return (
+      <Pane borderTop="muted" clearfix>
+        <Pane padding={16} float="right">
+          {footer ? (
+            renderNode(footer, close)
+          ) : (
+            <>
+              {/* Cancel should be first to make sure focus gets on it first. */}
+              {hasCancel && (
+                <Button tabIndex={0} onClick={() => onCancel(close)}>
+                  {cancelLabel}
+                </Button>
+              )}
+
+              <Button
+                tabIndex={0}
+                marginLeft={8}
+                appearance="primary"
+                isLoading={isConfirmLoading}
+                disabled={isConfirmDisabled}
+                onClick={() => onConfirm(close)}
+                intent={intent}
+              >
+                {confirmLabel}
+              </Button>
+            </>
+          )}
+        </Pane>
+      </Pane>
+    )
+  }
+
+  return (
+    <Overlay
+      isShown={isShown}
+      shouldCloseOnClick={shouldCloseOnOverlayClick}
+      shouldCloseOnEscapePress={shouldCloseOnEscapePress}
+      onExited={onCloseComplete}
+      onEntered={onOpenComplete}
+      containerProps={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        ...overlayProps
+      }}
+      preventBodyScrolling={preventBodyScrolling}
+    >
+      {({ state, close }) => (
+        <Pane
+          role="dialog"
+          backgroundColor="white"
+          elevation={4}
+          borderRadius={8}
+          width={width}
+          maxWidth={maxWidth}
+          maxHeight={maxHeight}
+          marginX={sideOffsetWithUnit}
+          marginY={topOffsetWithUnit}
+          display="flex"
+          flexDirection="column"
+          css={animationStyles}
+          data-state={state}
+          {...containerProps}
+        >
+          {renderHeader(close)}
+
+          <Pane
+            data-state={state}
+            display="flex"
+            overflow="auto"
+            padding={16}
+            flexDirection="column"
+            minHeight={minHeightContent}
+            {...contentContainerProps}
+          >
+            <Pane>{renderChildren(close)}</Pane>
+          </Pane>
+
+          {renderFooter(close)}
+        </Pane>
+      )}
+    </Overlay>
+  )
+})
 
 Dialog.propTypes = {
   /**


### PR DESCRIPTION
## Overview 
Do as the titles do. Also heavily memoizes handlers with `useCallback`.

## Screenshots (if applicable) 
![image](https://user-images.githubusercontent.com/5349500/82251521-31a36e80-9902-11ea-903c-e9a4ec450632.png)

![image](https://user-images.githubusercontent.com/5349500/82251550-3ec05d80-9902-11ea-8a70-08df19e5a9cc.png)


## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
