### PR TITLE
Convert portal to fc

### DIFF
--- a/src/portal/src/Portal.js
+++ b/src/portal/src/Portal.js
@@ -1,38 +1,50 @@
-import { Component } from 'react'
+import { useState, useEffect, memo } from 'react'
 import canUseDom from 'dom-helpers/util/inDOM'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 
-let portalContainer
+const initializePortal = () => {
+  if (!canUseDom) {
+    return null
+  }
 
-export default class Portal extends Component {
-  constructor() {
-    super()
+  const portalContainer = document.createElement('div')
+  portalContainer.setAttribute('evergreen-portal-container', '')
+  return portalContainer
+}
 
-    // This fixes SSR
-    if (!canUseDom) return
+const initializeEl = () => {
+  if (!canUseDom) {
+    return null
+  }
 
-    if (!portalContainer) {
-      portalContainer = document.createElement('div')
-      portalContainer.setAttribute('evergreen-portal-container', '')
+  return document.createElement('div')
+}
+
+const Portal = memo(({ children }) => {
+  const [portalContainer] = useState(initializePortal)
+  const [el] = useState(initializeEl)
+
+  useEffect(() => {
+    if (portalContainer) {
       document.body.appendChild(portalContainer)
+      portalContainer.appendChild(el)
     }
 
-    this.el = document.createElement('div')
-    portalContainer.appendChild(this.el)
-  }
+    return () => {
+      if (portalContainer) {
+        portalContainer.removeChild(el)
+      }
+    }
+  }, [])
 
-  componentWillUnmount() {
-    portalContainer.removeChild(this.el)
-  }
+  if (!canUseDom) return null
 
-  render() {
-    // This fixes SSR
-    if (!canUseDom) return null
-    return ReactDOM.createPortal(this.props.children, this.el)
-  }
-}
+  return ReactDOM.createPortal(children, el)
+})
 
 Portal.propTypes = {
   children: PropTypes.node.isRequired
 }
+
+export default Portal

--- a/src/portal/src/Portal.js
+++ b/src/portal/src/Portal.js
@@ -16,6 +16,7 @@ const initializePortal = () => {
 
   portalContainer = document.createElement('div')
   portalContainer.setAttribute('evergreen-portal-container', '')
+  document.body.appendChild(portalContainer)
   return portalContainer
 }
 
@@ -33,7 +34,6 @@ const Portal = memo(({ children }) => {
 
   useEffect(() => {
     if (portalContainer) {
-      document.body.appendChild(portalContainer)
       portalContainer.appendChild(el)
     }
 

--- a/src/portal/src/Portal.js
+++ b/src/portal/src/Portal.js
@@ -3,12 +3,18 @@ import canUseDom from 'dom-helpers/util/inDOM'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 
+let portalContainer
+
 const initializePortal = () => {
   if (!canUseDom) {
     return null
   }
 
-  const portalContainer = document.createElement('div')
+  if (portalContainer) {
+    return portalContainer
+  }
+
+  portalContainer = document.createElement('div')
   portalContainer.setAttribute('evergreen-portal-container', '')
   return portalContainer
 }
@@ -22,8 +28,8 @@ const initializeEl = () => {
 }
 
 const Portal = memo(({ children }) => {
-  const [portalContainer] = useState(initializePortal)
-  const [el] = useState(initializeEl)
+  const [portalContainer] = useState(initializePortal())
+  const [el] = useState(initializeEl())
 
   useEffect(() => {
     if (portalContainer) {


### PR DESCRIPTION
I believe this will carry over the previous behavior. Biggest thing was there was a lot of logic in the constructor and this component has to return null if it's rendered on the server for SSR.

Logic basically follows:
1. Initialize portal container + el in `useState` which should carry over the same behavior as having it in the constructor (returning null if no dom is accessible) 
2. When component mounts (client side behavior only), append portal + el to the dom. At this point, portal + el should have been initialized
3. sanity check if the dom is there before returning react portal element
4. clean up in useEffect but ripping portal from the dom


Haven't tested this in SSR, storybook works though :)