### PR TITLE
convert Overlay components to hooks + fc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2266,16 +2266,15 @@ interface OverlayProps {
   shouldCloseOnClick?: boolean;
   shouldCloseOnEscapePress?: boolean;
   onBeforeClose?: () => void;
-  onExit?: () => void;
+  onExit?: TransitionProps['onExit'];
   onExiting?: TransitionProps['onExiting'];
   onExited?: TransitionProps['onExited'];
-  onEnter?: () => void;
+  onEnter?: TransitionProps['onEnter'];
   onEntering?: TransitionProps['onEntering'];
   onEntered?: TransitionProps['onEntered'];
 }
 
-export class Overlay extends React.PureComponent<OverlayProps> {
-}
+export declare const Overlay: ForwardRefComponent<OverlayProps>
 
 export interface IconProps extends BoxProps<'svg'> {
   /**

--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -171,19 +171,19 @@ const Overlay = memo(props => {
     }
   }
 
-  const handleEnter = node => {
+  const handleEnter = (node, isAppearing) => {
     handleBodyScroll(true)
-    safeInvoke(props.onEnter, node)
+    safeInvoke(props.onEnter, node, isAppearing)
   }
 
-  const handleEntering = node => {
+  const handleEntering = (node, isAppearing) => {
     setStatus('entering')
-    safeInvoke(props.onEntering, node)
+    safeInvoke(props.onEntering, node, isAppearing)
   }
 
-  const handleEntered = node => {
+  const handleEntered = (node, isAppearing) => {
     setStatus('entered')
-    safeInvoke(props.onEntered, node)
+    safeInvoke(props.onEntered, node, isAppearing)
   }
 
   const handleExit = node => {

--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -1,15 +1,17 @@
+import React, { memo, useState, useEffect } from 'react'
 import cx from 'classnames'
 import { css } from 'glamor'
-import React from 'react'
 import PropTypes from 'prop-types'
 import Transition from 'react-transition-group/Transition'
 import Box from 'ui-box'
 import { Portal } from '../../portal'
 import { Stack } from '../../stack'
 import { StackingOrder } from '../../constants'
-import { withTheme } from '../../theme'
+import { useTheme } from '../../theme'
 import safeInvoke from '../../lib/safe-invoke'
 import preventBodyScroll from '../../lib/prevent-body-scroll'
+
+const NOOP = () => {}
 
 const animationEasing = {
   standard: `cubic-bezier(0.4, 0.0, 0.2, 1)`,
@@ -51,176 +53,88 @@ const animationStyles = backgroundColor => ({
     content: '" "'
   },
   '&[data-state="entering"]::before, &[data-state="entered"]::before': {
-    animation: `${fadeInAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.deceleration
-    } both`
+    animation: `${fadeInAnimation} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
   },
   '&[data-state="exiting"]::before, &[data-state="exited"]::before': {
-    animation: `${fadeOutAnimation} ${ANIMATION_DURATION}ms ${
-      animationEasing.acceleration
-    } both`
+    animation: `${fadeOutAnimation} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
   }
 })
 
 /**
  * Overlay is essentially a wrapper around react-transition-group/Transition
- * Learn more: https://reactcommunity.org/react-transition-group/
  */
-class Overlay extends React.Component {
-  static propTypes = {
-    /**
-     * Children can be a node or a function accepting `close: func`
-     * and `state: ENTERING | ENTERED | EXITING | EXITED`.
-     */
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+const Overlay = memo(props => {
+  const { containerProps = {}, isShown, children } = props
+  const theme = useTheme()
+  const [previousActiveElement, setPreviousActiveElement] = useState(null)
+  const [status, setStatus] = useState(isShown ? 'entering' : 'exited')
+  const [shouldExit, setShouldExit] = useState(false)
+  const [containerRef, setContainerRef] = useState(null)
 
-    /**
-     * Show the component; triggers the enter or exit states.
-     */
-    isShown: PropTypes.bool,
+  useEffect(() => {
+    if (isShown) {
+      setStatus('entering')
+    }
+  }, [isShown])
 
-    /**
-     * Props to be passed through on the inner Box.
-     */
-    containerProps: PropTypes.object,
-
-    /**
-     * Whether or not to prevent body scrolling outside the context of the overlay
-     */
-    preventBodyScrolling: PropTypes.bool,
-
-    /**
-     * Boolean indicating if clicking the overlay should close the overlay.
-     */
-    shouldCloseOnClick: PropTypes.bool,
-
-    /**
-     * Boolean indicating if pressing the esc key should close the overlay.
-     */
-    shouldCloseOnEscapePress: PropTypes.bool,
-
-    /**
-     * Function called when overlay is about to close.
-     * Return `false` to prevent the sheet from closing.
-     * type: `Function -> Boolean`
-     */
-    onBeforeClose: PropTypes.func,
-
-    /**
-     * Callback fired before the "exiting" status is applied.
-     * type: `Function(node: HtmlElement) -> void`
-     */
-    onExit: PropTypes.func,
-
-    /**
-     * Callback fired after the "exiting" status is applied.
-     * type: `Function(node: HtmlElement) -> void`
-     */
-    onExiting: PropTypes.func,
-
-    /**
-     * Callback fired after the "exited" status is applied.
-     * type: `Function(exitState: Any?, node: HtmlElement) -> void`
-     */
-    onExited: PropTypes.func,
-
-    /**
-     * Callback fired before the "entering" status is applied.
-     * An extra parameter isAppearing is supplied to indicate if the enter stage
-     * is occurring on the initial mount.
-     *
-     * type: `Function(node: HtmlElement, isAppearing: bool) -> void`
-     */
-    onEnter: PropTypes.func,
-
-    /**
-     * Callback fired after the "entering" status is applied.
-     * An extra parameter isAppearing is supplied to indicate if the enter stage
-     * is occurring on the initial mount.
-     *
-     * type: `Function(node: HtmlElement, isAppearing: bool) -> void`
-     */
-    onEntering: PropTypes.func,
-
-    /**
-     * Callback fired after the "entered" status is applied.
-     * An extra parameter isAppearing is supplied to indicate if the enter stage
-     * is occurring on the initial mount.
-     *
-     * type: `Function(node: HtmlElement, isAppearing: bool) -> void`
-     */
-    onEntered: PropTypes.func,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    onHide: () => {},
-    shouldCloseOnClick: true,
-    shouldCloseOnEscapePress: true,
-    preventBodyScrolling: false,
-    onExit: () => {},
-    onExiting: () => {},
-    onExited: () => {},
-    onEnter: () => {},
-    onEntering: () => {},
-    onEntered: () => {}
-  }
-
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      exiting: false,
-      exited: !props.isShown
+  const close = () => {
+    const shouldClose = safeInvoke(props.onBeforeClose)
+    if (shouldClose !== false) {
+      setShouldExit(true)
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (!prevProps.isShown && this.props.isShown) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        exited: false
-      })
+  const onEsc = event => {
+    if (event.key === 'Escape' && props.shouldCloseOnEscapePress) {
+      close()
     }
   }
 
-  componentWillUnmount() {
-    this.handleBodyScroll(false)
-    document.body.removeEventListener('keydown', this.onEsc, false)
-  }
+  useEffect(() => {
+    if (status === 'entered') {
+      setPreviousActiveElement(document.activeElement)
+      bringFocusInsideOverlay()
+    }
+
+    if (status === 'entering') {
+      document.body.addEventListener('keydown', onEsc, false)
+    }
+
+    if (status === 'exiting') {
+      document.body.removeEventListener('keydown', onEsc, false)
+      bringFocusBackToTarget()
+    }
+
+    return () => {
+      handleBodyScroll(false)
+      document.body.removeEventListener('keydown', onEsc, false)
+    }
+  }, [status])
 
   /**
    * Methods borrowed from BlueprintJS
    * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
    */
-  bringFocusInsideOverlay = () => {
+  const bringFocusInsideOverlay = () => {
     // Always delay focus manipulation to just before repaint to prevent scroll jumping
     return requestAnimationFrame(() => {
       // Container ref may be undefined between component mounting and Portal rendering
       // activeElement may be undefined in some rare cases in IE
 
       if (
-        this.containerElement == null || // eslint-disable-line eqeqeq, no-eq-null
+        containerRef == null || // eslint-disable-line eqeqeq, no-eq-null
         document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
-        !this.props.isShown
+        !isShown
       ) {
         return
       }
 
-      const isFocusOutsideModal = !this.containerElement.contains(
-        document.activeElement
-      )
+      const isFocusOutsideModal = !containerRef.contains(document.activeElement)
       if (isFocusOutsideModal) {
         // Element marked autofocus has higher priority than the other clowns
-        const autofocusElement = this.containerElement.querySelector(
-          '[autofocus]'
-        )
-        const wrapperElement = this.containerElement.querySelector('[tabindex]')
-        const buttonElement = this.containerElement.querySelector('button')
+        const autofocusElement = containerRef.querySelector('[autofocus]')
+        const wrapperElement = containerRef.querySelector('[tabindex]')
+        const buttonElement = containerRef.querySelector('button')
 
         if (autofocusElement) {
           autofocusElement.focus()
@@ -233,153 +147,211 @@ class Overlay extends React.Component {
     })
   }
 
-  bringFocusBackToTarget = () => {
+  const bringFocusBackToTarget = () => {
     return requestAnimationFrame(() => {
       if (
-        this.containerElement == null || // eslint-disable-line eqeqeq, no-eq-null
+        previousActiveElement == null || // eslint-disable-line eqeqeq, no-eq-null
+        containerRef == null || // eslint-disable-line eqeqeq, no-eq-null
         document.activeElement == null // eslint-disable-line eqeqeq, no-eq-null
       ) {
         return
       }
 
-      const isFocusInsideModal = this.containerElement.contains(
-        document.activeElement
-      )
-
       // Bring back focus on the target.
-      if (
-        this.previousActiveElement &&
-        (document.activeElement === document.body || isFocusInsideModal)
-      ) {
-        this.previousActiveElement.focus()
+      const isFocusInsideModal = containerRef.contains(document.activeElement)
+      if (document.activeElement === document.body || isFocusInsideModal) {
+        previousActiveElement.focus()
       }
     })
   }
 
-  onEsc = e => {
-    // Esc key
-    if (e.keyCode === 27 && this.props.shouldCloseOnEscapePress) {
-      this.close()
-    }
-  }
-
-  close = () => {
-    const shouldClose = safeInvoke(this.props.onBeforeClose)
-    if (shouldClose !== false) {
-      this.setState({ exiting: true })
-    }
-  }
-
-  handleBodyScroll = preventScroll => {
-    if (this.props.preventBodyScrolling) {
+  const handleBodyScroll = preventScroll => {
+    if (props.preventBodyScrolling) {
       preventBodyScroll(preventScroll)
     }
   }
 
-  handleEnter = () => {
-    this.handleBodyScroll(true)
-    safeInvoke(this.props.onEnter)
+  const handleEnter = node => {
+    handleBodyScroll(true)
+    safeInvoke(props.onEnter, node)
   }
 
-  handleEntering = node => {
-    document.body.addEventListener('keydown', this.onEsc, false)
-    this.props.onEntering(node)
+  const handleEntering = node => {
+    setStatus('entering')
+    safeInvoke(props.onEntering, node)
   }
 
-  handleEntered = node => {
-    this.previousActiveElement = document.activeElement
-    this.bringFocusInsideOverlay()
-    this.props.onEntered(node)
+  const handleEntered = node => {
+    setStatus('entered')
+    safeInvoke(props.onEntered, node)
   }
 
-  handleExit = () => {
-    this.handleBodyScroll(false)
-    safeInvoke(this.props.onExit)
+  const handleExit = node => {
+    handleBodyScroll(false)
+    safeInvoke(props.onExit, node)
   }
 
-  handleExiting = node => {
-    document.body.removeEventListener('keydown', this.onEsc, false)
-    this.bringFocusBackToTarget()
-    this.props.onExiting(node)
+  const handleExiting = node => {
+    setStatus('exiting')
+    safeInvoke(props.onExiting, node)
   }
 
-  handleExited = node => {
-    this.setState({ exiting: false, exited: true })
-    this.props.onExited(node)
+  const handleExited = node => {
+    setStatus('exited')
+    safeInvoke(props.onExited, node)
   }
 
-  handleBackdropClick = e => {
-    if (e.target !== e.currentTarget || !this.props.shouldCloseOnClick) {
+  const handleBackdropClick = event => {
+    if (event.target !== event.currentTarget || !props.shouldCloseOnClick) {
       return
     }
 
-    this.close()
+    close()
   }
 
-  onContainerRef = ref => {
-    this.containerElement = ref
-  }
+  if (status === 'exited') return null
 
-  render() {
-    const {
-      theme,
+  return (
+    <Stack value={StackingOrder.OVERLAY}>
+      {zIndex => (
+        <Portal>
+          <Transition
+            appear
+            unmountOnExit
+            timeout={ANIMATION_DURATION}
+            in={isShown && !shouldExit}
+            onExit={handleExit}
+            onExiting={handleExiting}
+            onExited={handleExited}
+            onEnter={handleEnter}
+            onEntering={handleEntering}
+            onEntered={handleEntered}
+          >
+            {state => (
+              <Box
+                onClick={handleBackdropClick}
+                innerRef={setContainerRef}
+                position="fixed"
+                top={0}
+                left={0}
+                right={0}
+                bottom={0}
+                zIndex={zIndex}
+                data-state={state}
+                {...containerProps}
+                className={cx(
+                  containerProps.className,
+                  css(animationStyles(theme.overlayBackgroundColor)).toString()
+                )}
+              >
+                {typeof children === 'function'
+                  ? children({ state, close })
+                  : children}
+              </Box>
+            )}
+          </Transition>
+        </Portal>
+      )}
+    </Stack>
+  )
+})
 
-      containerProps = {},
-      isShown,
-      children
-    } = this.props
+Overlay.propTypes = {
+  /**
+   * Children can be a node or a function accepting `close: func`
+   * and `state: ENTERING | ENTERED | EXITING | EXITED`.
+   */
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
 
-    const { exiting, exited } = this.state
+  /**
+   * Show the component; triggers the enter or exit states.
+   */
+  isShown: PropTypes.bool,
 
-    if (exited) return null
+  /**
+   * Props to be passed through on the inner Box.
+   */
+  containerProps: PropTypes.object,
 
-    return (
-      <Stack value={StackingOrder.OVERLAY}>
-        {zIndex => (
-          <Portal>
-            <Transition
-              appear
-              unmountOnExit
-              timeout={ANIMATION_DURATION}
-              in={isShown && !exiting}
-              onExit={this.handleExit}
-              onExiting={this.handleExiting}
-              onExited={this.handleExited}
-              onEnter={this.handleEnter}
-              onEntering={this.handleEntering}
-              onEntered={this.handleEntered}
-            >
-              {state => (
-                <Box
-                  onClick={this.handleBackdropClick}
-                  innerRef={this.onContainerRef}
-                  position="fixed"
-                  top={0}
-                  left={0}
-                  right={0}
-                  bottom={0}
-                  zIndex={zIndex}
-                  data-state={state}
-                  {...containerProps}
-                  className={cx(
-                    containerProps.className,
-                    css(animationStyles(theme.overlayBackgroundColor)).toString()
-                  )}
-                >
-                  {typeof children === 'function'
-                    ? children({
-                        state,
-                        close: this.close
-                      })
-                    : children}
-                </Box>
-              )}
-            </Transition>
-          </Portal>
-        )}
-      </Stack>
-    )
-  }
+  /**
+   * Whether or not to prevent body scrolling outside the context of the overlay
+   */
+  preventBodyScrolling: PropTypes.bool,
+
+  /**
+   * Boolean indicating if clicking the overlay should close the overlay.
+   */
+  shouldCloseOnClick: PropTypes.bool,
+
+  /**
+   * Boolean indicating if pressing the esc key should close the overlay.
+   */
+  shouldCloseOnEscapePress: PropTypes.bool,
+
+  /**
+   * Function called when overlay is about to close.
+   * Return `false` to prevent the sheet from closing.
+   * type: `Function -> Boolean`
+   */
+  onBeforeClose: PropTypes.func,
+
+  /**
+   * Callback fired before the "exiting" status is applied.
+   * type: `Function(node: HtmlElement) -> void`
+   */
+  onExit: PropTypes.func,
+
+  /**
+   * Callback fired after the "exiting" status is applied.
+   * type: `Function(node: HtmlElement) -> void`
+   */
+  onExiting: PropTypes.func,
+
+  /**
+   * Callback fired after the "exited" status is applied.
+   * type: `Function(exitState: Any?, node: HtmlElement) -> void`
+   */
+  onExited: PropTypes.func,
+
+  /**
+   * Callback fired before the "entering" status is applied.
+   * An extra parameter isAppearing is supplied to indicate if the enter stage
+   * is occurring on the initial mount.
+   *
+   * type: `Function(node: HtmlElement, isAppearing: bool) -> void`
+   */
+  onEnter: PropTypes.func,
+
+  /**
+   * Callback fired after the "entering" status is applied.
+   * An extra parameter isAppearing is supplied to indicate if the enter stage
+   * is occurring on the initial mount.
+   *
+   * type: `Function(node: HtmlElement, isAppearing: bool) -> void`
+   */
+  onEntering: PropTypes.func,
+
+  /**
+   * Callback fired after the "entered" status is applied.
+   * An extra parameter isAppearing is supplied to indicate if the enter stage
+   * is occurring on the initial mount.
+   *
+   * type: `Function(node: HtmlElement, isAppearing: bool) -> void`
+   */
+  onEntered: PropTypes.func
 }
 
-export default withTheme(Overlay)
+Overlay.defaultProps = {
+  onHide: NOOP,
+  shouldCloseOnClick: true,
+  shouldCloseOnEscapePress: true,
+  preventBodyScrolling: false,
+  onExit: NOOP,
+  onExiting: NOOP,
+  onExited: NOOP,
+  onEnter: NOOP,
+  onEntering: NOOP,
+  onEntered: NOOP
+}
+
+export default Overlay


### PR DESCRIPTION
## Overview 

This migrates the Overlay components to use hooks + React.FC
 
## Screenshots (if applicable) 
NA

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
