### PR TITLE
Fix Combobox autocompleteProps typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -652,7 +652,7 @@ export interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof Box
   /**
    * Properties forwarded to the autocomplete component. Use with caution.
    */
-  autocompleteProps?: AutocompleteProps
+  autocompleteProps?: Omit<AutocompleteProps, 'items' | 'selectedItem' | 'onChange' | 'itemToString' | 'children'>
   /**
    * Default selected item when uncontrolled.
    */


### PR DESCRIPTION
Since some of the props are being used by the combobox, is that safe for us to omit them from  `autocompleteProps`? Now I have a problem with `autocompleteProps.items` and `autocompleteProps.children` because they are required fields.