### PR TITLE
Convert <Combobox />, <RadioGroup />, <(Un)orderedList /> to fc + memo + forwardRef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1279,8 +1279,7 @@ export interface RadioGroupProps extends Omit<PaneProps, 'onChange'> {
   onChange?(value: string): void
 }
 
-export class RadioGroup extends React.PureComponent<RadioGroupProps> {
-}
+export declare const RadioGroup: ForwardRefComponent<RadioGroupProps>
 
 export interface Option {
   label?: string
@@ -2136,6 +2135,16 @@ export interface TooltipProps {
 export class Tooltip extends React.PureComponent<TooltipProps> {
 }
 
+export interface OrderedListProps extends React.ComponentPropsWithoutRef<typeof Box> {
+  /**
+   * Size of the text used in a list item.
+   */
+  size?: keyof Typography['text']
+}
+
+export declare const OrderedList: ForwardRefComponent<OrderedListProps>
+export declare const Ol: ForwardRefComponent<OrderedListProps>
+
 export interface UnorderedListProps extends React.ComponentPropsWithoutRef<typeof Box> {
   /**
    * Size of the text used in a list item.
@@ -2152,8 +2161,8 @@ export interface UnorderedListProps extends React.ComponentPropsWithoutRef<typeo
   iconColor?: string
 }
 
-export class UnorderedList extends React.PureComponent<UnorderedListProps> {
-}
+export declare const UnorderedList: ForwardRefComponent<UnorderedListProps>
+export declare const Ul: ForwardRefComponent<UnorderedListProps>
 
 export function majorScale(x: number): number
 
@@ -2804,15 +2813,6 @@ export class SelectedPropType extends React.PureComponent<UnknownProps> {
 }
 
 export class StackingContext extends React.PureComponent<UnknownProps> {
-}
-
-export class Ul extends React.PureComponent<UnknownProps> {
-}
-
-export class OrderedList extends React.PureComponent<UnknownProps> {
-}
-
-export class Ol extends React.PureComponent<UnknownProps> {
 }
 
 export class Li extends React.PureComponent<UnknownProps> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -673,8 +673,7 @@ export interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof Box
   isLoading?: boolean
 }
 
-export class Combobox extends React.PureComponent<ComboboxProps> {
-}
+export declare const Combobox: React.FC<ComboboxProps>
 
 export interface CornerDialogProps {
   /**

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { memo, useState } from 'react'
 import PropTypes from 'prop-types'
 import Box, { dimensions, spacing, position, layout } from 'ui-box'
 import { Autocomplete } from '../../autocomplete'
@@ -6,198 +6,191 @@ import { TextInput } from '../../text-input'
 import { IconButton } from '../../buttons'
 import { CaretDownIcon } from '../../icons'
 
-export default class Combobox extends PureComponent {
-  static propTypes = {
-    /**
-     * Implements some APIs from ui-box.
-     */
-    ...dimensions.propTypes,
-    ...spacing.propTypes,
-    ...position.propTypes,
-    ...layout.propTypes,
+const Combobox = memo(props => {
+  const {
+    items,
+    selectedItem,
+    initialSelectedItem,
+    itemToString,
+    width,
+    height,
+    onChange,
+    placeholder,
+    inputProps,
+    buttonProps,
+    openOnFocus,
+    autocompleteProps,
+    isLoading,
+    ...rest
+  } = props
 
-    /**
-     * The options to show in the menu.
-     */
-    items: PropTypes.array.isRequired,
+  const disabled = disabled || isLoading
 
-    /**
-     * The selected item when controlled.
-     */
-    selectedItem: PropTypes.any,
+  const [isOpenedByButton, setIsOpenedByButton] = useState(false)
 
-    /**
-     * Function called when value changes.
-     */
-    onChange: PropTypes.func,
-
-    /**
-     * When true, open the autocomplete on focus.
-     */
-    openOnFocus: PropTypes.bool,
-
-    /**
-     * Default selected item when uncontrolled.
-     */
-    initialSelectedItem: PropTypes.any,
-
-    /**
-     * The placeholder text when there is no value present.
-     */
-    placeholder: PropTypes.string,
-
-    /**
-     * In case the array of items is not an array of strings,
-     * this function is used on each item to return the string that will be shown on the filter
-     */
-    itemToString: PropTypes.func,
-
-    /**
-     * Properties forwarded to the input. Use with caution.
-     */
-    inputProps: PropTypes.object,
-
-    /**
-     * Properties forwarded to the button. Use with caution.
-     */
-    buttonProps: PropTypes.object,
-
-    /**
-     * Properties forwarded to the autocomplete component. Use with caution.
-     */
-    autocompleteProps: PropTypes.object,
-
-    /**
-     * Makes the input element disabled.
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * When true, show a loading spinner. This also disables the button.
-     */
-    isLoading: PropTypes.bool
-  }
-
-  static defaultProps = {
-    width: 240,
-    openOnFocus: false,
-    disabled: false,
-    isLoading: false
-  }
-
-  constructor(props, context) {
-    super(props, context)
-    this.state = {
-      isOpenedByButton: false
-    }
-  }
-
-  handleStateChange = changes => {
+  const handleStateChange = changes => {
     if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
       if (!changes.isOpen) {
-        this.setState({ isOpenedByButton: false })
+        setIsOpenedByButton(false)
       }
     }
   }
 
-  render() {
-    const {
-      items,
-      selectedItem,
-      initialSelectedItem,
-      itemToString,
-      width,
-      height,
-      onChange,
-      placeholder,
-      inputProps,
-      buttonProps,
-      openOnFocus,
-      autocompleteProps,
-      isLoading,
-      ...props
-    } = this.props
-
-    const disabled = props.disabled || isLoading
-
-    return (
-      <Autocomplete
-        items={items}
-        selectedItem={selectedItem}
-        initialSelectedItem={initialSelectedItem}
-        itemToString={itemToString}
-        onChange={onChange}
-        onStateChange={this.handleStateChange}
-        isFilterDisabled={this.state.isOpenedByButton}
-        {...autocompleteProps}
-      >
-        {({
-          getRef,
-          isShown,
-          openMenu,
-          inputValue,
-          getInputProps,
-          getToggleButtonProps,
-          clearSelection
-        }) => (
-          <Box
-            innerRef={ref => getRef(ref)}
-            display="inline-flex"
-            width={width}
-            {...props}
-          >
-            <TextInput
-              width={0}
-              flex={1}
-              height={height}
-              value={inputValue}
-              borderTopRightRadius={0}
-              borderBottomRightRadius={0}
-              disabled={disabled}
-              {...getInputProps({
-                ...inputProps,
-                placeholder,
-                onFocus: () => {
-                  if (openOnFocus) openMenu()
-                },
-                onChange: e => {
-                  if (this.state.isOpenedByButton) {
-                    this.setState({
-                      isOpenedByButton: false
-                    })
-                  }
-
-                  if (e.target.value.trim() === '') {
-                    // Prevent the selected item from sticking around
-                    clearSelection()
-                  }
+  return (
+    <Autocomplete
+      items={items}
+      selectedItem={selectedItem}
+      initialSelectedItem={initialSelectedItem}
+      itemToString={itemToString}
+      onChange={onChange}
+      onStateChange={handleStateChange}
+      isFilterDisabled={isOpenedByButton}
+      {...autocompleteProps}
+    >
+      {({
+        getRef,
+        isShown,
+        openMenu,
+        inputValue,
+        getInputProps,
+        getToggleButtonProps,
+        clearSelection
+      }) => (
+        <Box
+          innerRef={ref => getRef(ref)}
+          display="inline-flex"
+          width={width}
+          {...rest}
+        >
+          <TextInput
+            width={0}
+            flex={1}
+            height={height}
+            value={inputValue}
+            borderTopRightRadius={0}
+            borderBottomRightRadius={0}
+            disabled={disabled}
+            {...getInputProps({
+              ...inputProps,
+              placeholder,
+              onFocus: () => {
+                if (openOnFocus) openMenu()
+              },
+              onChange: e => {
+                if (isOpenedByButton) {
+                  setIsOpenedByButton(false)
                 }
-              })}
-            />
-            <IconButton
-              color="muted"
-              icon={isLoading ? undefined : <CaretDownIcon />}
-              appearance="default"
-              height={height}
-              marginLeft={-1}
-              paddingLeft={isLoading ? 12 : 0}
-              paddingRight={0}
-              borderTopLeftRadius={0}
-              borderBottomLeftRadius={0}
-              disabled={disabled}
-              isLoading={isLoading}
-              {...getToggleButtonProps({
-                ...buttonProps,
-                onClick: () => {
-                  if (!isShown) {
-                    this.setState({ isOpenedByButton: true })
-                  }
+
+                if (e.target.value.trim() === '') {
+                  // Prevent the selected item from sticking around
+                  clearSelection()
                 }
-              })}
-            />
-          </Box>
-        )}
-      </Autocomplete>
-    )
-  }
+              }
+            })}
+          />
+          <IconButton
+            color="muted"
+            icon={isLoading ? undefined : <CaretDownIcon />}
+            appearance="default"
+            height={height}
+            marginLeft={-1}
+            paddingLeft={isLoading ? 12 : 0}
+            paddingRight={0}
+            borderTopLeftRadius={0}
+            borderBottomLeftRadius={0}
+            disabled={disabled}
+            isLoading={isLoading}
+            {...getToggleButtonProps({
+              ...buttonProps,
+              onClick: () => {
+                if (!isShown) {
+                  setIsOpenedByButton(true)
+                }
+              }
+            })}
+          />
+        </Box>
+      )}
+    </Autocomplete>
+  )
+})
+
+Combobox.propTypes = {
+  /**
+   * Implements some APIs from ui-box.
+   */
+  ...dimensions.propTypes,
+  ...spacing.propTypes,
+  ...position.propTypes,
+  ...layout.propTypes,
+
+  /**
+   * The options to show in the menu.
+   */
+  items: PropTypes.array.isRequired,
+
+  /**
+   * The selected item when controlled.
+   */
+  selectedItem: PropTypes.any,
+
+  /**
+   * Function called when value changes.
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * When true, open the autocomplete on focus.
+   */
+  openOnFocus: PropTypes.bool,
+
+  /**
+   * Default selected item when uncontrolled.
+   */
+  initialSelectedItem: PropTypes.any,
+
+  /**
+   * The placeholder text when there is no value present.
+   */
+  placeholder: PropTypes.string,
+
+  /**
+   * In case the array of items is not an array of strings,
+   * this function is used on each item to return the string that will be shown on the filter
+   */
+  itemToString: PropTypes.func,
+
+  /**
+   * Properties forwarded to the input. Use with caution.
+   */
+  inputProps: PropTypes.object,
+
+  /**
+   * Properties forwarded to the button. Use with caution.
+   */
+  buttonProps: PropTypes.object,
+
+  /**
+   * Properties forwarded to the autocomplete component. Use with caution.
+   */
+  autocompleteProps: PropTypes.object,
+
+  /**
+   * Makes the input element disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * When true, show a loading spinner. This also disables the button.
+   */
+  isLoading: PropTypes.bool
 }
+
+Combobox.defaultProps = {
+  width: 240,
+  openOnFocus: false,
+  disabled: false,
+  isLoading: false
+}
+
+export default Combobox

--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { spacing, position, layout, dimensions } from 'ui-box'
 import { Pane } from '../../layers'
@@ -7,90 +7,8 @@ import Radio from './Radio'
 
 let radioCount = 1 // Used for generating unique input names
 
-export default class RadioGroup extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes some Box APIs.
-     */
-    ...spacing.propTypes,
-    ...position.propTypes,
-    ...layout.propTypes,
-    ...dimensions.propTypes,
-
-    /**
-     * The options for the radios of the Radio Group.
-     */
-    options: PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.node.isRequired,
-        value: PropTypes.string.isRequired,
-        isDisabled: PropTypes.bool
-      })
-    ).isRequired,
-
-    /**
-     * The selected item value when controlled.
-     */
-    value: PropTypes.string,
-
-    /**
-     * The default value of the Radio Group when uncontrolled.
-     */
-    defaultValue: PropTypes.string,
-
-    /**
-     * Function called when state changes.
-     */
-    onChange: PropTypes.func.isRequired,
-
-    /**
-     * Label to display above the radio button options.
-     */
-    label: PropTypes.string,
-
-    /**
-     * The size of the radio circle. This also informs the text size and spacing.
-     */
-    size: PropTypes.oneOf([12, 16]).isRequired,
-
-    /**
-     * When true, the radio get the required attribute.
-     */
-    isRequired: PropTypes.bool.isRequired
-  }
-
-  static defaultProps = {
-    options: [],
-    onChange: () => {},
-    size: 12,
-    isRequired: false
-  }
-
-  constructor(props, context) {
-    super(props, context)
-
-    this.state = {
-      value: props.defaultValue || props.options[0].value
-    }
-
-    this.name = `RadioGroup-${radioCount}`
-    radioCount += 1
-  }
-
-  handleChange = event => {
-    const { value } = event.target
-
-    // Save a render cycle when it's a controlled input
-    if (!this.props.value) {
-      this.setState({ value })
-    }
-
-    if (this.props.onChange) {
-      this.props.onChange(value)
-    }
-  }
-
-  render() {
+const RadioGroup = memo(
+  forwardRef((props, ref) => {
     const {
       size,
       label,
@@ -99,14 +17,24 @@ export default class RadioGroup extends PureComponent {
       options,
       onChange,
       isRequired,
-      ...props
-    } = this.props
+      ...rest
+    } = props
 
-    // Allows it to behave like a controlled input
-    const selected = value || this.state.value
+    const name = useRef()
+    name.current = `RadioGroup-${radioCount}`
+    radioCount += 1
+
+    const handleChange = useCallback(
+      e => {
+        onChange(e.target.value)
+      },
+      [onChange]
+    )
+
+    const selected = value || defaultValue || props.options[0].value
 
     return (
-      <Pane role="group" aria-label={label} {...props}>
+      <Pane role="group" aria-label={label} {...rest} ref={ref}>
         {label && (
           <Text color="muted" fontWeight={500}>
             {label}
@@ -116,16 +44,76 @@ export default class RadioGroup extends PureComponent {
           <Radio
             key={item.value}
             size={size}
-            name={this.name}
+            name={name.current}
             value={item.value}
             label={item.label}
             checked={selected === item.value}
             disabled={item.isDisabled}
-            onChange={this.handleChange}
+            onChange={handleChange}
             isRequired={isRequired}
           />
         ))}
       </Pane>
     )
-  }
+  })
+)
+
+RadioGroup.propTypes = {
+  /**
+   * Composes some Box APIs.
+   */
+  ...spacing.propTypes,
+  ...position.propTypes,
+  ...layout.propTypes,
+  ...dimensions.propTypes,
+
+  /**
+   * The options for the radios of the Radio Group.
+   */
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node.isRequired,
+      value: PropTypes.string.isRequired,
+      isDisabled: PropTypes.bool
+    })
+  ).isRequired,
+
+  /**
+   * The selected item value when controlled.
+   */
+  value: PropTypes.string,
+
+  /**
+   * The default value of the Radio Group when uncontrolled.
+   */
+  defaultValue: PropTypes.string,
+
+  /**
+   * Function called when state changes.
+   */
+  onChange: PropTypes.func.isRequired,
+
+  /**
+   * Label to display above the radio button options.
+   */
+  label: PropTypes.string,
+
+  /**
+   * The size of the radio circle. This also informs the text size and spacing.
+   */
+  size: PropTypes.oneOf([12, 16]).isRequired,
+
+  /**
+   * When true, the radio get the required attribute.
+   */
+  isRequired: PropTypes.bool.isRequired
 }
