### PR TITLE
convert tab components to React.FC

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1539,8 +1539,7 @@ export declare const SideSheet: ForwardRefComponent<SideSheetProps>
 
 export type SidebarTabProps = TabProps
 
-export class SidebarTab extends React.PureComponent<SidebarTabProps> {
-}
+export declare const SidebarTab: ForwardRefComponent<SidebarTabProps>
 
 export interface SmallProps extends BoxProps<'small'> {
 
@@ -1869,18 +1868,15 @@ export interface TabProps extends TextProps {
   appearance?: DefaultAppearance
 }
 
-export class Tab extends React.PureComponent<TabProps> {
-}
+export declare const Tab: ForwardRefComponent<TabProps>
 
-export type TablistProps = React.ComponentPropsWithoutRef<typeof Box>
+export type TablistProps = BoxProps<'div'>
 
-export class Tablist extends React.PureComponent<TablistProps> {
-}
+export declare const Tablist: ForwardRefComponent<TablistProps>
 
 export type TabNavigationProps = BoxProps<'nav'>
 
-export class TabNavigation extends React.PureComponent<TabNavigationProps> {
-}
+export declare const TabNavigation: ForwardRefComponent<TabNavigationProps>
 
 export interface TagInputProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
   addOnBlur?: boolean

--- a/src/tabs/src/SidebarTab.js
+++ b/src/tabs/src/SidebarTab.js
@@ -1,33 +1,27 @@
-import React, { PureComponent } from 'react'
+import React, { memo, forwardRef } from 'react'
 import Box from 'ui-box'
 import Tab from './Tab'
 
-export default class SidebarTab extends PureComponent {
-  static propTypes = {
-    ...Tab.propTypes
-  }
+const styles = {
+  width: '100%',
+  paddingX: 0,
+  paddingLeft: 8,
+  marginX: 0,
+  marginBottom: 4,
+  justifyContent: 'auto'
+}
 
-  static defaultProps = {
-    height: 32
-  }
+const SidebarTab = memo(
+  forwardRef((props, ref) => {
+    const { children, height = 32, isSelected, ...rest } = props
 
-  static styles = {
-    width: '100%',
-    paddingX: 0,
-    paddingLeft: 8,
-    marginX: 0,
-    marginBottom: 4,
-    justifyContent: 'auto'
-  }
-
-  render() {
-    const { children, height, isSelected, ...props } = this.props
     return (
       <Tab
         isSelected={isSelected}
         height={height}
-        {...SidebarTab.styles}
-        {...props}
+        {...styles}
+        {...rest}
+        ref={ref}
         display="flex"
       >
         <Box is="span" flex="1">
@@ -35,5 +29,9 @@ export default class SidebarTab extends PureComponent {
         </Box>
       </Tab>
     )
-  }
-}
+  })
+)
+
+SidebarTab.propTypes = Tab.propTypes
+
+export default SidebarTab

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -1,91 +1,55 @@
-import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { Text } from '../../typography'
-import { withTheme } from '../../theme'
+import React, { forwardRef, memo } from 'react'
+import safeInvoke from '../../lib/safe-invoke'
 import warning from '../../lib/warning'
+import { useTheme } from '../../theme'
+import { Text } from '../../typography'
 
-class Tab extends PureComponent {
-  static propTypes = {
-    /**
-     * Composes the Text component as the base.
-     */
-    ...Text.propTypes,
+const styles = {
+  display: 'inline-flex',
+  fontWeight: 500,
+  paddingX: 8,
+  marginX: 4,
+  borderRadius: 3,
+  lineHeight: '28px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textDecoration: 'none',
+  tabIndex: 0
+}
 
-    /**
-     * Function triggered when tab is selected.
-     */
-    onSelect: PropTypes.func,
+const Tab = memo(
+  forwardRef((props, ref) => {
+    const theme = useTheme()
 
-    /**
-     * When true, the tab is selected.
-     */
-    isSelected: PropTypes.bool,
-
-    /**
-     * The appearance of the tab.
-     * The default theme only comes with a default style.
-     */
-    appearance: PropTypes.string,
-
-    /**
-     * Theme provided by ThemeProvider.
-     */
-    theme: PropTypes.object.isRequired
-  }
-
-  static defaultProps = {
-    onSelect: () => {},
-    onKeyPress: () => {},
-    is: 'span',
-    height: 28,
-    disabled: false
-  }
-
-  static styles = {
-    display: 'inline-flex',
-    fontWeight: 500,
-    paddingX: 8,
-    marginX: 4,
-    borderRadius: 3,
-    lineHeight: '28px',
-    alignItems: 'center',
-    justifyContent: 'center',
-    textDecoration: 'none',
-    tabIndex: 0
-  }
-
-  handleClick = e => {
-    if (typeof this.props.onClick === 'function') {
-      this.props.onClick(e)
-    }
-
-    this.props.onSelect()
-  }
-
-  handleKeyPress = e => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      this.props.onSelect()
-      e.preventDefault()
-    }
-
-    this.props.onKeyPress(e)
-  }
-
-  render() {
     const {
-      theme,
-      is,
-      height,
-      onSelect,
-      isSelected,
       appearance,
-      disabled,
-      ...props
-    } = this.props
+      disabled = false,
+      height = 28,
+      is = 'span',
+      isSelected,
+      onKeyPress = () => {},
+      onSelect = () => {},
+      ...rest
+    } = props
+
+    const handleClick = e => {
+      safeInvoke(props.onClick, e)
+      onSelect()
+    }
+
+    const handleKeyPress = e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        onSelect()
+        e.preventDefault()
+      }
+
+      onKeyPress(e)
+    }
 
     if (process.env.NODE_ENV !== 'production') {
       warning(
-        typeof this.props.onClick === 'function',
+        typeof props.onClick === 'function',
         '<Tab> expects `onSelect` prop, but you passed `onClick`.'
       )
     }
@@ -125,14 +89,38 @@ class Tab extends PureComponent {
         is={is}
         size={textSize}
         height={height}
-        {...Tab.styles}
-        {...props}
-        onClick={this.handleClick}
-        onKeyPress={this.handleKeyPress}
+        ref={ref}
+        {...styles}
+        {...rest}
+        onClick={handleClick}
+        onKeyPress={handleKeyPress}
         {...elementBasedProps}
       />
     )
-  }
+  })
+)
+
+Tab.propTypes = {
+  /**
+   * Composes the Text component as the base.
+   */
+  ...Text.propTypes,
+
+  /**
+   * Function triggered when tab is selected.
+   */
+  onSelect: PropTypes.func,
+
+  /**
+   * When true, the tab is selected.
+   */
+  isSelected: PropTypes.bool,
+
+  /**
+   * The appearance of the tab.
+   * The default theme only comes with a default style.
+   */
+  appearance: PropTypes.string
 }
 
