### PR TITLE
convert Popover components to hooks + fc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1145,8 +1145,7 @@ export interface PopoverProps {
   statelessProps?: PopoverStatelessProps
 }
 
-export class Popover extends React.PureComponent<PopoverProps> {
-}
+export declare const Popover: ForwardRefComponent<PopoverProps>
 
 export type ParagraphProps = React.ComponentPropsWithoutRef<typeof Box> & {
   size?: keyof Typography['paragraph']

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -1,163 +1,40 @@
+import React, { memo, useState, useEffect } from 'react'
 import cx from 'classnames'
 import { css as glamorCss } from 'glamor'
-import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Positioner } from '../../positioner'
 import { Tooltip } from '../../tooltip'
 import { Position } from '../../constants'
 import PopoverStateless from './PopoverStateless'
 
-export default class Popover extends Component {
-  static propTypes = {
-    /**
-     * The position the Popover is on. Smart positioning might override this.
-     */
-    position: PropTypes.oneOf([
-      Position.TOP,
-      Position.TOP_LEFT,
-      Position.TOP_RIGHT,
-      Position.BOTTOM,
-      Position.BOTTOM_LEFT,
-      Position.BOTTOM_RIGHT,
-      Position.LEFT,
-      Position.RIGHT
-    ]),
-
-    /**
-     * When true, the Popover is manually shown.
-     */
-    isShown: PropTypes.bool,
-    /**
-     * Open the Popover based on click or hover. Default is click.
-     */
-    trigger: PropTypes.oneOf(['click', 'hover']),
-
-    /**
-     * The content of the Popover.
-     */
-    content: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-
-    /**
-     * The target button of the Popover.
-     * When a function the following arguments are passed:
-     * ({ toggle: Function -> Void, getRef: Function -> Ref, isShown: Bool })
-     */
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
-      .isRequired,
-
-    /**
-     * The display property passed to the Popover card.
-     */
-    display: PropTypes.string,
-
-    /**
-     * The min width of the Popover card.
-     */
-    minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-
-    /**
-     * The min height of the Popover card.
-     */
-    minHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-
-    /**
-     * Properties passed through to the Popover card.
-     */
-    statelessProps: PropTypes.shape(PopoverStateless.propTypes),
-
-    /**
-     * Duration of the animation.
-     */
-    animationDuration: PropTypes.number,
-
-    /**
-     * Function called when the Popover opens.
-     */
-    onOpen: PropTypes.func.isRequired,
-
-    /**
-     * Function fired when Popover closes.
-     */
-    onClose: PropTypes.func.isRequired,
-
-    /**
-     * Function that will be called when the enter transition is complete.
-     */
-    onOpenComplete: PropTypes.func.isRequired,
-
-    /**
-     * Function that will be called when the exit transition is complete.
-     */
-    onCloseComplete: PropTypes.func.isRequired,
-
-    /**
-     * Function that will be called when the body is clicked.
-     */
-    onBodyClick: PropTypes.func.isRequired,
-
-    /**
-     * When true, bring focus inside of the Popover on open.
-     */
-    bringFocusInside: PropTypes.bool,
-
-    /**
-     * Boolean indicating if clicking outside the dialog should close the dialog.
-     */
-    shouldCloseOnExternalClick: PropTypes.bool
-  }
-
-  static defaultProps = {
-    position: Position.BOTTOM,
-    minWidth: 200,
-    minHeight: 40,
-    animationDuration: 300,
-    onOpen: () => {},
-    onClose: () => {},
-    onOpenComplete: () => {},
-    onCloseComplete: () => {},
-    onBodyClick: () => {},
-    bringFocusInside: false,
-    shouldCloseOnExternalClick: true,
-    trigger: 'click'
-  }
-
-  constructor(props) {
-    super(props)
-    this.state = {
-      isShown: props.isShown
-    }
-  }
-
-  componentWillUnmount() {
-    document.body.removeEventListener('click', this.onBodyClick, false)
-    document.body.removeEventListener('keydown', this.onEsc, false)
-  }
+const Popover = memo(props => {
+  const [isShown, setIsShown] = useState(props.isShown)
+  const [popoverNode, setPopoverNode] = useState(null)
+  const [targetRef, setTargetRef] = useState(null)
 
   /**
    * Methods borrowed from BlueprintJS
    * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
    */
-  bringFocusInside = () => {
+  const bringFocusInside = () => {
     // Always delay focus manipulation to just before repaint to prevent scroll jumping
     return requestAnimationFrame(() => {
       // Container ref may be undefined between component mounting and Portal rendering
       // activeElement may be undefined in some rare cases in IE
       if (
-        this.popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
+        popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
         document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
-        !this.state.isShown
+        !isShown
       ) {
         return
       }
 
-      const isFocusOutsideModal = !this.popoverNode.contains(
-        document.activeElement
-      )
+      const isFocusOutsideModal = !popoverNode.contains(document.activeElement)
       if (isFocusOutsideModal) {
         // Element marked autofocus has higher priority than the other clowns
-        const autofocusElement = this.popoverNode.querySelector('[autofocus]')
-        const wrapperElement = this.popoverNode.querySelector('[tabindex]')
-        const buttonElements = this.popoverNode.querySelectorAll(
+        const autofocusElement = popoverNode.querySelector('[autofocus]')
+        const wrapperElement = popoverNode.querySelector('[tabindex]')
+        const buttonElements = popoverNode.querySelectorAll(
           'button, a, [role="menuitem"], [role="menuitemradio"]'
         )
 
@@ -172,122 +49,95 @@ export default class Popover extends Component {
     })
   }
 
-  bringFocusBackToTarget = () => {
+  const bringFocusBackToTarget = () => {
     return requestAnimationFrame(() => {
       if (
-        this.popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
+        targetRef == null || // eslint-disable-line eqeqeq, no-eq-null
+        popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
         document.activeElement == null // eslint-disable-line eqeqeq, no-eq-null
       ) {
         return
       }
 
-      const isFocusInsideModal = this.popoverNode.contains(
-        document.activeElement
-      )
+      const isFocusInsideModal = popoverNode.contains(document.activeElement)
 
       // Bring back focus on the target.
-      if (
-        this.targetRef &&
-        (document.activeElement === document.body || isFocusInsideModal)
-      ) {
-        this.targetRef.focus()
+      if (document.activeElement === document.body || isFocusInsideModal) {
+        targetRef.focus()
       }
     })
   }
 
-  onBodyClick = e => {
-    // Ignore clicks on the popover or button
-    if (this.targetRef && this.targetRef.contains(e.target)) {
+  const open = () => {
+    if (isShown) {
       return
     }
 
-    if (this.popoverNode && this.popoverNode.contains(e.target)) {
+    setIsShown(true)
+    props.onOpen()
+  }
+
+  const close = () => {
+    if (!isShown) {
+      return
+    }
+
+    setIsShown(false)
+    bringFocusBackToTarget()
+    props.onClose()
+  }
+
+  const toggle = () => (isShown ? close() : open())
+  const handleOpenHover = props.trigger === 'hover' ? open : undefined
+  const handleCloseHover = props.trigger === 'hover' ? close : undefined
+  const handleKeyDown = event =>
+    event.key === 'ArrowDown' ? bringFocusInside() : undefined
+  const onEsc = event => (event.key === 'Escape' ? close() : undefined)
+
+  const onBodyClick = event => {
+    // Ignore clicks on the popover or button
+    if (targetRef && targetRef.contains(event.target)) {
+      return
+    }
+
+    if (popoverNode && popoverNode.contains(event.target)) {
       return
     }
 
     // Notify body click
-    this.props.onBodyClick(e)
+    props.onBodyClick(event)
 
-    if (this.props.shouldCloseOnExternalClick === false) {
-      return
-    }
-
-    this.close()
-  }
-
-  onEsc = e => {
-    // Esc key
-    if (e.keyCode === 27) {
-      this.close()
+    if (props.shouldCloseOnExternalClick !== false) {
+      close()
     }
   }
 
-  toggle = () => {
-    if (this.state.isShown) {
-      this.close()
+  const handleOpenComplete = () => {
+    if (props.bringFocusInside) bringFocusInside()
+    props.onOpenComplete()
+  }
+
+  useEffect(() => {
+    if (isShown) {
+      document.body.addEventListener('click', onBodyClick, false)
+      document.body.addEventListener('keydown', onEsc, false)
     } else {
-      this.open()
-    }
-  }
-
-  open = () => {
-    if (this.state.isShown) {
-      return
+      document.body.removeEventListener('click', onBodyClick, false)
+      document.body.removeEventListener('keydown', onEsc, false)
     }
 
-    this.setState({ isShown: true })
-    document.body.addEventListener('click', this.onBodyClick, false)
-    document.body.addEventListener('keydown', this.onEsc, false)
-
-    this.props.onOpen()
-  }
-
-  close = () => {
-    if (!this.state.isShown) {
-      return
+    return () => {
+      document.body.removeEventListener('click', onBodyClick, false)
+      document.body.removeEventListener('keydown', onEsc, false)
     }
+  }, [isShown])
 
-    this.setState({ isShown: false })
-    document.body.removeEventListener('click', this.onBodyClick, false)
-    document.body.removeEventListener('keydown', this.onEsc, false)
-
-    this.bringFocusBackToTarget()
-    this.props.onClose()
-  }
-
-  handleOpenComplete = () => {
-    if (this.props.bringFocusInside) this.bringFocusInside()
-    this.props.onOpenComplete()
-  }
-
-  handleCloseComplete = () => {
-    this.props.onCloseComplete()
-  }
-
-  handleKeyDown = e => {
-    if (e.key === 'ArrowDown') {
-      this.bringFocusInside()
-    }
-  }
-
-  handleOpenHover = () => {
-    if (this.props.trigger === 'hover') {
-      this.open()
-    }
-  }
-
-  handleCloseHover = () => {
-    if (this.props.trigger === 'hover') {
-      this.close()
-    }
-  }
-
-  renderTarget = ({ getRef, isShown }) => {
-    const { children } = this.props
+  const renderTarget = ({ getRef, isShown }) => {
+    const { children } = props
     const isTooltipInside = children && children.type === Tooltip
 
     const getTargetRef = ref => {
-      this.targetRef = ref
+      setTargetRef(ref)
       getRef(ref)
     }
 
@@ -296,16 +146,16 @@ export default class Popover extends Component {
      */
     if (typeof children === 'function') {
       return children({
-        toggle: this.toggle,
         getRef: getTargetRef,
-        isShown
+        isShown,
+        toggle
       })
     }
 
     const popoverTargetProps = {
-      onClick: this.toggle,
-      onMouseEnter: this.handleOpenHover,
-      onKeyDown: this.handleKeyDown,
+      onClick: toggle,
+      onMouseEnter: handleOpenHover,
+      onKeyDown: handleKeyDown,
       role: 'button',
       'aria-expanded': isShown,
       'aria-haspopup': true
@@ -339,65 +189,165 @@ export default class Popover extends Component {
     })
   }
 
-  render() {
-    const {
-      isShown,
-      content,
-      display,
-      minWidth,
-      position,
-      minHeight,
-      statelessProps = {},
-      animationDuration,
-      onCloseComplete
-    } = this.props
-    const { isShown: stateIsShown } = this.state
+  const {
+    content,
+    display,
+    minWidth,
+    position,
+    minHeight,
+    statelessProps = {},
+    animationDuration,
+    onCloseComplete
+  } = props
 
-    // If `isShown` is a boolean, popover is controlled manually, not via mouse events
-    const shown = typeof isShown === 'boolean' ? isShown : stateIsShown
+  // If `props.isShown` is a boolean, popover is controlled manually, not via mouse events
+  const shown = typeof props.isShown === 'boolean' ? props.isShown : isShown
 
-    return (
-      <Positioner
-        target={({ getRef, isShown, targetWidth }) => {
-          return this.renderTarget({ getRef, isShown, targetWidth })
-        }}
-        isShown={shown}
-        position={position}
-        animationDuration={animationDuration}
-        onOpenComplete={this.handleOpenComplete}
-        onCloseComplete={onCloseComplete}
-      >
-        {({ css, style, state, getRef }) => (
-          <PopoverStateless
-            innerRef={ref => {
-              this.popoverNode = ref
-              getRef(ref)
-            }}
-            data-state={state}
-            display={display}
-            minWidth={minWidth}
-            minHeight={minHeight}
-            {...statelessProps}
-            className={cx(
-              statelessProps.className,
-              css ? glamorCss(css).toString() : undefined
-            )}
-            style={
-              statelessProps && statelessProps.style
-                ? {
-                    ...style,
-                    ...statelessProps.style
-                  }
-                : style
-            }
-            onMouseLeave={this.handleCloseHover}
-          >
-            {typeof content === 'function'
-              ? content({ close: this.close })
-              : content}
-          </PopoverStateless>
-        )}
-      </Positioner>
-    )
-  }
+  return (
+    <Positioner
+      target={renderTarget}
+      isShown={shown}
+      position={position}
+      animationDuration={animationDuration}
+      onOpenComplete={handleOpenComplete}
+      onCloseComplete={onCloseComplete}
+    >
+      {({ css, style, state, getRef }) => (
+        <PopoverStateless
+          ref={ref => {
+            setPopoverNode(ref)
+            getRef(ref)
+          }}
+          data-state={state}
+          display={display}
+          minWidth={minWidth}
+          minHeight={minHeight}
+          {...statelessProps}
+          className={cx(
+            statelessProps.className,
+            glamorCss(css, style, statelessProps.style).toString()
+          )}
+          // Overwrite `statelessProps.style` since we are including it via className
+          style={undefined}
+          onMouseLeave={handleCloseHover}
+        >
+          {typeof content === 'function' ? content({ close }) : content}
+        </PopoverStateless>
+      )}
+    </Positioner>
+  )
+})
+
+Popover.propTypes = {
+  /**
+   * The position the Popover is on. Smart positioning might override this.
+   */
+  position: PropTypes.oneOf([
+    Position.TOP,
+    Position.TOP_LEFT,
+    Position.TOP_RIGHT,
+    Position.BOTTOM,
+    Position.BOTTOM_LEFT,
+    Position.BOTTOM_RIGHT,
+    Position.LEFT,
+    Position.RIGHT
+  ]),
+
+  /**
+   * When true, the Popover is manually shown.
+   */
+  isShown: PropTypes.bool,
+  /**
+   * Open the Popover based on click or hover. Default is click.
+   */
+  trigger: PropTypes.oneOf(['click', 'hover']),
+
+  /**
+   * The content of the Popover.
+   */
+  content: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+  /**
+   * The target button of the Popover.
+   * When a function the following arguments are passed:
+   * ({ toggle: Function -> Void, getRef: Function -> Ref, isShown: Bool })
+   */
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+
+  /**
+   * The display property passed to the Popover card.
+   */
+  display: PropTypes.string,
+
+  /**
+   * The min width of the Popover card.
+   */
+  minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+  /**
+   * The min height of the Popover card.
+   */
+  minHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+
+  /**
+   * Properties passed through to the Popover card.
+   */
+  statelessProps: PropTypes.shape(PopoverStateless.propTypes),
+
+  /**
+   * Duration of the animation.
+   */
+  animationDuration: PropTypes.number,
+
+  /**
+   * Function called when the Popover opens.
+   */
+  onOpen: PropTypes.func.isRequired,
+
+  /**
+   * Function fired when Popover closes.
+   */
+  onClose: PropTypes.func.isRequired,
+
+  /**
+   * Function that will be called when the enter transition is complete.
+   */
+  onOpenComplete: PropTypes.func.isRequired,
+
+  /**
+   * Function that will be called when the exit transition is complete.
+   */
+  onCloseComplete: PropTypes.func.isRequired,
+
+  /**
+   * Function that will be called when the body is clicked.
+   */
+  onBodyClick: PropTypes.func.isRequired,
+
+  /**
+   * When true, bring focus inside of the Popover on open.
+   */
+  bringFocusInside: PropTypes.bool,
+
+  /**
+   * Boolean indicating if clicking outside the dialog should close the dialog.
+   */
+  shouldCloseOnExternalClick: PropTypes.bool
 }
+
+Popover.defaultProps = {
+  position: Position.BOTTOM,
+  minWidth: 200,
+  minHeight: 40,
+  animationDuration: 300,
+  onOpen: () => {},
+  onClose: () => {},
+  onOpenComplete: () => {},
+  onCloseComplete: () => {},
+  onBodyClick: () => {},
+  bringFocusInside: false,
+  shouldCloseOnExternalClick: true,
+  trigger: 'click'
+}
+
+export default Popover

--- a/src/popover/src/PopoverStateless.js
+++ b/src/popover/src/PopoverStateless.js
@@ -1,34 +1,33 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { Card } from '../../layers'
 
-export default class PopoverStateless extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Card as the base.
-     */
-    ...Card.propTypes,
+const PopoverStateless = memo(
+  forwardRef(({ children, ...props }, ref) => (
+    <Card
+      ref={ref}
+      role="dialog"
+      elevation={3}
+      overflow="hidden"
+      minWidth={200}
+      backgroundColor="white"
+      {...props}
+    >
+      {children}
+    </Card>
+  ))
+)
 
-    /**
-     * The content of the Popover.
-     */
-    children: PropTypes.node
-  }
+PopoverStateless.propTypes = {
+  /**
+   * Composes the Card as the base.
+   */
+  ...Card.propTypes,
 
-  render() {
-    const { children, ...props } = this.props
-
-    return (
-      <Card
-        role="dialog"
-        elevation={3}
-        overflow="hidden"
-        minWidth={200}
-        backgroundColor="white"
-        {...props}
-      >
-        {children}
-      </Card>
-    )
-  }
+  /**
+   * The content of the Popover.
+   */
+  children: PropTypes.node
 }
+
+export default PopoverStateless

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -216,7 +216,6 @@ export default class Positioner extends PureComponent {
       isShown,
       children,
       initialScale,
-      targetOffset,
       animationDuration
     } = this.props
 
@@ -246,7 +245,6 @@ export default class Positioner extends PureComponent {
                       state,
                       zIndex,
                       css: getCSS({
-                        targetOffset,
                         initialScale,
                         animationDuration
                       }),


### PR DESCRIPTION
## Overview 
This migrates the Popover components to use hooks + React.FC
 
## Screenshots (if applicable) 
NA

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
