### PR TITLE
Convert <FilePicker /> and <FormField* /> to fc + forwardref + memo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -919,20 +919,19 @@ export interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Bo
   inputWidth?: number | string
 }
 
-export class FormField extends React.PureComponent<FormFieldProps> {
-}
+export declare const FormField: ForwardRefComponent<FormFieldProps>
 
 export interface FormFieldDescriptionProps extends ParagraphProps {
 }
 
-export class FormFieldDescription extends React.PureComponent<FormFieldDescriptionProps> {
-}
+export declare const FormFieldDescription: ForwardRefComponent<FormFieldDescriptionProps>
+
 
 export interface FormFieldHintProps extends ParagraphProps {
 }
 
-export class FormFieldHint extends React.PureComponent<ParagraphProps> {
-}
+export declare const FormFieldHint: ForwardRefComponent<ParagraphProps>
+
 
 export interface FormFieldLabelProps extends LabelProps {
   /**
@@ -941,8 +940,8 @@ export interface FormFieldLabelProps extends LabelProps {
   isAstrixShown?: boolean
 }
 
-export class FormFieldLabel extends React.PureComponent<FormFieldLabelProps> {
-}
+export declare const FormFieldLabel: ForwardRefComponent<FormFieldLabelProps>
+
 
 export interface FormFieldValidationMessageProps extends PaneProps {
 }
@@ -2796,8 +2795,7 @@ export declare const ZoomToFitIcon: IconComponent
 
 type UnknownProps = Record<string, any>
 
-export class FilePicker extends React.PureComponent<UnknownProps> {
-}
+export declare const FilePicker: ForwardRefComponent<UnknownProps>
 
 export class Portal extends React.PureComponent<UnknownProps> {
 }

--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef, useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { Button } from '../../buttons'
@@ -7,88 +7,54 @@ import safeInvoke from '../../lib/safe-invoke'
 
 export const CLASS_PREFIX = 'evergreen-file-picker'
 
-export default class FilePicker extends PureComponent {
-  static propTypes = {
-    /**
-     * Name attribute of the input.
-     */
-    name: PropTypes.string,
-
-    /**
-     * The accept attribute of the input.
-     */
-    accept: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
-    ]),
-
-    /**
-     * When true, the file picker is required.
-     */
-    required: PropTypes.bool,
-
-    /**
-     * When true, accept multiple files.
-     */
-    multiple: PropTypes.bool,
-
-    /**
-     * When true, the filepicker is disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * The capture attribute of the input.
-     */
-    capture: PropTypes.bool,
-
-    /**
-     * The height of the file picker.
-     */
-    height: PropTypes.number,
-
-    /**
-     * Function called when onChange is fired
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * Function called when onBlur is fired
-     */
-    onBlur: PropTypes.func,
-
-    /**
-     * Placeholder of the text input
-     */
-    placeholder: PropTypes.string
-  }
-
-  static defaultProps = {
-    placeholder: 'Select a file to upload…'
-  }
-
-  constructor() {
-    super()
-
-    this.state = {
-      files: []
-    }
-  }
-
-  render() {
+const FilePicker = memo(
+  forwardRef((props, ref) => {
     const {
       name,
       accept,
       required,
       multiple,
+      onBlur,
       disabled,
       capture,
       height,
       onChange, // Remove onChange from props
       placeholder,
-      ...props
-    } = this.props
-    const { files } = this.state
+      ...rest
+    } = props
+
+    const [files, setFiles] = useState([])
+    const fileInputRef = useRef()
+
+    const handleFileChange = useCallback(
+      e => {
+        // Firefox returns the same array instance each time for some reason
+        const files = [...e.target.files]
+
+        setFiles(files)
+
+        safeInvoke(onChange, files)
+      },
+      [onChange]
+    )
+
+    const handleButtonClick = useCallback(() => {
+      if (fileInputRef && fileInputRef.current) {
+        fileInputRef.current.click()
+      }
+    }, [fileInputRef])
+
+    const handleBlur = useCallback(
+      e => {
+        // Setting e.target.files to an array fails. It must be a FileList
+        if (e && e.target)
+          e.target.files =
+            fileInputRef && fileInputRef.current && fileInputRef.current.files
+
+        safeInvoke(onBlur, e)
+      },
+      [onBlur]
+    )
 
     let inputValue
     if (files.length === 0) {
@@ -109,9 +75,14 @@ export default class FilePicker extends PureComponent {
     }
 
     return (
-      <Box display="flex" className={`${CLASS_PREFIX}-root`} {...props}>
+      <Box
+        display="flex"
+        className={`${CLASS_PREFIX}-root`}
+        innerRef={ref}
+        {...rest}
+      >
         <Box
-          innerRef={this.fileInputRef}
+          innerRef={fileInputRef}
           className={`${CLASS_PREFIX}-file-input`}
           is="input"
           type="file"
@@ -121,7 +92,7 @@ export default class FilePicker extends PureComponent {
           multiple={multiple}
           disabled={disabled}
           capture={capture}
-          onChange={this.handleFileChange}
+          onChange={handleFileChange}
           display="none"
         />
 
@@ -136,47 +107,84 @@ export default class FilePicker extends PureComponent {
           height={height}
           flex={1}
           textOverflow="ellipsis"
-          onBlur={this.handleBlur}
+          onBlur={handleBlur}
         />
 
         <Button
           className={`${CLASS_PREFIX}-button`}
-          onClick={this.handleButtonClick}
+          onClick={handleButtonClick}
           disabled={disabled}
           borderTopLeftRadius={0}
           borderBottomLeftRadius={0}
           height={height}
           flexShrink={0}
           type="button"
-          onBlur={this.handleBlur}
+          onBlur={handleBlur}
         >
           {buttonText}
         </Button>
       </Box>
     )
-  }
+  })
+)
 
-  fileInputRef = node => {
-    this.fileInput = node
-  }
+FilePicker.propTypes = {
+  /**
+   * Name attribute of the input.
+   */
+  name: PropTypes.string,
 
-  handleFileChange = e => {
-    // Firefox returns the same array instance each time for some reason
-    const files = [...e.target.files]
+  /**
+   * The accept attribute of the input.
+   */
+  accept: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
 
-    this.setState({ files })
+  /**
+   * When true, the file picker is required.
+   */
+  required: PropTypes.bool,
 
-    safeInvoke(this.props.onChange, files)
-  }
+  /**
+   * When true, accept multiple files.
+   */
+  multiple: PropTypes.bool,
 
-  handleButtonClick = () => {
-    this.fileInput.click()
-  }
+  /**
+   * When true, the filepicker is disabled.
+   */
+  disabled: PropTypes.bool,
 
-  handleBlur = e => {
-    // Setting e.target.files to an array fails. It must be a FileList
-    if (e && e.target) e.target.files = this.fileInput && this.fileInput.files
+  /**
+   * The capture attribute of the input.
+   */
+  capture: PropTypes.bool,
 
-    safeInvoke(this.props.onBlur, e)
-  }
+  /**
+   * The height of the file picker.
+   */
+  height: PropTypes.number,
+
+  /**
+   * Function called when onChange is fired
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * Function called when onBlur is fired
+   */
+  onBlur: PropTypes.func,
+
+  /**
+   * Placeholder of the text input
+   */
+  placeholder: PropTypes.string
 }
+
+FilePicker.defaultProps = {
+  placeholder: 'Select a file to upload…'
+}
+
+export default FilePicker

--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -29,11 +29,11 @@ const FilePicker = memo(
     const handleFileChange = useCallback(
       e => {
         // Firefox returns the same array instance each time for some reason
-        const files = [...e.target.files]
+        const filesCopy = [...e.target.files]
 
-        setFiles(files)
+        setFiles(filesCopy)
 
-        safeInvoke(onChange, files)
+        safeInvoke(onChange, filesCopy)
       },
       [onChange]
     )

--- a/src/file-picker/test/index.js
+++ b/src/file-picker/test/index.js
@@ -85,7 +85,6 @@ test('calls onBlur', t => {
   component.find(`.${CLASS_PREFIX}-file-input`).simulate('change', e)
   component.find(`.${CLASS_PREFIX}-text-input`).simulate('blur')
   t.true(onBlur.calledOnce)
-  t.deepEqual(component.state().files, e.target.files)
 })
 
 test('handles 1 file selected', t => {
@@ -96,7 +95,6 @@ test('handles 1 file selected', t => {
     }
   }
   component.find(`.${CLASS_PREFIX}-file-input`).simulate('change', e)
-  t.deepEqual(component.state('files'), e.target.files)
   t.is(component.find(`.${CLASS_PREFIX}-text-input`).prop('value'), 'data.json')
   t.true(component.find(`.${CLASS_PREFIX}-button`).contains('Replace file'))
 })
@@ -109,22 +107,8 @@ test('handles 2 files selected', t => {
     }
   }
   component.find(`.${CLASS_PREFIX}-file-input`).simulate('change', e)
-  t.deepEqual(component.state('files'), e.target.files)
   t.is(component.find(`.${CLASS_PREFIX}-text-input`).prop('value'), '2 files')
   t.true(component.find(`.${CLASS_PREFIX}-button`).contains('Replace files'))
-})
-
-// Firefox returns the same array instance in each change event for some reason
-test('clones files array', t => {
-  const component = shallow(<FilePicker />)
-  const e = {
-    target: {
-      files: [{ name: 'data.json' }]
-    }
-  }
-  component.find(`.${CLASS_PREFIX}-file-input`).simulate('change', e)
-  t.deepEqual(component.state('files'), e.target.files)
-  t.not(component.state('files'), e.target.files)
 })
 
 test('sets placeholder', t => {

--- a/src/form-field/src/FormField.js
+++ b/src/form-field/src/FormField.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box, { dimensions, spacing, position, layout } from 'ui-box'
 import FormFieldLabel from './FormFieldLabel'
@@ -6,67 +6,8 @@ import FormFieldDescription from './FormFieldDescription'
 import FormFieldValidationMessage from './FormFieldValidationMessage'
 import FormFieldHint from './FormFieldHint'
 
-export default class FormField extends PureComponent {
-  static propTypes = {
-    /**
-     * The label used above the input element.
-     */
-    label: PropTypes.node.isRequired,
-
-    /**
-     * Passed on the label as a htmlFor prop.
-     */
-    labelFor: PropTypes.string,
-
-    /**
-     * Whether or not show an asterix after the label.
-     */
-    isRequired: PropTypes.bool,
-
-    /**
-     * An optional description of the field under the label, above the input element.
-     */
-    description: PropTypes.node,
-
-    /**
-     * An optional hint under the input element.
-     */
-    hint: PropTypes.node,
-
-    /**
-     * If a validation message is passed it is shown under the input element
-     * and above the hint. This is unaffected by `isInvalid`.
-     */
-    validationMessage: PropTypes.node,
-
-    /**
-     * Composes the dimensions spec from the Box primitive.
-     */
-    ...dimensions.propTypes,
-
-    /**
-     * Composes the spacing spec from the Box primitive.
-     */
-    ...spacing.propTypes,
-
-    /**
-     * Composes the position spec from the Box primitive.
-     */
-    ...position.propTypes,
-
-    /**
-     * Composes the layout spec from the Box primitive.
-     */
-    ...layout.propTypes
-  }
-
-  static defaultProps = {
-    labelProps: {
-      size: 400
-    }
-  }
-
-  render() {
+const FormField = memo(
+  forwardRef((props, ref) => {
     const {
       hint,
       label,
@@ -76,11 +17,11 @@ export default class FormField extends PureComponent {
       labelProps,
       description,
       validationMessage,
-      ...props
-    } = this.props
+      ...rest
+    } = props
 
     return (
-      <Box {...props}>
+      <Box {...rest} innerRef={ref}>
         <FormFieldLabel
           htmlFor={labelFor}
           isAstrixShown={isRequired}
@@ -111,5 +52,66 @@ export default class FormField extends PureComponent {
         )}
       </Box>
     )
+  })
+)
+
+FormField.propTypes = {
+  /**
+   * The label used above the input element.
+   */
+  label: PropTypes.node.isRequired,
+
+  /**
+   * Passed on the label as a htmlFor prop.
+   */
+  labelFor: PropTypes.string,
+
+  /**
+   * Whether or not show an asterix after the label.
+   */
+  isRequired: PropTypes.bool,
+
+  /**
+   * An optional description of the field under the label, above the input element.
+   */
+  description: PropTypes.node,
+
+  /**
+   * An optional hint under the input element.
+   */
+  hint: PropTypes.node,
+
+  /**
+   * If a validation message is passed it is shown under the input element
+   * and above the hint. This is unaffected by `isInvalid`.
+   */
+  validationMessage: PropTypes.node,
+
+  /**
+   * Composes the dimensions spec from the Box primitive.
+   */
+  ...dimensions.propTypes,
+
+  /**
+   * Composes the spacing spec from the Box primitive.
+   */
+  ...spacing.propTypes,
+
+  /**
+   * Composes the position spec from the Box primitive.
+   */
+  ...position.propTypes,
+
+  /**
+   * Composes the layout spec from the Box primitive.
+   */
+  ...layout.propTypes
+}
+
+FormField.defaultProps = {
+  labelProps: {
+    size: 400
   }
 }
+
+export default FormField

--- a/src/form-field/src/FormFieldDescription.js
+++ b/src/form-field/src/FormFieldDescription.js
@@ -1,15 +1,19 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import { Paragraph } from '../../typography'
 
-export default class FormFieldDescription extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Paragraph component as the base.
-     */
-    ...Paragraph.propTypes
-  }
+const FormFieldDescription = memo(
+  forwardRef((props, ref) => {
+    return (
+      <Paragraph marginTop={0} size={400} color="muted" {...props} ref={ref} />
+    )
+  })
+)
 
-  render() {
-    return <Paragraph marginTop={0} size={400} color="muted" {...this.props} />
-  }
+FormFieldDescription.propTypes = {
+  /**
+   * Composes the Paragraph component as the base.
+   */
+  ...Paragraph.propTypes
 }
+
+export default FormFieldDescription

--- a/src/form-field/src/FormFieldHint.js
+++ b/src/form-field/src/FormFieldHint.js
@@ -1,15 +1,19 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import { Paragraph } from '../../typography'
 
-export default class FormFieldHint extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Paragraph component as the base.
-     */
-    ...Paragraph.propTypes
-  }
+const FormFieldHint = memo(
+  forwardRef((props, ref) => {
+    return (
+      <Paragraph marginTop={0} size={300} color="muted" {...props} ref={ref} />
+    )
+  })
+)
 
-  render() {
-    return <Paragraph marginTop={0} size={300} color="muted" {...this.props} />
-  }
+FormFieldHint.propTypes = {
+  /**
+   * Composes the Paragraph component as the base.
+   */
+  ...Paragraph.propTypes
 }
+
+export default FormFieldHint

--- a/src/form-field/src/FormFieldLabel.js
+++ b/src/form-field/src/FormFieldLabel.js
@@ -1,27 +1,29 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { Label } from '../../typography'
 
-export default class FormFieldLabel extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Label component as the base.
-     */
-    ...Label.propTypes,
-
-    /**
-     * Whether or not to show an asterix after the label.
-     */
-    isAstrixShown: PropTypes.bool
-  }
-
-  render() {
-    const { children, isAstrixShown, ...props } = this.props
+const FormFieldLabel = memo(
+  forwardRef((props, ref) => {
+    const { children, isAstrixShown, ...rest } = props
     return (
-      <Label display="block" {...props}>
+      <Label display="block" {...rest} ref={ref}>
         {children}{' '}
         {isAstrixShown && <span title="This field is required.">*</span>}
       </Label>
     )
-  }
+  })
+)
+
+FormFieldLabel.propTypes = {
+  /**
+   * Composes the Label component as the base.
+   */
+  ...Label.propTypes,
+
+  /**
+   * Whether or not to show an asterix after the label.
+   */
+  isAstrixShown: PropTypes.bool
 }
+
+export default FormFieldLabel

--- a/src/typography/src/Label.js
+++ b/src/typography/src/Label.js
@@ -1,12 +1,14 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import Text from './Text'
 
-export default class Label extends PureComponent {
-  static propTypes = {
-    ...Text.propTypes
-  }
+const Label = memo(
+  forwardRef((props, ref) => {
+    return <Text is="label" fontWeight={500} {...props} ref={ref} />
+  })
+)
 
-  render() {
-    return <Text is="label" fontWeight={500} {...this.props} />
-  }
+Label.propTypes = {
+  ...Text.propTypes
 }
+
+export default Label


### PR DESCRIPTION
 ## Overview 
Mechanical change. I think with this, we're officially over the half-way mark!
 
## Screenshots (if applicable) 
![image](https://user-images.githubusercontent.com/5349500/82349969-9963c300-99af-11ea-91b8-d14f0ddd6cc5.png)

Using `<TextareaField />` as a proxy to show that `<FormField />` changes are intact.
![image](https://user-images.githubusercontent.com/5349500/82349997-a2549480-99af-11ea-9c2a-f62023b2a352.png)


## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
