### PR TITLE
Align Checkbox and Switch props a little more closely

### DIFF
--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -146,11 +146,6 @@ Checkbox.propTypes = {
   indeterminate: PropTypes.bool,
 
   /**
-   * Function that returns the ref of the checkbox.
-   */
-  innerRef: PropTypes.func,
-
-  /**
    * Function called when state changes.
    */
   onChange: PropTypes.func,
@@ -176,7 +171,6 @@ Checkbox.propTypes = {
 Checkbox.defaultProps = {
   checked: false,
   indeterminate: false,
-  innerRef: () => {},
   onChange: () => {},
   appearance: 'default'
 }

--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, useCallback } from 'react'
+import React, { memo, forwardRef } from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout } from 'ui-box'
@@ -73,9 +73,6 @@ const Switch = memo(
     } = props
 
     const theme = useTheme()
-
-    const handleChange = useCallback(event => onChange(event), [onChange])
-
     const themedClassName = theme.getSwitchClassName(appearance)
 
     return (
@@ -96,7 +93,7 @@ const Switch = memo(
           checked={checked}
           disabled={disabled}
           defaultChecked={defaultChecked}
-          onChange={handleChange}
+          onChange={onChange}
         />
         <Box height={height} width={height * 2}>
           <Box

--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, useState, useCallback } from 'react'
+import React, { memo, forwardRef, useCallback } from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout } from 'ui-box'
@@ -63,7 +63,7 @@ const Switch = memo(
       id,
       name,
       height,
-      checked: checkedProps,
+      checked,
       onChange,
       disabled,
       appearance,
@@ -71,25 +71,11 @@ const Switch = memo(
       defaultChecked,
       ...rest
     } = props
-    const [isChecked, setIsChecked] = useState(
-      checkedProps || defaultChecked || false
-    )
 
     const theme = useTheme()
 
-    const handleChange = useCallback(
-      value => {
-        if (checkedProps) {
-          onChange(value)
-        } else {
-          setIsChecked(checked => !checked)
-          onChange(value)
-        }
-      },
-      [onChange]
-    )
+    const handleChange = useCallback(event => onChange(event), [onChange])
 
-    const checked = checkedProps ? checkedProps : isChecked
     const themedClassName = theme.getSwitchClassName(appearance)
 
     return (


### PR DESCRIPTION
## Overview 
This PR removes the optionality for `onChange` in `<Switch />` (forcing developers to wire up state for it themselves), and cleans up an unused `innerRef` in `<Checkbox />` (now that we're slowly supporting ref-forwarding everywhere in EG.
 
## Screenshots (if applicable) 

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