+
+RadioGroup.defaultProps = {
+  options: [],
+  onChange: () => {},
+  size: 12,
+  isRequired: false
+}
+
+export default RadioGroup

--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, useRef, useCallback } from 'react'
+import React, { memo, forwardRef, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { spacing, position, layout, dimensions } from 'ui-box'
 import { Pane } from '../../layers'
@@ -20,9 +20,7 @@ const RadioGroup = memo(
       ...rest
     } = props
 
-    const name = useRef()
-    name.current = `RadioGroup-${radioCount}`
-    radioCount += 1
+    const [name] = useState(`RadioGroup-${radioCount++}`)
 
     const handleChange = useCallback(
       e => {
@@ -44,7 +42,7 @@ const RadioGroup = memo(
           <Radio
             key={item.value}
             size={size}
-            name={name.current}
+            name={name}
             value={item.value}
             label={item.label}
             checked={selected === item.value}

--- a/src/typography/src/OrderedList.js
+++ b/src/typography/src/OrderedList.js
@@ -1,32 +1,18 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 
-export default class OrderedList extends PureComponent {
-  static propTypes = {
-    ...Box.propTypes,
+const styles = {
+  is: 'ol',
+  margin: 0,
+  marginLeft: '1.1em',
+  padding: 0,
+  listStyle: 'decimal'
+}
 
-    /**
-     * Size of the text used in a list item.
-     * Can be: 300, 400, 500, 600.
-     */
-    size: PropTypes.oneOf([300, 400, 500, 600]).isRequired
-  }
-
-  static defaultProps = {
-    size: 400
-  }
-
-  static styles = {
-    is: 'ol',
-    margin: 0,
-    marginLeft: '1.1em',
-    padding: 0,
-    listStyle: 'decimal'
-  }
-
-  render() {
-    const { children, size, ...props } = this.props
+const OrderedList = memo(
+  forwardRef((props, ref) => {
+    const { children, size, ...rest } = props
 
     const finalChildren = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -40,9 +26,25 @@ export default class OrderedList extends PureComponent {
     })
 
     return (
-      <Box {...OrderedList.styles} {...props}>
+      <Box {...styles} {...rest} innerRef={ref}>
         {finalChildren}
       </Box>
     )
-  }
+  })
+)
+
+OrderedList.propTypes = {
+  ...Box.propTypes,
+
+  /**
+   * Size of the text used in a list item.
+   * Can be: 300, 400, 500, 600.
+   */
+  size: PropTypes.oneOf([300, 400, 500, 600]).isRequired
 }
+
+OrderedList.defaultProps = {
+  size: 400
+}
+
+export default OrderedList

--- a/src/typography/src/UnorderedList.js
+++ b/src/typography/src/UnorderedList.js
@@ -1,38 +1,18 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 
-export default class UnorderedList extends PureComponent {
-  static propTypes = {
-    ...Box.propTypes,
+const styles = {
+  is: 'ul',
+  margin: 0,
+  marginLeft: '1.1em',
+  padding: 0,
+  listStyle: 'disc'
+}
 
-    /**
-     * Size of the text used in a list item.
-     * Can be: 300, 400, 500, 600.
-     */
-    size: PropTypes.oneOf([300, 400, 500, 600]).isRequired,
-
-    /**
-     * When passed, adds a icon before each list item in the list
-     * You can override this on a individual list item.
-     */
-    icon: PropTypes.node
-  }
-
-  static defaultProps = {
-    size: 400
-  }
-
-  static styles = {
-    is: 'ul',
-    margin: 0,
-    marginLeft: '1.1em',
-    padding: 0,
-    listStyle: 'disc'
-  }
-
-  render() {
-    const { children, size, icon, ...props } = this.props
+const UnorderedList = memo(
+  forwardRef((props, ref) => {
+    const { children, size, icon, ...rest } = props
 
     const enrichedChildren = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -48,9 +28,31 @@ export default class UnorderedList extends PureComponent {
     })
 
     return (
-      <Box {...UnorderedList.styles} {...props}>
+      <Box {...styles} {...rest} innerRef={ref}>
         {enrichedChildren}
       </Box>
     )
-  }
+  })
+)
+
+UnorderedList.propTypes = {
+  ...Box.propTypes,
+
+  /**
+   * Size of the text used in a list item.
+   * Can be: 300, 400, 500, 600.
+   */
+  size: PropTypes.oneOf([300, 400, 500, 600]).isRequired,
+
+  /**
+   * When passed, adds a icon before each list item in the list
+   * You can override this on a individual list item.
+   */
+  icon: PropTypes.node
 }
+
+UnorderedList.defaultProps = {
+  size: 400
+}
+
+export default UnorderedList


### PR DESCRIPTION
## Overview 
Converts the aforementioned to fc + memo + forwardRef. Also does some light cleanup: 
* Adds + refines types for `<OrderedList />` + `<Ol />`
* Aliases `Ul` and `UnorderedList` as referencing the same component props (no more unknown!)
* Removes the ability for `<RadioGroup />` to hold its own state (no more debates around controlled vs. uncontrolled)> 
 
## Screenshots (if applicable) 
**`<Ul />`**: 
![image](https://user-images.githubusercontent.com/5349500/82695235-8fdd9380-9c19-11ea-886c-898b0ed1c60c.png)

**`<Combobox />`**: 
![image](https://user-images.githubusercontent.com/5349500/82695273-a08e0980-9c19-11ea-9ca0-009f65fc076d.png)

**`<RadioGroup />`**: 
![image](https://user-images.githubusercontent.com/5349500/82695356-c61b1300-9c19-11ea-95de-36d60a43dd5b.png)

**`<Ol />`**: 
![image](https://user-images.githubusercontent.com/5349500/82695426-eb0f8600-9c19-11ea-8311-7b904587959d.png)


## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
