### PR TITLE
Convert Positioner component to Hooks/FC

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1182,7 +1182,7 @@ export interface PositionerProps {
   onOpenComplete?: () => void
 }
 
-export class Positioner extends React.PureComponent<PositionerProps> {
+export declare const Positioner: ForwardRefComponent<PositionerProps> {
 }
 
 export interface RadioProps extends Omit<BoxProps<'input'>, 'onChange'> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1182,8 +1182,7 @@ export interface PositionerProps {
   onOpenComplete?: () => void
 }
 
-export declare const Positioner: ForwardRefComponent<PositionerProps> {
-}
+export declare const Positioner: ForwardRefComponent<PositionerProps>
 
 export interface RadioProps extends Omit<BoxProps<'input'>, 'onChange'> {
   /**

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -39,7 +39,6 @@ const Positioner = memo(forwardRef((props, ref) => {
     position = Position.BOTTOM,
     bodyOffset = 6,
     targetOffset = 6,
-    innerRef,
     onOpenComplete = () => {},
     onCloseComplete = () => {}
   } = props
@@ -71,7 +70,6 @@ const Positioner = memo(forwardRef((props, ref) => {
 
   const getRef = (newRef) => {
     setPositionerRef(newRef)
-    safeInvoke(innerRef, newRef)
     safeInvoke(ref, newRef)
   }
 
@@ -212,11 +210,6 @@ Positioner.propTypes = {
    * Function that returns the element being positioned.
    */
   children: PropTypes.func.isRequired,
-
-  /**
-   * Function that returns the ref of the element being positioned.
-   */
-  innerRef: PropTypes.func,
 
   /**
    * The minimum distance from the body to the element being positioned.

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -1,20 +1,15 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef, useState, useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
 import Transition from 'react-transition-group/Transition'
 import { Portal } from '../../portal'
 import { Stack } from '../../stack'
 import { StackingOrder, Position } from '../../constants'
+import safeInvoke from '../../lib/safe-invoke'
 import getPosition from './getPosition'
 
 const animationEasing = {
   spring: `cubic-bezier(0.175, 0.885, 0.320, 1.175)`
 }
-
-const initialState = () => ({
-  top: null,
-  left: null,
-  transformOrigin: null
-})
 
 const getCSS = ({ initialScale, animationDuration }) => ({
   position: 'fixed',
@@ -34,236 +29,230 @@ const getCSS = ({ initialScale, animationDuration }) => ({
   }
 })
 
-export default class Positioner extends PureComponent {
-  static propTypes = {
-    /**
-     * The position the element that is being positioned is on.
-     * Smart positioning might override this.
-     */
-    position: PropTypes.oneOf([
-      Position.TOP,
-      Position.TOP_LEFT,
-      Position.TOP_RIGHT,
-      Position.BOTTOM,
-      Position.BOTTOM_LEFT,
-      Position.BOTTOM_RIGHT,
-      Position.LEFT,
-      Position.RIGHT
-    ]).isRequired,
+const Positioner = memo(forwardRef((props, ref) => {
+  const {
+    target,
+    isShown,
+    children,
+    initialScale = 0.9,
+    animationDuration = 300,
+    position = Position.BOTTOM,
+    bodyOffset = 6,
+    targetOffset = 6,
+    innerRef,
+    onOpenComplete = () => {},
+    onCloseComplete = () => {}
+  } = props
 
-    /**
-     * When true, show the element being positioned.
-     */
-    isShown: PropTypes.bool,
+  const [top, setTop] = useState(0)
+  const [left, setLeft] = useState(0)
+  const [height, setHeight] = useState(0)
+  const [width, setWidth] = useState(0)
+  const [transformOrigin, setTransformOrigin] = useState(null)
+  const [latestAnimationFrame, setLatestAnimationFrame] = useState()
+  const [targetRef, setTargetRef] = useState()
+  const [positionerRef, setPositionerRef] = useState()
 
-    /**
-     * Function that returns the element being positioned.
-     */
-    children: PropTypes.func.isRequired,
-
-    /**
-     * Function that returns the ref of the element being positioned.
-     */
-    innerRef: PropTypes.func.isRequired,
-
-    /**
-     * The minimum distance from the body to the element being positioned.
-     */
-    bodyOffset: PropTypes.number.isRequired,
-
-    /**
-     * The minimum distance from the target to the element being positioned.
-     */
-    targetOffset: PropTypes.number.isRequired,
-
-    /**
-     * Function that should return a node for the target.
-     * ({ getRef: () -> Ref, isShown: Bool }) -> React Node
-     */
-    target: PropTypes.func.isRequired,
-
-    /**
-     * Initial scale of the element being positioned.
-     */
-    initialScale: PropTypes.number.isRequired,
-
-    /**
-     * Duration of the animation.
-     */
-    animationDuration: PropTypes.number.isRequired,
-
-    /**
-     * Function that will be called when the exit transition is complete.
-     */
-    onCloseComplete: PropTypes.func.isRequired,
-
-    /**
-     * Function that will be called when the enter transition is complete.
-     */
-    onOpenComplete: PropTypes.func.isRequired
-  }
-
-  static defaultProps = {
-    position: Position.BOTTOM,
-    bodyOffset: 6,
-    targetOffset: 6,
-    initialScale: 0.9,
-    animationDuration: 300,
-    innerRef: () => {},
-    onOpenComplete: () => {},
-    onCloseComplete: () => {}
-  }
-
-  constructor(props, context) {
-    super(props, context)
-    this.state = initialState()
-  }
-
-  componentWillUnmount() {
-    if (this.latestAnimationFrame) {
-      cancelAnimationFrame(this.latestAnimationFrame)
+  useLayoutEffect(() => {
+    if (latestAnimationFrame) {
+      cancelAnimationFrame(latestAnimationFrame)
     }
+    
+    setLatestAnimationFrame(requestAnimationFrame(() => {
+      update(height, width)
+    }))
+    
+    return () => {
+      if (latestAnimationFrame) {
+        cancelAnimationFrame(latestAnimationFrame)
+      }
+    }
+  }, [left, top, height, width, transformOrigin, positionerRef])
+
+  const getRef = (newRef) => {
+    setPositionerRef(newRef)
+    safeInvoke(innerRef, newRef)
+    safeInvoke(ref, newRef)
   }
 
-  getTargetRef = ref => {
-    this.targetRef = ref
+  const handleEnter = () => {
+    update()
   }
 
-  getRef = ref => {
-    this.positionerRef = ref
-    this.props.innerRef(ref)
-  }
+  const update = (prevHeight = 0, prevWidth = 0) => {
+    if (!isShown || !targetRef || !positionerRef) return
 
-  handleEnter = () => {
-    this.update()
-  }
+    const targetRect = targetRef.getBoundingClientRect()
 
-  update = (prevHeight = 0, prevWidth = 0) => {
-    if (!this.props.isShown || !this.targetRef || !this.positionerRef) return
-
-    const targetRect = this.targetRef.getBoundingClientRect()
     const hasEntered =
-      this.positionerRef.getAttribute('data-state') === 'entered'
+      positionerRef.getAttribute('data-state') === 'entered'
 
     const viewportHeight = document.documentElement.clientHeight
     const viewportWidth = document.documentElement.clientWidth
 
-    let height
-    let width
+    let positionerHeight
+    let positionerWidth
     if (hasEntered) {
       // Only when the animation is done should we opt-in to `getBoundingClientRect`
-      const positionerRect = this.positionerRef.getBoundingClientRect()
+      const positionerRect = positionerRef.getBoundingClientRect()
 
       // https://github.com/segmentio/evergreen/issues/255
       // We need to ceil the width and height to prevent jitter when
       // the window is zoomed (when `window.devicePixelRatio` is not an integer)
-      height = Math.round(positionerRect.height)
-      width = Math.round(positionerRect.width)
+      positionerHeight = Math.round(positionerRect.height)
+      positionerWidth = Math.round(positionerRect.width)
     } else {
       // When the animation is in flight use `offsetWidth/Height` which
       // does not calculate the `transform` property as part of its result.
       // There is still change on jitter during the animation (although unoticable)
       // When the browser is zoomed in — we fix this with `Math.max`.
-      height = Math.max(this.positionerRef.offsetHeight, prevHeight)
-      width = Math.max(this.positionerRef.offsetWidth, prevWidth)
+      positionerHeight = Math.max(positionerRef.offsetHeight, prevHeight)
+      positionerWidth = Math.max(positionerRef.offsetWidth, prevWidth)
     }
 
-    const { rect, transformOrigin } = getPosition({
-      position: this.props.position,
+    const { rect, transformOrigin: updatedTransformOrigin } = getPosition({
+      position,
       targetRect,
-      targetOffset: this.props.targetOffset,
+      targetOffset,
       dimensions: {
-        height,
-        width
+        height: positionerHeight,
+        width: positionerWidth
       },
       viewport: {
         width: viewportWidth,
         height: viewportHeight
       },
-      viewportOffset: this.props.bodyOffset
+      viewportOffset: bodyOffset
     })
 
-    this.setState(
-      {
-        left: rect.left,
-        top: rect.top,
-        transformOrigin
-      },
-      () => {
-        this.latestAnimationFrame = requestAnimationFrame(() => {
-          this.update(height, width)
-        })
-      }
-    )
+    setHeight(positionerHeight)
+    setWidth(positionerWidth)
+    setLeft(rect.left)
+    setTop(rect.top)
+    setTransformOrigin(updatedTransformOrigin)
   }
 
-  handleExited = () => {
-    this.setState(
-      () => {
-        return {
-          ...initialState()
-        }
-      },
-      () => {
-        this.props.onCloseComplete()
-      }
-    )
+  const handleExited = () => {
+    setLeft(0)
+    setTop(0)
+    setHeight(0)
+    setWidth(0)
+    setTransformOrigin(null)
+    onCloseComplete()
   }
+   
+  return (
+    <Stack value={StackingOrder.POSITIONER}>
+      {zIndex => {
+        return (
+          <React.Fragment>
+            {target({ getRef: setTargetRef, isShown })}
 
-  render() {
-    const {
-      target,
-      isShown,
-      children,
-      initialScale,
-      animationDuration
-    } = this.props
-
-    const { left, top, transformOrigin } = this.state
-
-    return (
-      <Stack value={StackingOrder.POSITIONER}>
-        {zIndex => {
-          return (
-            <React.Fragment>
-              {target({ getRef: this.getTargetRef, isShown })}
-
-              <Transition
-                appear
-                in={isShown}
-                timeout={animationDuration}
-                onEnter={this.handleEnter}
-                onEntered={this.props.onOpenComplete}
-                onExited={this.handleExited}
-                unmountOnExit
-              >
-                {state => (
-                  <Portal>
-                    {children({
-                      top,
-                      left,
-                      state,
-                      zIndex,
-                      css: getCSS({
-                        initialScale,
-                        animationDuration
-                      }),
-                      style: {
-                        transformOrigin,
-                        left,
-                        top,
-                        zIndex
-                      },
-                      getRef: this.getRef,
+            <Transition
+              appear
+              in={isShown}
+              timeout={animationDuration}
+              onEnter={handleEnter}
+              onEntered={onOpenComplete}
+              onExited={handleExited}
+              unmountOnExit
+            >
+              {state => (
+                <Portal>
+                  {children({
+                    top,
+                    left,
+                    state,
+                    zIndex,
+                    css: getCSS({
+                      initialScale,
                       animationDuration
-                    })}
-                  </Portal>
-                )}
-              </Transition>
-            </React.Fragment>
-          )
-        }}
-      </Stack>
-    )
-  }
+                    }),
+                    style: {
+                      transformOrigin,
+                      left,
+                      top,
+                      zIndex
+                    },
+                    getRef,
+                    animationDuration
+                  })}
+                </Portal>
+              )}
+            </Transition>
+          </React.Fragment>
+        )
+      }}
+    </Stack>
+  )
+}))
+
+Positioner.propTypes = {
+  /**
+   * The position the element that is being positioned is on.
+   * Smart positioning might override this.
+   */
+  position: PropTypes.oneOf([
+    Position.TOP,
+    Position.TOP_LEFT,
+    Position.TOP_RIGHT,
+    Position.BOTTOM,
+    Position.BOTTOM_LEFT,
+    Position.BOTTOM_RIGHT,
+    Position.LEFT,
+    Position.RIGHT
+  ]),
+
+  /**
+   * When true, show the element being positioned.
+   */
+  isShown: PropTypes.bool,
+
+  /**
+   * Function that returns the element being positioned.
+   */
+  children: PropTypes.func.isRequired,
+
+  /**
+   * Function that returns the ref of the element being positioned.
+   */
+  innerRef: PropTypes.func,
+
+  /**
+   * The minimum distance from the body to the element being positioned.
+   */
+  bodyOffset: PropTypes.number,
+
+  /**
+   * The minimum distance from the target to the element being positioned.
+   */
+  targetOffset: PropTypes.number,
+
+  /**
+   * Function that should return a node for the target.
+   * ({ getRef: () -> Ref, isShown: Bool }) -> React Node
+   */
+  target: PropTypes.func.isRequired,
+
+  /**
+   * Initial scale of the element being positioned.
+   */
+  initialScale: PropTypes.number,
+
+  /**
+   * Duration of the animation.
+   */
+  animationDuration: PropTypes.number,
+
+  /**
+   * Function that will be called when the exit transition is complete.
+   */
+  onCloseComplete: PropTypes.func,
+
+  /**
+   * Function that will be called when the enter transition is complete.
+   */
+  onOpenComplete: PropTypes.func
 }
+
+export default Positioner


### PR DESCRIPTION
<!-- 
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
 -->
 
## Overview 
Convert the Positioner component to use forwardRef, memo, and hooks 

## Screenshots
![Screen Recording 2020-06-25 at 2 40 57 PM](https://user-images.githubusercontent.com/17129452/85798331-2528e780-b6f2-11ea-8416-e05fc99e3219.gif)
![Screen Recording 2020-06-25 at 2 39 42 PM](https://user-images.githubusercontent.com/17129452/85798335-265a1480-b6f2-11ea-8061-97626efa2b85.gif)

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [x] Popovers work as expected
- [x] Tooltips work as expected
