### PR TITLE
Convert <Menu /> and its subcomponents to fc + hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1094,9 +1094,9 @@ declare const MenuItem: React.FC<MenuItemProps>
 declare const MenuDivider: React.FC<{}>
 declare const MenuGroup: React.FC<MenuGroupProps>
 declare const MenuOption: React.FC<MenuOptionProps>
-declare const MenuOptionsGroup: React.FC<MenuOptionsGroupProps<T>>
+declare class MenuOptionsGroup<T> extends React.FC<MenuOptionsGroupProps<T>> {}
 
-export class Menu extends React.PureComponent<MenuProps> {
+export declare class Menu extends React.FC<MenuProps> {
   // @ts-ignore
   public static Item = MenuItem
   // @ts-ignore

--- a/index.d.ts
+++ b/index.d.ts
@@ -1094,19 +1094,14 @@ declare const MenuItem: React.FC<MenuItemProps>
 declare const MenuDivider: React.FC<{}>
 declare const MenuGroup: React.FC<MenuGroupProps>
 declare const MenuOption: React.FC<MenuOptionProps>
-declare class MenuOptionsGroup<T> extends React.FC<MenuOptionsGroupProps<T>> {}
+declare const MenuOptionsGroup: React.FC<MenuOptionsGroupProps<any>>
 
-export declare class Menu extends React.FC<MenuProps> {
-  // @ts-ignore
-  public static Item = MenuItem
-  // @ts-ignore
-  public static Divider = MenuDivider
-  // @ts-ignore
-  public static Group = MenuGroup
-  // @ts-ignore
-  public static Option = MenuOption
-  // @ts-ignore
-  public static OptionsGroup = MenuOptionsGroup
+export declare const Menu: React.FC<MenuProps> & {
+  Item: typeof MenuItem
+  Divider: typeof MenuDivider
+  Group: typeof MenuGroup
+  Option: typeof MenuOption
+  OptionsGroup: typeof MenuOptionsGroup
 }
 
 export type PaneProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, 'border' | 'borderTop' | 'borderRight' | 'borderBottom' | 'borderLeft'> & {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1090,22 +1090,23 @@ export interface MenuOptionsGroupProps<T> {
   options: Array<{ value: T, label: string }>
 }
 
+declare const MenuItem: React.FC<MenuItemProps>
+declare const MenuDivider: React.FC<{}>
+declare const MenuGroup: React.FC<MenuGroupProps>
+declare const MenuOption: React.FC<MenuOptionProps>
+declare const MenuOptionsGroup: React.FC<MenuOptionsGroupProps<T>>
+
 export class Menu extends React.PureComponent<MenuProps> {
   // @ts-ignore
-  public static Item = class MenuItem extends React.PureComponent<MenuItemProps> {
-  }
+  public static Item = MenuItem
   // @ts-ignore
-  public static Divider = class MenuDivider extends React.PureComponent {
-  }
+  public static Divider = MenuDivider
   // @ts-ignore
-  public static Group = class MenuGroup extends React.PureComponent<MenuGroupProps> {
-  }
+  public static Group = MenuGroup
   // @ts-ignore
-  public static Option = class Option extends React.PureComponent<MenuOptionProps> {
-  }
+  public static Option = MenuOption
   // @ts-ignore
-  public static OptionsGroup = class MenuOptionsGroup<T extends string | number | null> extends React.PureComponent<MenuOptionsGroupProps<T>> {
-  }
+  public static OptionsGroup = MenuOptionsGroup
 }
 
 export type PaneProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, 'border' | 'borderTop' | 'borderRight' | 'borderBottom' | 'borderLeft'> & {

--- a/src/menu/src/MenuGroup.js
+++ b/src/menu/src/MenuGroup.js
@@ -1,32 +1,33 @@
-import React from 'react'
+import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Heading } from '../../typography'
 
-export default class MenuGroup extends React.PureComponent {
-  static propTypes = {
-    /**
-     * Title of the menu group.
-     */
-    title: PropTypes.node,
+const MenuGroup = memo(props => {
+  const { title, children } = props
 
-    /**
-     * The children of the menu group.
-     */
-    children: PropTypes.node
-  }
+  return (
+    <Pane paddingY={8}>
+      {title && (
+        <Heading size={100} marginX={16} marginY={8}>
+          {title}
+        </Heading>
+      )}
+      {children}
+    </Pane>
+  )
+})
 
-  render() {
-    const { title, children } = this.props
-    return (
-      <Pane paddingY={8}>
-        {title && (
-          <Heading size={100} marginX={16} marginY={8}>
-            {title}
-          </Heading>
-        )}
-        {children}
-      </Pane>
-    )
-  }
+MenuGroup.propTypes = {
+  /**
+   * Title of the menu group.
+   */
+  title: PropTypes.node,
+
+  /**
+   * The children of the menu group.
+   */
+  children: PropTypes.node
 }
+
+export default MenuGroup

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -1,102 +1,46 @@
-import React from 'react'
+import React, { memo, forwardRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { IconWrapper } from '../../icons/src/IconWrapper'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import safeInvoke from '../../lib/safe-invoke'
-import warning from '../../lib/warning'
 
-class MenuItem extends React.PureComponent {
-  static propTypes = {
-    /**
-     * Element type to use for the menu item.
-     * For example: `<MenuItem is={ReactRouterLink}>...</MenuItem>`
-     */
-    is: Box.propTypes.is,
-
-    /**
-     * Function that is called on click and enter/space keypress.
-     */
-    onSelect: PropTypes.func,
-
-    /**
-     * The Evergreen or custom icon before the label.
-     */
-    icon: PropTypes.node,
-
-    /**
-     * The children of the component.
-     */
-    children: PropTypes.node,
-
-    /**
-     * Secondary text shown on the right.
-     */
-    secondaryText: PropTypes.node,
-
-    /**
-     * The default theme only supports one default appearance.
-     */
-    appearance: PropTypes.string.isRequired,
-
-    /**
-     * The intent of the menu item.
-     */
-    intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger'])
-      .isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    is: 'div',
-    intent: 'none',
-    appearance: 'default',
-    onSelect: () => {}
-  }
-
-  handleClick = event => {
-    this.props.onSelect(event)
-
-    /* eslint-disable react/prop-types */
-    safeInvoke(this.props.onClick, event)
-    /* eslint-enable react/prop-types */
-  }
-
-  handleKeyPress = event => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      this.props.onSelect(event)
-      event.preventDefault()
-    }
-
-    /* eslint-disable react/prop-types */
-    safeInvoke(this.props.onKeyPress, event)
-    /* eslint-enable react/prop-types */
-  }
-
-  render() {
+const MenuItem = memo(
+  forwardRef((props, ref) => {
     const {
       is,
       children,
-      theme,
       appearance,
       secondaryText,
       intent,
       icon,
+      onSelect,
+      onKeyPress,
       ...passthroughProps
-    } = this.props
+    } = props
 
-    if (process.env.NODE_ENV !== 'production') {
-      warning(
-        'onClick' in this.props,
-        '<Menu.Item> expects `onSelect` prop, but you passed `onClick`.'
-      )
-    }
+    const theme = useTheme()
+
+    const handleClick = useCallback(
+      event => {
+        onSelect(event)
+      },
+      [onSelect]
+    )
+
+    const handleKeyPress = useCallback(
+      event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          onSelect(event)
+          event.preventDefault()
+        }
+
+        safeInvoke(onKeyPress, event)
+      },
+      [onSelect, onKeyPress]
+    )
 
     const themedClassName = theme.getMenuItemClassName(appearance, 'none')
 
@@ -105,13 +49,14 @@ class MenuItem extends React.PureComponent {
         is={is}
         role="menuitem"
         className={themedClassName}
-        onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
+        onClick={handleClick}
+        onKeyPress={handleKeyPress}
         height={icon ? 40 : 32}
         tabIndex={0}
         data-isselectable="true"
         display="flex"
         alignItems="center"
+        ref={ref}
         {...passthroughProps}
       >
         <IconWrapper
@@ -132,7 +77,57 @@ class MenuItem extends React.PureComponent {
         )}
       </Pane>
     )
-  }
+  })
+)
+
+MenuItem.propTypes = {
+  /**
+   * Element type to use for the menu item.
+   * For example: `<MenuItem is={ReactRouterLink}>...</MenuItem>`
+   */
+  is: Box.propTypes.is,
+
+  /**
+   * Function that is called on click and enter/space keypress.
+   */
+  onSelect: PropTypes.func,
+
+  /**
+   * The Evergreen or custom icon before the label.
+   */
+  icon: PropTypes.node,
+
+  /**
+   * The children of the component.
+   */
+  children: PropTypes.node,
+
+  /**
+   * Secondary text shown on the right.
+   */
+  secondaryText: PropTypes.node,
+
+  /**
+   * The default theme only supports one default appearance.
+   */
+  appearance: PropTypes.string.isRequired,
+
+  /**
+   * The intent of the menu item.
+   */
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+
+  /**
+   * Callback to invoke onkeypress
+   */
+  onKeyPress: PropTypes.func
 }
 
-export default withTheme(MenuItem)
+MenuItem.defaultProps = {
+  is: 'div',
+  intent: 'none',
+  appearance: 'default',
+  onSelect: () => {}
+}
+
+export default MenuItem

--- a/src/menu/src/MenuOption.js
+++ b/src/menu/src/MenuOption.js
@@ -1,122 +1,117 @@
-import React from 'react'
+import React, { memo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
 import { TickIcon } from '../../icons'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 
-class MenuOption extends React.PureComponent {
-  static propTypes = {
-    /**
-     * The id attribute of the menu option.
-     */
-    id: PropTypes.string,
+const MenuOption = memo(props => {
+  const {
+    id,
+    children,
+    appearance,
+    onSelect,
+    secondaryText,
+    isSelected
+  } = props
 
-    /**
-     * Function that is called on click and enter/space keypress.
-     */
-    onSelect: PropTypes.func,
+  const handleClick = useCallback(e => onSelect(e), [onSelect])
 
-    /**
-     * The icon before the label.
-     */
-    isSelected: PropTypes.bool,
+  const handleKeyPress = useCallback(
+    e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        onSelect(e)
+        e.preventDefault()
+      }
+    },
+    [onSelect]
+  )
 
-    /**
-     * The children of the component.
-     */
-    children: PropTypes.node,
+  const theme = useTheme()
+  const themedClassName = theme.getMenuItemClassName(appearance, 'none')
 
-    /**
-     * Secondary text shown on the right.
-     */
-    secondaryText: PropTypes.node,
+  const textProps = isSelected
+    ? {
+        color: 'selected',
+        fontWeight: 500,
+        marginLeft: 16
+      }
+    : { marginLeft: 44 }
 
-    /**
-     * The default theme only supports one default appearance.
-     */
-    appearance: PropTypes.string.isRequired,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    appearance: 'default',
-    isSelected: false,
-    onClick: () => {},
-    onSelect: () => {},
-    onKeyPress: () => {}
-  }
-
-  handleClick = () => {
-    this.props.onSelect()
-  }
-
-  handleKeyPress = e => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      this.props.onSelect()
-      e.preventDefault()
-    }
-  }
-
-  render() {
-    const {
-      id,
-      children,
-      theme,
-      appearance,
-      secondaryText,
-      isSelected
-    } = this.props
-
-    const themedClassName = theme.getMenuItemClassName(appearance, 'none')
-
-    const textProps = isSelected
-      ? {
-          color: 'selected',
-          fontWeight: 500,
-          marginLeft: 16
-        }
-      : { marginLeft: 44 }
-
-    return (
-      <Pane
-        id={id}
-        role="menuitemradio"
-        tabIndex={0}
-        className={themedClassName}
-        onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
-        data-isselectable="true"
-        aria-checked={isSelected}
-        height={40}
-        display="flex"
-        alignItems="center"
-      >
-        {isSelected && (
-          <TickIcon
-            aria-hidden
-            color="selected"
-            marginLeft={16}
-            marginRight={-4}
-            size={16}
-            flexShrink={0}
-          />
-        )}
-        <Text {...textProps} marginRight={16} flex={1}>
-          {children}
+  return (
+    <Pane
+      id={id}
+      role="menuitemradio"
+      tabIndex={0}
+      className={themedClassName}
+      onClick={handleClick}
+      onKeyPress={handleKeyPress}
+      data-isselectable="true"
+      aria-checked={isSelected}
+      height={40}
+      display="flex"
+      alignItems="center"
+    >
+      {isSelected && (
+        <TickIcon
+          aria-hidden
+          color="selected"
+          marginLeft={16}
+          marginRight={-4}
+          size={16}
+          flexShrink={0}
+        />
+      )}
+      <Text {...textProps} marginRight={16} flex={1}>
+        {children}
+      </Text>
+      {secondaryText && (
+        <Text marginRight={16} color="muted">
+          {secondaryText}
         </Text>
-        {secondaryText && (
-          <Text marginRight={16} color="muted">
-            {secondaryText}
-          </Text>
-        )}
-      </Pane>
-    )
-  }
+      )}
+    </Pane>
+  )
+})
+
+MenuOption.propTypes = {
+  /**
+   * The id attribute of the menu option.
+   */
+  id: PropTypes.string,
+
+  /**
+   * Function that is called on click and enter/space keypress.
+   */
+  onSelect: PropTypes.func,
+
+  /**
+   * The icon before the label.
+   */
+  isSelected: PropTypes.bool,
+
+  /**
+   * The children of the component.
+   */
+  children: PropTypes.node,
+
+  /**
+   * Secondary text shown on the right.
+   */
+  secondaryText: PropTypes.node,
+
+  /**
+   * The default theme only supports one default appearance.
+   */
+  appearance: PropTypes.string.isRequired
 }
 
-export default withTheme(MenuOption)
+MenuOption.defaultProps = {
+  appearance: 'default',
+  isSelected: false,
+  onClick: () => {},
+  onSelect: () => {},
+  onKeyPress: () => {}
+}
+
+export default MenuOption


### PR DESCRIPTION
## Overview 
Converts and lightly polishes up the APIs for `<Menu />` and its subcomponents. I'm still not _entirely_ sure the best way to type this, but I think it's a start and is somewhat close. 
 
## Screenshots (if applicable) 
![image](https://user-images.githubusercontent.com/5349500/82711464-5c5f3100-9c3a-11ea-859a-9329472f1779.png)

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