-export default withTheme(Tab)
+export default Tab

--- a/src/tabs/src/TabNavigation.js
+++ b/src/tabs/src/TabNavigation.js
@@ -1,12 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { forwardRef } from 'react'
 import Box from 'ui-box'
 
-export default class TabNavigation extends PureComponent {
-  static propTypes = {
-    ...Box.propTypes
-  }
+const TabNavigation = forwardRef((props, ref) => {
+  return <Box is="nav" role="navigation" {...props} ref={ref} />
+})
 
-  render() {
-    return <Box is="nav" role="navigation" {...this.props} />
-  }
-}
+TabNavigation.propTypes = Box.propTypes
+
+export default TabNavigation

--- a/src/tabs/src/Tablist.js
+++ b/src/tabs/src/Tablist.js
@@ -1,12 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { forwardRef } from 'react'
 import Box from 'ui-box'
 
-export default class Tablist extends PureComponent {
-  static propTypes = {
-    ...Box.propTypes
-  }
+const Tablist = forwardRef((props, ref) => {
+  return <Box role="tablist" {...props} ref={ref} />
+})
 
-  render() {
-    return <Box role="tablist" {...this.props} />
-  }
-}
+Tablist.propTypes = Box.propTypes
+
+export default Tablist


### PR DESCRIPTION
## Overview 
This PR converts all tab components to React.FC and updates their corresponding types.
 
## Screenshots (if applicable) 
NA

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
