### PR TITLE
move defaultProps into default values

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -106,12 +106,14 @@ const Autocomplete = memo(
   forwardRef((props, ref) => {
     const {
       children,
-      itemSize,
+      itemSize = 32,
       position,
-      renderItem,
+      renderItem = autocompleteItemRenderer,
+      isFilterDisabled = false,
       itemsFilter,
-      popoverMaxHeight,
-      popoverMinWidth,
+      itemToString = i => (i ? String(i) : ''),
+      popoverMaxHeight = 240,
+      popoverMinWidth = 240,
       ...restProps
     } = props
 
@@ -177,13 +179,13 @@ const Autocomplete = memo(
                   getMenuProps={getMenuProps}
                   highlightedIndex={highlightedIndex}
                   inputValue={inputValue}
-                  isFilterDisabled={props.isFilterDisabled}
-                  itemsFilter={props.itemsFilter}
-                  itemSize={props.itemSize}
-                  itemToString={props.itemToString}
+                  isFilterDisabled={isFilterDisabled}
+                  itemsFilter={itemsFilter}
+                  itemSize={itemSize}
+                  itemToString={itemToString}
                   originalItems={props.items}
-                  popoverMaxHeight={props.popoverMaxHeight}
-                  renderItem={props.renderItem}
+                  popoverMaxHeight={popoverMaxHeight}
+                  renderItem={renderItem}
                   selectedItem={selectedItem}
                   title={props.title}
                   width={Math.max(targetWidth, popoverMinWidth)}
@@ -236,7 +238,7 @@ Autocomplete.propTypes = {
    * In case the array of items is not an array of strings,
    * this function is used on each item to return the string that will be shown on the filter
    */
-  itemToString: PropTypes.func.isRequired,
+  itemToString: PropTypes.func,
 
   /**
    * Function that will render the 'filter' component.
@@ -293,15 +295,6 @@ Autocomplete.propTypes = {
   popoverMaxHeight: PropTypes.number,
 
   ...Downshift.propTypes
-}
-
-Autocomplete.defaultProps = {
-  itemToString: i => (i ? String(i) : ''),
-  itemSize: 32,
-  isFilterDisabled: false,
-  popoverMinWidth: 240,
-  popoverMaxHeight: 240,
-  renderItem: autocompleteItemRenderer
 }
 
 export default Autocomplete

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -31,19 +31,19 @@ const Button = memo(
     const {
       className,
 
-      intent,
-      height,
-      isActive,
+      intent = 'none',
+      height = 32,
+      isActive = false,
       children,
       disabled,
-      appearance,
+      appearance = 'default',
       isLoading,
 
       // Paddings
       paddingRight,
       paddingLeft,
-      paddingTop,
-      paddingBottom,
+      paddingTop = 0,
+      paddingBottom = 0,
 
       // Icons
       iconBefore,
@@ -132,7 +132,7 @@ Button.propTypes = {
   /**
    * The appearance of the button.
    */
-  appearance: PropTypes.oneOf(['default', 'minimal', 'primary']).isRequired,
+  appearance: PropTypes.oneOf(['default', 'minimal', 'primary']),
 
   /**
    * When true, show a loading spinner before the children.
@@ -167,15 +167,6 @@ Button.propTypes = {
    * Only use if you know what you are doing.
    */
   className: PropTypes.string
-}
-
-Button.defaultProps = {
-  appearance: 'default',
-  height: 32,
-  intent: 'none',
-  isActive: false,
-  paddingBottom: 0,
-  paddingTop: 0
 }
 
 Button.styles = {

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -7,7 +7,7 @@ import Button from './Button'
 const IconButton = memo(
   forwardRef((props, ref) => {
     const theme = useTheme()
-    const { icon, iconSize, height, intent, ...restProps } = props
+    const { icon, iconSize, height, intent = 'none', ...restProps } = props
 
     let iconWithProps
     if (icon && React.isValidElement(icon)) {
@@ -70,12 +70,12 @@ IconButton.propTypes = {
   /**
    * The intent of the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
 
   /**
    * The appearance of the button.
    */
-  appearance: PropTypes.oneOf(['default', 'minimal', 'primary']).isRequired,
+  appearance: PropTypes.oneOf(['default', 'minimal', 'primary']),
 
   /**
    * Forcefully set the active state of a button.
@@ -94,12 +94,6 @@ IconButton.propTypes = {
    * Only use if you know what you are doing.
    */
   className: PropTypes.string
-}
-
-IconButton.defaultProps = {
-  intent: 'none',
-  appearance: 'default',
-  height: 32
 }
 
 export default IconButton

--- a/src/buttons/src/TextDropdownButton.js
+++ b/src/buttons/src/TextDropdownButton.js
@@ -14,21 +14,18 @@ const TextDropdownButton = memo(
       className,
       intent,
       height,
-      isActive,
+      isActive = false,
       children,
       disabled,
       appearance,
       isLoading,
 
-      // Paddings
       paddingRight,
       paddingLeft,
       paddingTop,
       paddingBottom,
 
-      // Icons
-      icon,
-
+      icon = <CaretDownIcon />,
       ...restProps
     } = props
 
@@ -106,11 +103,6 @@ TextDropdownButton.propTypes = {
    * Only use if you know what you are doing.
    */
   className: PropTypes.string
-}
-
-TextDropdownButton.defaultProps = {
-  isActive: false,
-  icon: <CaretDownIcon />
 }
 
 TextDropdownButton.styles = {

--- a/src/checkbox/src/Checkbox.js
+++ b/src/checkbox/src/Checkbox.js
@@ -38,13 +38,13 @@ const Checkbox = memo(
       id,
       name,
       label,
-      appearance,
+      appearance = 'default',
       disabled,
       isInvalid,
-      checked,
-      onChange,
+      checked = false,
+      onChange = () => {},
       value,
-      indeterminate,
+      indeterminate = false,
       ...rest
     } = props
 
@@ -166,13 +166,6 @@ Checkbox.propTypes = {
    * The default theme only comes with a default style.
    */
   appearance: PropTypes.string
-}
-
-Checkbox.defaultProps = {
-  checked: false,
-  indeterminate: false,
-  onChange: () => {},
-  appearance: 'default'
 }
 
 export default Checkbox

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -12,15 +12,15 @@ const Combobox = memo(props => {
     selectedItem,
     initialSelectedItem,
     itemToString,
-    width,
+    width = 240,
     height,
     onChange,
     placeholder,
     inputProps,
     buttonProps,
-    openOnFocus,
+    openOnFocus = false,
     autocompleteProps,
-    isLoading,
+    isLoading = false,
     ...rest
   } = props
 
@@ -184,13 +184,6 @@ Combobox.propTypes = {
    * When true, show a loading spinner. This also disables the button.
    */
   isLoading: PropTypes.bool
-}
-
-Combobox.defaultProps = {
-  width: 240,
-  openOnFocus: false,
-  disabled: false,
-  isLoading: false
 }
 
 export default Combobox

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -50,21 +50,21 @@ const animationStyles = {
 const CornerDialog = memo(props => {
   const {
     title,
-    width,
+    width = 392,
     children,
-    intent,
+    intent = 'none',
     isShown,
-    hasFooter,
-    hasCancel,
-    hasClose,
-    cancelLabel,
-    confirmLabel,
+    hasFooter = true,
+    hasCancel = true,
+    hasClose = true,
+    cancelLabel = 'Close',
+    confirmLabel = 'Learn More',
     onOpenComplete,
-    onCloseComplete,
-    onCancel,
-    onConfirm,
+    onCloseComplete = () => {},
+    onCancel = close => close(),
+    onConfirm = close => close(),
     containerProps = {},
-    position
+    position = positions.BOTTOM_RIGHT
   } = props
 
   const [exiting, setExiting] = useState(false)
@@ -195,7 +195,7 @@ CornerDialog.propTypes = {
   /**
    * The intent of the CornerDialog. Used for the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
 
   /**
    * When true, the dialog is shown.
@@ -278,20 +278,6 @@ CornerDialog.propTypes = {
     positions.BOTTOM_LEFT,
     positions.BOTTOM_RIGHT
   ])
-}
-
-CornerDialog.defaultProps = {
-  width: 392,
-  intent: 'none',
-  hasFooter: true,
-  confirmLabel: 'Learn More',
-  hasCancel: true,
-  hasClose: true,
-  cancelLabel: 'Close',
-  onCancel: close => close(),
-  onConfirm: close => close(),
-  onCloseComplete: () => {},
-  position: positions.BOTTOM_RIGHT
 }
 
 export default CornerDialog

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -45,190 +45,190 @@ const animationStyles = {
   }
 }
 
-const Dialog = memo(props => {
-  const {
-    title,
-    width,
-    intent,
-    isShown,
-    topOffset,
-    sideOffset,
-    hasHeader,
-    header,
-    hasClose,
-    hasFooter,
-    footer,
-    hasCancel,
-    onCloseComplete,
-    onOpenComplete,
-    onCancel,
-    onConfirm,
-    confirmLabel,
-    isConfirmLoading,
-    isConfirmDisabled,
-    cancelLabel,
-    shouldCloseOnOverlayClick,
-    shouldCloseOnEscapePress,
+const Dialog = memo(
+  ({
+    children,
+    cancelLabel = 'Cancel',
+    confirmLabel = 'Confirm',
     containerProps = {},
     contentContainerProps,
-    minHeightContent,
-    preventBodyScrolling,
-    overlayProps,
-    children
-  } = props
+    footer,
+    hasCancel = true,
+    hasClose = true,
+    hasFooter = true,
+    hasHeader = true,
+    header,
+    intent = 'none',
+    isConfirmDisabled = false,
+    isConfirmLoading = false,
+    isShown = false,
+    minHeightContent = 80,
+    onCancel = close => close(),
+    onCloseComplete,
+    onConfirm = close => close(),
+    onOpenComplete,
+    overlayProps = {},
+    preventBodyScrolling = false,
+    shouldCloseOnEscapePress = true,
+    shouldCloseOnOverlayClick = true,
+    sideOffset = '16px',
+    title,
+    topOffset = '12vmin',
+    width = 560
+  }) => {
+    const sideOffsetWithUnit = Number.isInteger(sideOffset)
+      ? `${sideOffset}px`
+      : sideOffset
+    const maxWidth = `calc(100% - ${sideOffsetWithUnit} * 2)`
 
-  const sideOffsetWithUnit = Number.isInteger(sideOffset)
-    ? `${sideOffset}px`
-    : sideOffset
-  const maxWidth = `calc(100% - ${sideOffsetWithUnit} * 2)`
+    const topOffsetWithUnit = Number.isInteger(topOffset)
+      ? `${topOffset}px`
+      : topOffset
+    const maxHeight = `calc(100% - ${topOffsetWithUnit} * 2)`
 
-  const topOffsetWithUnit = Number.isInteger(topOffset)
-    ? `${topOffset}px`
-    : topOffset
-  const maxHeight = `calc(100% - ${topOffsetWithUnit} * 2)`
+    const renderChildren = close => {
+      if (typeof children === 'function') {
+        return children({ close })
+      }
 
-  const renderChildren = close => {
-    if (typeof children === 'function') {
-      return children({ close })
+      if (typeof children === 'string') {
+        return <Paragraph>{children}</Paragraph>
+      }
+
+      return children
     }
 
-    if (typeof children === 'string') {
-      return <Paragraph>{children}</Paragraph>
+    const renderNode = (node, close) => {
+      if (typeof node === 'function') {
+        return node({ close })
+      }
+
+      return node
     }
 
-    return children
-  }
+    const renderHeader = close => {
+      if (!header && !hasHeader) {
+        return undefined
+      }
 
-  const renderNode = (node, close) => {
-    if (typeof node === 'function') {
-      return node({ close })
-    }
-
-    return node
-  }
-
-  const renderHeader = close => {
-    if (!header && !hasHeader) {
-      return undefined
-    }
-
-    return (
-      <Pane
-        padding={16}
-        flexShrink={0}
-        borderBottom="muted"
-        display="flex"
-        alignItems="center"
-      >
-        {header ? (
-          renderNode(header, close)
-        ) : (
-          <>
-            <Heading is="h4" size={600} flex="1">
-              {title}
-            </Heading>
-            {hasClose && (
-              <IconButton
-                appearance="minimal"
-                icon={<CrossIcon />}
-                onClick={() => onCancel(close)}
-              />
-            )}
-          </>
-        )}
-      </Pane>
-    )
-  }
-
-  const renderFooter = close => {
-    if (!footer && !hasFooter) {
-      return undefined
-    }
-
-    return (
-      <Pane borderTop="muted" clearfix>
-        <Pane padding={16} float="right">
-          {footer ? (
-            renderNode(footer, close)
+      return (
+        <Pane
+          padding={16}
+          flexShrink={0}
+          borderBottom="muted"
+          display="flex"
+          alignItems="center"
+        >
+          {header ? (
+            renderNode(header, close)
           ) : (
             <>
-              {/* Cancel should be first to make sure focus gets on it first. */}
-              {hasCancel && (
-                <Button tabIndex={0} onClick={() => onCancel(close)}>
-                  {cancelLabel}
-                </Button>
+              <Heading is="h4" size={600} flex="1">
+                {title}
+              </Heading>
+              {hasClose && (
+                <IconButton
+                  appearance="minimal"
+                  icon={<CrossIcon />}
+                  onClick={() => onCancel(close)}
+                />
               )}
-
-              <Button
-                tabIndex={0}
-                marginLeft={8}
-                appearance="primary"
-                isLoading={isConfirmLoading}
-                disabled={isConfirmDisabled}
-                onClick={() => onConfirm(close)}
-                intent={intent}
-              >
-                {confirmLabel}
-              </Button>
             </>
           )}
         </Pane>
-      </Pane>
+      )
+    }
+
+    const renderFooter = close => {
+      if (!footer && !hasFooter) {
+        return undefined
+      }
+
+      return (
+        <Pane borderTop="muted" clearfix>
+          <Pane padding={16} float="right">
+            {footer ? (
+              renderNode(footer, close)
+            ) : (
+              <>
+                {/* Cancel should be first to make sure focus gets on it first. */}
+                {hasCancel && (
+                  <Button tabIndex={0} onClick={() => onCancel(close)}>
+                    {cancelLabel}
+                  </Button>
+                )}
+
+                <Button
+                  tabIndex={0}
+                  marginLeft={8}
+                  appearance="primary"
+                  isLoading={isConfirmLoading}
+                  disabled={isConfirmDisabled}
+                  onClick={() => onConfirm(close)}
+                  intent={intent}
+                >
+                  {confirmLabel}
+                </Button>
+              </>
+            )}
+          </Pane>
+        </Pane>
+      )
+    }
+
+    return (
+      <Overlay
+        isShown={isShown}
+        shouldCloseOnClick={shouldCloseOnOverlayClick}
+        shouldCloseOnEscapePress={shouldCloseOnEscapePress}
+        onExited={onCloseComplete}
+        onEntered={onOpenComplete}
+        containerProps={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          ...overlayProps
+        }}
+        preventBodyScrolling={preventBodyScrolling}
+      >
+        {({ state, close }) => (
+          <Pane
+            role="dialog"
+            backgroundColor="white"
+            elevation={4}
+            borderRadius={8}
+            width={width}
+            maxWidth={maxWidth}
+            maxHeight={maxHeight}
+            marginX={sideOffsetWithUnit}
+            marginY={topOffsetWithUnit}
+            display="flex"
+            flexDirection="column"
+            css={animationStyles}
+            data-state={state}
+            {...containerProps}
+          >
+            {renderHeader(close)}
+
+            <Pane
+              data-state={state}
+              display="flex"
+              overflow="auto"
+              padding={16}
+              flexDirection="column"
+              minHeight={minHeightContent}
+              {...contentContainerProps}
+            >
+              <Pane>{renderChildren(close)}</Pane>
+            </Pane>
+
+            {renderFooter(close)}
+          </Pane>
+        )}
+      </Overlay>
     )
   }
-
-  return (
-    <Overlay
-      isShown={isShown}
-      shouldCloseOnClick={shouldCloseOnOverlayClick}
-      shouldCloseOnEscapePress={shouldCloseOnEscapePress}
-      onExited={onCloseComplete}
-      onEntered={onOpenComplete}
-      containerProps={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        justifyContent: 'center',
-        ...overlayProps
-      }}
-      preventBodyScrolling={preventBodyScrolling}
-    >
-      {({ state, close }) => (
-        <Pane
-          role="dialog"
-          backgroundColor="white"
-          elevation={4}
-          borderRadius={8}
-          width={width}
-          maxWidth={maxWidth}
-          maxHeight={maxHeight}
-          marginX={sideOffsetWithUnit}
-          marginY={topOffsetWithUnit}
-          display="flex"
-          flexDirection="column"
-          css={animationStyles}
-          data-state={state}
-          {...containerProps}
-        >
-          {renderHeader(close)}
-
-          <Pane
-            data-state={state}
-            display="flex"
-            overflow="auto"
-            padding={16}
-            flexDirection="column"
-            minHeight={minHeightContent}
-            {...contentContainerProps}
-          >
-            <Pane>{renderChildren(close)}</Pane>
-          </Pane>
-
-          {renderFooter(close)}
-        </Pane>
-      )}
-    </Overlay>
-  )
-})
+)
 
 Dialog.propTypes = {
   /**
@@ -240,7 +240,7 @@ Dialog.propTypes = {
   /**
    * The intent of the Dialog. Used for the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
 
   /**
    * When true, the dialog is shown.
@@ -392,29 +392,6 @@ Dialog.propTypes = {
    * Props that are passed to the Overlay component.
    */
   overlayProps: PropTypes.object
-}
-
-Dialog.defaultProps = {
-  isShown: false,
-  hasHeader: true,
-  hasClose: true,
-  hasFooter: true,
-  hasCancel: true,
-  intent: 'none',
-  width: 560,
-  topOffset: '12vmin',
-  sideOffset: '16px',
-  minHeightContent: 80,
-  confirmLabel: 'Confirm',
-  isConfirmLoading: false,
-  isConfirmDisabled: false,
-  cancelLabel: 'Cancel',
-  shouldCloseOnOverlayClick: true,
-  shouldCloseOnEscapePress: true,
-  onCancel: close => close(),
-  onConfirm: close => close(),
-  preventBodyScrolling: false,
-  overlayProps: {}
 }
 
 export default Dialog

--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -18,8 +18,8 @@ const FilePicker = memo(
       disabled,
       capture,
       height,
-      onChange, // Remove onChange from props
-      placeholder,
+      onChange,
+      placeholder = 'Select a file to upload…',
       ...rest
     } = props
 
@@ -181,10 +181,6 @@ FilePicker.propTypes = {
    * Placeholder of the text input
    */
   placeholder: PropTypes.string
-}
-
-FilePicker.defaultProps = {
-  placeholder: 'Select a file to upload…'
 }
 
 export default FilePicker

--- a/src/form-field/src/FormField.js
+++ b/src/form-field/src/FormField.js
@@ -14,7 +14,7 @@ const FormField = memo(
       labelFor,
       children,
       isRequired,
-      labelProps,
+      labelProps = { size: 400 },
       description,
       validationMessage,
       ...rest
@@ -106,12 +106,6 @@ FormField.propTypes = {
    * Composes the layout spec from the Box primitive.
    */
   ...layout.propTypes
-}
-
-FormField.defaultProps = {
-  labelProps: {
-    size: 400
-  }
 }
 
 export default FormField

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -10,13 +10,13 @@ import safeInvoke from '../../lib/safe-invoke'
 const MenuItem = memo(
   forwardRef((props, ref) => {
     const {
-      is,
+      is = 'div',
       children,
-      appearance,
+      appearance = 'default',
       secondaryText,
-      intent,
+      intent = 'none',
       icon,
-      onSelect,
+      onSelect = () => {},
       onKeyPress,
       ...passthroughProps
     } = props
@@ -110,24 +110,17 @@ MenuItem.propTypes = {
   /**
    * The default theme only supports one default appearance.
    */
-  appearance: PropTypes.string.isRequired,
+  appearance: PropTypes.string,
 
   /**
    * The intent of the menu item.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']).isRequired,
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
 
   /**
    * Callback to invoke onkeypress
    */
   onKeyPress: PropTypes.func
-}
-
-MenuItem.defaultProps = {
-  is: 'div',
-  intent: 'none',
-  appearance: 'default',
-  onSelect: () => {}
 }
 
 export default MenuItem

--- a/src/menu/src/MenuOption.js
+++ b/src/menu/src/MenuOption.js
@@ -9,10 +9,10 @@ const MenuOption = memo(props => {
   const {
     id,
     children,
-    appearance,
-    onSelect,
+    appearance = 'default',
+    onSelect = () => {},
     secondaryText,
-    isSelected
+    isSelected = false
   } = props
 
   const handleClick = useCallback(e => onSelect(e), [onSelect])
@@ -103,15 +103,7 @@ MenuOption.propTypes = {
   /**
    * The default theme only supports one default appearance.
    */
-  appearance: PropTypes.string.isRequired
-}
-
-MenuOption.defaultProps = {
-  appearance: 'default',
-  isSelected: false,
-  onClick: () => {},
-  onSelect: () => {},
-  onKeyPress: () => {}
+  appearance: PropTypes.string
 }
 
 export default MenuOption

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -7,250 +7,260 @@ import { Tooltip } from '../../tooltip'
 import { Position } from '../../constants'
 import PopoverStateless from './PopoverStateless'
 
-const Popover = memo(props => {
-  const [isShown, setIsShown] = useState(props.isShown)
-  const [popoverNode, setPopoverNode] = useState(null)
-  const [targetRef, setTargetRef] = useState(null)
-
-  /**
-   * Methods borrowed from BlueprintJS
-   * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
-   */
-  const bringFocusInside = () => {
-    // Always delay focus manipulation to just before repaint to prevent scroll jumping
-    return requestAnimationFrame(() => {
-      // Container ref may be undefined between component mounting and Portal rendering
-      // activeElement may be undefined in some rare cases in IE
-      if (
-        popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
-        document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
-        !isShown
-      ) {
-        return
-      }
-
-      const isFocusOutsideModal = !popoverNode.contains(document.activeElement)
-      if (isFocusOutsideModal) {
-        // Element marked autofocus has higher priority than the other clowns
-        const autofocusElement = popoverNode.querySelector('[autofocus]')
-        const wrapperElement = popoverNode.querySelector('[tabindex]')
-        const buttonElements = popoverNode.querySelectorAll(
-          'button, a, [role="menuitem"], [role="menuitemradio"]'
-        )
-
-        if (autofocusElement) {
-          autofocusElement.focus()
-        } else if (wrapperElement) {
-          wrapperElement.focus()
-        } else if (buttonElements.length > 0) {
-          buttonElements[0].focus()
-        }
-      }
-    })
-  }
-
-  const bringFocusBackToTarget = () => {
-    return requestAnimationFrame(() => {
-      if (
-        targetRef == null || // eslint-disable-line eqeqeq, no-eq-null
-        popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
-        document.activeElement == null // eslint-disable-line eqeqeq, no-eq-null
-      ) {
-        return
-      }
-
-      const isFocusInsideModal = popoverNode.contains(document.activeElement)
-
-      // Bring back focus on the target.
-      if (document.activeElement === document.body || isFocusInsideModal) {
-        targetRef.focus()
-      }
-    })
-  }
-
-  const open = () => {
-    if (isShown) {
-      return
-    }
-
-    setIsShown(true)
-    props.onOpen()
-  }
-
-  const close = () => {
-    if (!isShown) {
-      return
-    }
-
-    setIsShown(false)
-    bringFocusBackToTarget()
-    props.onClose()
-  }
-
-  // If `props.isShown` is a boolean, treat as a controlled component
-  // `open` and `close` should be applied when it changes
-  useEffect(() => {
-    if (typeof props.isShown !== 'boolean' || props.isShown === isShown) {
-      return
-    }
-
-    if (props.isShown) {
-      open()
-    } else {
-      close()
-    }
-  }, [props.isShown])
-
-  const toggle = () => (isShown ? close() : open())
-  const handleOpenHover = props.trigger === 'hover' ? open : undefined
-  const handleCloseHover = props.trigger === 'hover' ? close : undefined
-  const handleKeyDown = event =>
-    event.key === 'ArrowDown' ? bringFocusInside() : undefined
-  const onEsc = event => (event.key === 'Escape' ? close() : undefined)
-
-  const onBodyClick = event => {
-    // Ignore clicks on the popover or button
-    if (targetRef && targetRef.contains(event.target)) {
-      return
-    }
-
-    if (popoverNode && popoverNode.contains(event.target)) {
-      return
-    }
-
-    // Notify body click
-    props.onBodyClick(event)
-
-    if (props.shouldCloseOnExternalClick !== false) {
-      close()
-    }
-  }
-
-  const handleOpenComplete = () => {
-    if (props.bringFocusInside) bringFocusInside()
-    props.onOpenComplete()
-  }
-
-  useEffect(() => {
-    if (isShown) {
-      document.body.addEventListener('click', onBodyClick, false)
-      document.body.addEventListener('keydown', onEsc, false)
-    } else {
-      document.body.removeEventListener('click', onBodyClick, false)
-      document.body.removeEventListener('keydown', onEsc, false)
-    }
-
-    return () => {
-      document.body.removeEventListener('click', onBodyClick, false)
-      document.body.removeEventListener('keydown', onEsc, false)
-    }
-  }, [isShown])
-
-  const renderTarget = ({ getRef, isShown }) => {
-    const { children } = props
-    const isTooltipInside = children && children.type === Tooltip
-
-    const getTargetRef = ref => {
-      setTargetRef(ref)
-      getRef(ref)
-    }
-
-    /**
-     * When a function is passed, you can control the Popover manually.
-     */
-    if (typeof children === 'function') {
-      return children({
-        getRef: getTargetRef,
-        isShown,
-        toggle
-      })
-    }
-
-    const popoverTargetProps = {
-      onClick: toggle,
-      onMouseEnter: handleOpenHover,
-      onKeyDown: handleKeyDown,
-      role: 'button',
-      'aria-expanded': isShown,
-      'aria-haspopup': true
-    }
-
-    /**
-     * Tooltips can be used within a Popover (not the other way around)
-     * In this case the children is the Tooltip instead of a button.
-     * Pass the properties to the Tooltip and let the Tooltip
-     * add the properties to the target.
-     */
-    if (isTooltipInside) {
-      return React.cloneElement(children, {
-        popoverProps: {
-          getTargetRef,
-          isShown,
-
-          // These propeties will be spread as `popoverTargetProps`
-          // in the Tooltip component.
-          ...popoverTargetProps
-        }
-      })
-    }
-
-    /**
-     * With normal usage only popover props end up on the target.
-     */
-    return React.cloneElement(children, {
-      innerRef: getTargetRef,
-      ...popoverTargetProps
-    })
-  }
-
-  const {
+const Popover = memo(
+  ({
+    animationDuration = 300,
+    bringFocusInside: shouldBringFocusInside = false,
+    children,
     content,
     display,
-    minWidth,
-    position,
-    minHeight,
+    minHeight = 40,
+    minWidth = 200,
+    onBodyClick = () => {},
+    onClose = () => {},
+    onCloseComplete = () => {},
+    onOpen = () => {},
+    onOpenComplete = () => {},
+    position = Position.BOTTOM,
+    shouldCloseOnExternalClick = true,
     statelessProps = {},
-    animationDuration,
-    onCloseComplete
-  } = props
+    trigger = 'click',
+    ...props
+  }) => {
+    const [isShown, setIsShown] = useState(props.isShown)
+    const [popoverNode, setPopoverNode] = useState(null)
+    const [targetRef, setTargetRef] = useState(null)
 
-  // If `props.isShown` is a boolean, popover is controlled manually, not via mouse events
-  const shown = typeof props.isShown === 'boolean' ? props.isShown : isShown
+    /**
+     * Methods borrowed from BlueprintJS
+     * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
+     */
+    const bringFocusInside = () => {
+      // Always delay focus manipulation to just before repaint to prevent scroll jumping
+      return requestAnimationFrame(() => {
+        // Container ref may be undefined between component mounting and Portal rendering
+        // activeElement may be undefined in some rare cases in IE
+        if (
+          popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
+          document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
+          !isShown
+        ) {
+          return
+        }
 
-  return (
-    <Positioner
-      target={renderTarget}
-      isShown={shown}
-      position={position}
-      animationDuration={animationDuration}
-      onOpenComplete={handleOpenComplete}
-      onCloseComplete={onCloseComplete}
-    >
-      {({ css, style, state, getRef }) => (
-        <PopoverStateless
-          ref={ref => {
-            setPopoverNode(ref)
-            getRef(ref)
-          }}
-          data-state={state}
-          display={display}
-          minWidth={minWidth}
-          minHeight={minHeight}
-          {...statelessProps}
-          className={cx(
-            statelessProps.className,
-            glamorCss(css, style, statelessProps.style).toString()
-          )}
-          // Overwrite `statelessProps.style` since we are including it via className
-          style={undefined}
-          onMouseLeave={handleCloseHover}
-        >
-          {typeof content === 'function' ? content({ close }) : content}
-        </PopoverStateless>
-      )}
-    </Positioner>
-  )
-})
+        const isFocusOutsideModal = !popoverNode.contains(
+          document.activeElement
+        )
+        if (isFocusOutsideModal) {
+          // Element marked autofocus has higher priority than the other clowns
+          const autofocusElement = popoverNode.querySelector('[autofocus]')
+          const wrapperElement = popoverNode.querySelector('[tabindex]')
+          const buttonElements = popoverNode.querySelectorAll(
+            'button, a, [role="menuitem"], [role="menuitemradio"]'
+          )
+
+          if (autofocusElement) {
+            autofocusElement.focus()
+          } else if (wrapperElement) {
+            wrapperElement.focus()
+          } else if (buttonElements.length > 0) {
+            buttonElements[0].focus()
+          }
+        }
+      })
+    }
+
+    const bringFocusBackToTarget = () => {
+      return requestAnimationFrame(() => {
+        if (
+          targetRef == null || // eslint-disable-line eqeqeq, no-eq-null
+          popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
+          document.activeElement == null // eslint-disable-line eqeqeq, no-eq-null
+        ) {
+          return
+        }
+
+        const isFocusInsideModal = popoverNode.contains(document.activeElement)
+
+        // Bring back focus on the target.
+        if (document.activeElement === document.body || isFocusInsideModal) {
+          targetRef.focus()
+        }
+      })
+    }
+
+    const open = () => {
+      if (isShown) {
+        return
+      }
+
+      setIsShown(true)
+      onOpen()
+    }
+
+    const close = () => {
+      if (!isShown) {
+        return
+      }
+
+      setIsShown(false)
+      bringFocusBackToTarget()
+      onClose()
+    }
+
+    // If `props.isShown` is a boolean, treat as a controlled component
+    // `open` and `close` should be applied when it changes
+    useEffect(() => {
+      if (typeof props.isShown !== 'boolean' || props.isShown === isShown) {
+        return
+      }
+
+      if (props.isShown) {
+        open()
+      } else {
+        close()
+      }
+    }, [props.isShown])
+
+    const toggle = () => (isShown ? close() : open())
+    const handleOpenHover = trigger === 'hover' ? open : undefined
+    const handleCloseHover = trigger === 'hover' ? close : undefined
+    const handleKeyDown = event =>
+      event.key === 'ArrowDown' ? bringFocusInside() : undefined
+    const onEsc = event => (event.key === 'Escape' ? close() : undefined)
+
+    const handleBodyClick = event => {
+      // Ignore clicks on the popover or button
+      if (targetRef && targetRef.contains(event.target)) {
+        return
+      }
+
+      if (popoverNode && popoverNode.contains(event.target)) {
+        return
+      }
+
+      // Notify body click
+      onBodyClick(event)
+
+      if (shouldCloseOnExternalClick !== false) {
+        close()
+      }
+    }
+
+    const handleOpenComplete = () => {
+      if (shouldBringFocusInside) bringFocusInside()
+      onOpenComplete()
+    }
+
+    useEffect(() => {
+      if (isShown) {
+        document.body.addEventListener('click', handleBodyClick, false)
+        document.body.addEventListener('keydown', onEsc, false)
+      } else {
+        document.body.removeEventListener('click', handleBodyClick, false)
+        document.body.removeEventListener('keydown', onEsc, false)
+      }
+
+      return () => {
+        document.body.removeEventListener('click', handleBodyClick, false)
+        document.body.removeEventListener('keydown', onEsc, false)
+      }
+    }, [isShown])
+
+    const renderTarget = ({ getRef, isShown }) => {
+      const isTooltipInside = children && children.type === Tooltip
+
+      const getTargetRef = ref => {
+        setTargetRef(ref)
+        getRef(ref)
+      }
+
+      /**
+       * When a function is passed, you can control the Popover manually.
+       */
+      if (typeof children === 'function') {
+        return children({
+          getRef: getTargetRef,
+          isShown,
+          toggle
+        })
+      }
+
+      const popoverTargetProps = {
+        onClick: toggle,
+        onMouseEnter: handleOpenHover,
+        onKeyDown: handleKeyDown,
+        role: 'button',
+        'aria-expanded': isShown,
+        'aria-haspopup': true
+      }
+
+      /**
+       * Tooltips can be used within a Popover (not the other way around)
+       * In this case the children is the Tooltip instead of a button.
+       * Pass the properties to the Tooltip and let the Tooltip
+       * add the properties to the target.
+       */
+      if (isTooltipInside) {
+        return React.cloneElement(children, {
+          popoverProps: {
+            getTargetRef,
+            isShown,
+
+            // These propeties will be spread as `popoverTargetProps`
+            // in the Tooltip component.
+            ...popoverTargetProps
+          }
+        })
+      }
+
+      /**
+       * With normal usage only popover props end up on the target.
+       */
+      return React.cloneElement(children, {
+        innerRef: getTargetRef,
+        ...popoverTargetProps
+      })
+    }
+
+    // If `props.isShown` is a boolean, popover is controlled manually, not via mouse events
+    const shown = typeof props.isShown === 'boolean' ? props.isShown : isShown
+
+    return (
+      <Positioner
+        target={renderTarget}
+        isShown={shown}
+        position={position}
+        animationDuration={animationDuration}
+        onOpenComplete={handleOpenComplete}
+        onCloseComplete={onCloseComplete}
+      >
+        {({ css, style, state, getRef }) => (
+          <PopoverStateless
+            ref={ref => {
+              setPopoverNode(ref)
+              getRef(ref)
+            }}
+            data-state={state}
+            display={display}
+            minWidth={minWidth}
+            minHeight={minHeight}
+            {...statelessProps}
+            className={cx(
+              statelessProps.className,
+              glamorCss(css, style, statelessProps.style).toString()
+            )}
+            // Overwrite `statelessProps.style` since we are including it via className
+            style={undefined}
+            onMouseLeave={handleCloseHover}
+          >
+            {typeof content === 'function' ? content({ close }) : content}
+          </PopoverStateless>
+        )}
+      </Positioner>
+    )
+  }
+)
 
 Popover.propTypes = {
   /**
@@ -316,27 +326,27 @@ Popover.propTypes = {
   /**
    * Function called when the Popover opens.
    */
-  onOpen: PropTypes.func.isRequired,
+  onOpen: PropTypes.func,
 
   /**
    * Function fired when Popover closes.
    */
-  onClose: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
 
   /**
    * Function that will be called when the enter transition is complete.
    */
-  onOpenComplete: PropTypes.func.isRequired,
+  onOpenComplete: PropTypes.func,
 
   /**
    * Function that will be called when the exit transition is complete.
    */
-  onCloseComplete: PropTypes.func.isRequired,
+  onCloseComplete: PropTypes.func,
 
   /**
    * Function that will be called when the body is clicked.
    */
-  onBodyClick: PropTypes.func.isRequired,
+  onBodyClick: PropTypes.func,
 
   /**
    * When true, bring focus inside of the Popover on open.
@@ -347,21 +357,6 @@ Popover.propTypes = {
    * Boolean indicating if clicking outside the dialog should close the dialog.
    */
   shouldCloseOnExternalClick: PropTypes.bool
-}
-
-Popover.defaultProps = {
-  position: Position.BOTTOM,
-  minWidth: 200,
-  minHeight: 40,
-  animationDuration: 300,
-  onOpen: () => {},
-  onClose: () => {},
-  onOpenComplete: () => {},
-  onCloseComplete: () => {},
-  onBodyClick: () => {},
-  bringFocusInside: false,
-  shouldCloseOnExternalClick: true,
-  trigger: 'click'
 }
 
 export default Popover

--- a/src/radio/src/Radio.js
+++ b/src/radio/src/Radio.js
@@ -22,13 +22,13 @@ const Radio = memo(
       name,
       label,
       disabled,
-      isInvalid,
+      isInvalid = false,
       checked,
-      onChange,
+      onChange = () => {},
       value,
-      size,
-      isRequired,
-      appearance,
+      size = 12,
+      isRequired = false,
+      appearance = 'default',
       ...rest
     } = props
 
@@ -141,27 +141,19 @@ Radio.propTypes = {
   /**
    * When true, the radio get the required attribute.
    */
-  isRequired: PropTypes.bool.isRequired,
+  isRequired: PropTypes.bool,
 
   /**
    * When true, the aria-invalid attribute is true.
    * Used for accessibility.
    */
-  isInvalid: PropTypes.bool.isRequired,
+  isInvalid: PropTypes.bool,
 
   /**
    * The appearance of the checkbox.
    * The default theme only comes with a default style.
    */
-  appearance: PropTypes.string.isRequired
-}
-
-Radio.defaultProps = {
-  appearance: 'default',
-  onChange: () => {},
-  size: 12,
-  isRequired: false,
-  isInvalid: false
+  appearance: PropTypes.string
 }
 
 export default Radio

--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -10,13 +10,13 @@ let radioCount = 1 // Used for generating unique input names
 const RadioGroup = memo(
   forwardRef((props, ref) => {
     const {
-      size,
+      size = 12,
       label,
       defaultValue,
       value,
-      options,
-      onChange,
-      isRequired,
+      options = [],
+      onChange = () => {},
+      isRequired = false,
       ...rest
     } = props
 
@@ -89,7 +89,7 @@ RadioGroup.propTypes = {
   /**
    * Function called when state changes.
    */
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
 
   /**
    * Label to display above the radio button options.
@@ -99,19 +99,12 @@ RadioGroup.propTypes = {
   /**
    * The size of the radio circle. This also informs the text size and spacing.
    */
-  size: PropTypes.oneOf([12, 16]).isRequired,
+  size: PropTypes.oneOf([12, 16]),
 
   /**
    * When true, the radio get the required attribute.
    */
-  isRequired: PropTypes.bool.isRequired
-}
-
-RadioGroup.defaultProps = {
-  options: [],
-  onChange: () => {},
-  size: 12,
-  isRequired: false
+  isRequired: PropTypes.bool
 }
 
 export default RadioGroup

--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -8,7 +8,12 @@ import { StackingOrder } from '../../constants'
 const SearchInput = memo(
   forwardRef((props, ref) => {
     const theme = useTheme()
-    const { appearance, disabled, height, ...restProps } = props
+    const {
+      appearance = 'default',
+      disabled,
+      height = 32,
+      ...restProps
+    } = props
     const { matchedProps, remainingProps } = splitBoxProps(restProps)
     const { width } = matchedProps
     const iconSize = theme.getIconSizeForInput(height)
@@ -55,11 +60,6 @@ SearchInput.propTypes = {
    * Composes the TextInput component as the base.
    */
   ...TextInput.propTypes
-}
-
-SearchInput.defaultProps = {
-  height: 32,
-  appearance: 'default'
 }
 
 export default SearchInput

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -40,23 +40,23 @@ const SelectMenu = memo(
   forwardRef((props, ref) => {
     const {
       title,
-      width,
-      height,
+      width = 240,
+      height = 248,
       options,
-      onSelect,
-      onDeselect,
+      onSelect = () => {},
+      onDeselect = () => {},
       onFilterChange,
       selected,
-      position,
+      position = Position.BOTTOM_LEFT,
       hasTitle,
       hasFilter,
-      filterPlaceholder,
-      filterIcon,
+      filterPlaceholder = 'Filter...',
+      filterIcon = <SearchIcon />,
       detailView,
       emptyView,
       titleView,
-      isMultiSelect,
-      closeOnSelect,
+      isMultiSelect = false,
+      closeOnSelect = false,
       ...rest
     } = props
 
@@ -199,18 +199,6 @@ SelectMenu.propTypes = {
    * When true, menu closes on option selection.
    */
   closeOnSelect: PropTypes.bool
-}
-
-SelectMenu.defaultProps = {
-  onSelect: () => {},
-  onDeselect: () => {},
-  width: 240,
-  height: 248,
-  position: Position.BOTTOM_LEFT,
-  isMultiSelect: false,
-  filterPlaceholder: 'Filter...',
-  filterIcon: <SearchIcon />,
-  closeOnSelect: false
 }
 
 export default SelectMenu

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -39,14 +39,14 @@ const SelectMenuContent = memo(props => {
     title,
     width,
     height,
-    options,
-    hasTitle,
-    hasFilter,
+    options = [],
+    hasTitle = true,
+    hasFilter = true,
     filterPlaceholder,
     filterIcon,
     close,
     listProps,
-    titleView,
+    titleView = DefaultTitleView,
     detailView,
     emptyView,
     isMultiSelect,
@@ -127,13 +127,6 @@ SelectMenuContent.propTypes = {
    * Node that is displayed instead of options list when there are no options.
    */
   emptyView: PropTypes.node
-}
-
-SelectMenuContent.defaultProps = {
-  options: [],
-  hasTitle: true,
-  hasFilter: true,
-  titleView: DefaultTitleView
 }
 
 export default SelectMenuContent

--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -11,7 +11,7 @@ const Select = memo(
     const {
       id,
       name,
-      height,
+      height = 32,
       children,
       defaultValue,
       disabled,
@@ -19,8 +19,8 @@ const Select = memo(
       value,
       required,
       autoFocus,
-      isInvalid,
-      appearance,
+      isInvalid = false,
+      appearance = 'default',
       ...restProps
     } = props
 
@@ -144,13 +144,7 @@ Select.propTypes = {
   /**
    * The appearance of the select. The default theme only supports default.
    */
-  appearance: PropTypes.string.isRequired
-}
-
-Select.defaultProps = {
-  appearance: 'default',
-  height: 32,
-  isInvalid: false
+  appearance: PropTypes.string
 }
 
 export default Select

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -128,16 +128,16 @@ const animationStylesClass = {
 const SideSheet = memo(
   forwardRef((props, ref) => {
     const {
-      width,
+      width = 620,
       isShown,
       children,
       containerProps,
-      onOpenComplete,
-      onCloseComplete,
+      onOpenComplete = () => {},
+      onCloseComplete = () => {},
       onBeforeClose,
-      shouldCloseOnOverlayClick,
-      shouldCloseOnEscapePress,
-      position,
+      shouldCloseOnOverlayClick = true,
+      shouldCloseOnEscapePress = true,
+      position = Position.RIGHT,
       preventBodyScrolling
     } = props
 
@@ -225,7 +225,7 @@ SideSheet.propTypes = {
   /**
    * Width of the SideSheet.
    */
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
    * Properties to pass through the SideSheet container Pane.
@@ -240,21 +240,12 @@ SideSheet.propTypes = {
     Position.BOTTOM,
     Position.LEFT,
     Position.RIGHT
-  ]).isRequired,
+  ]),
 
   /**
    * Whether or not to prevent scrolling in the outer body
    */
   preventBodyScrolling: PropTypes.bool
-}
-
-SideSheet.defaultProps = {
-  width: 620,
-  onCloseComplete: () => {},
-  onOpenComplete: () => {},
-  shouldCloseOnOverlayClick: true,
-  shouldCloseOnEscapePress: true,
-  position: Position.RIGHT
 }
 
 export default SideSheet

--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -62,12 +62,12 @@ const Switch = memo(
     const {
       id,
       name,
-      height,
+      height = 16,
       checked,
-      onChange,
-      disabled,
-      appearance,
-      hasCheckIcon,
+      onChange = () => {},
+      disabled = false,
+      appearance = 'default',
+      hasCheckIcon = true,
       defaultChecked,
       ...rest
     } = props
@@ -176,7 +176,7 @@ Switch.propTypes = {
    * The appearance of the checkbox.
    * The default theme only comes with a default style.
    */
-  appearance: PropTypes.string.isRequired,
+  appearance: PropTypes.string,
 
   /**
    * When true, the switch has a check icon.
@@ -188,14 +188,6 @@ Switch.propTypes = {
    * This is for uncontrolled usage.
    */
   defaultChecked: PropTypes.bool
-}
-
-Switch.defaultProps = {
-  height: 16,
-  onChange: () => {},
-  appearance: 'default',
-  hasCheckIcon: true,
-  disabled: false
 }
 
 export default Switch

--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -9,17 +9,18 @@ const Textarea = memo(
     const theme = useTheme()
     const {
       className,
-      width,
+      width = '100%',
       height,
-      disabled,
+      disabled = false,
       required,
-      isInvalid,
-      appearance,
+      isInvalid = false,
+      appearance = 'default',
       placeholder,
-      spellCheck,
-      grammarly,
+      spellCheck = true,
+      grammarly = false,
       ...restProps
     } = props
+
     const themedClassName = theme.getTextareaClassName(appearance)
 
     return (
@@ -99,15 +100,6 @@ Textarea.propTypes = {
    * Only use if you know what you are doing.
    */
   className: PropTypes.string
-}
-
-Textarea.defaultProps = {
-  appearance: 'default',
-  width: '100%',
-  disabled: false,
-  isInvalid: false,
-  spellCheck: true,
-  grammarly: false
 }
 
 Textarea.styles = {

--- a/src/typography/src/Code.js
+++ b/src/typography/src/Code.js
@@ -7,7 +7,7 @@ import Text from './Text'
 const Code = memo(
   forwardRef((props, ref) => {
     const theme = useTheme()
-    const { className, appearance, ...restProps } = props
+    const { className, appearance = 'default', ...restProps } = props
 
     const {
       className: themedClassName = '',
@@ -40,10 +40,6 @@ Code.propTypes = {
    * Only use if you know what you are doing.
    */
   className: PropTypes.string
-}
-
-Code.defaultProps = {
-  appearance: 'default'
 }
 
 export default Code

--- a/src/typography/src/Heading.js
+++ b/src/typography/src/Heading.js
@@ -6,7 +6,7 @@ import { useTheme } from '../../theme'
 const Heading = memo(
   forwardRef((props, ref) => {
     const theme = useTheme()
-    const { marginTop, size, ...restProps } = props
+    const { marginTop, size = 500, ...restProps } = props
     const {
       marginTop: defaultMarginTop,
       ...headingStyle
@@ -49,10 +49,6 @@ Heading.propTypes = {
     PropTypes.number,
     PropTypes.string
   ])
-}
-
-Heading.defaultProps = {
-  size: 500
 }
 
 export default Heading

--- a/src/typography/src/Link.js
+++ b/src/typography/src/Link.js
@@ -7,7 +7,7 @@ import Text from './Text'
 const Link = memo(
   forwardRef((props, ref) => {
     const theme = useTheme()
-    const { className, color, ...restProps } = props
+    const { className, color = 'default', ...restProps } = props
     const themedClassName = theme.getLinkClassName(color)
 
     return (
@@ -52,10 +52,6 @@ Link.propTypes = {
    * Only use if you know what you are doing.
    */
   className: PropTypes.string
-}
-
-Link.defaultProps = {
-  color: 'default'
 }
 
 export default Link

--- a/src/typography/src/OrderedList.js
+++ b/src/typography/src/OrderedList.js
@@ -12,7 +12,7 @@ const styles = {
 
 const OrderedList = memo(
   forwardRef((props, ref) => {
-    const { children, size, ...rest } = props
+    const { children, size = 400, ...rest } = props
 
     const finalChildren = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -40,11 +40,7 @@ OrderedList.propTypes = {
    * Size of the text used in a list item.
    * Can be: 300, 400, 500, 600.
    */
-  size: PropTypes.oneOf([300, 400, 500, 600]).isRequired
-}
-
-OrderedList.defaultProps = {
-  size: 400
+  size: PropTypes.oneOf([300, 400, 500, 600])
 }
 
 export default OrderedList

--- a/src/typography/src/Paragraph.js
+++ b/src/typography/src/Paragraph.js
@@ -6,7 +6,13 @@ import { useTheme } from '../../theme'
 const Paragraph = memo(
   forwardRef((props, ref) => {
     const theme = useTheme()
-    const { size, color, fontFamily, marginTop, ...restProps } = props
+    const {
+      size = 400,
+      color = 'default',
+      fontFamily = 'ui',
+      marginTop,
+      ...restProps
+    } = props
 
     const {
       marginTop: defaultMarginTop,
@@ -41,19 +47,13 @@ Paragraph.propTypes = {
    * Size of the text style.
    * Can be: 300, 400, 500.
    */
-  size: PropTypes.oneOf([300, 400, 500]).isRequired,
+  size: PropTypes.oneOf([300, 400, 500]),
 
   /**
    * Font family.
    * Can be: `ui`, `display` or `mono` or a custom font family.
    */
-  fontFamily: PropTypes.string.isRequired
-}
-
-Paragraph.defaultProps = {
-  size: 400,
-  color: 'default',
-  fontFamily: 'ui'
+  fontFamily: PropTypes.string
 }
 
 export default Paragraph

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -11,9 +11,9 @@ const Text = memo(
     const {
       className,
       css,
-      size,
-      color,
-      fontFamily,
+      size = 400,
+      color = 'default',
+      fontFamily = 'ui',
       marginTop,
       ...restProps
     } = props
@@ -57,12 +57,6 @@ Text.propTypes = {
    * Can be: `ui`, `display` or `mono` or a custom font family.
    */
   fontFamily: PropTypes.string
-}
-
-Text.defaultProps = {
-  size: 400,
-  color: 'default',
-  fontFamily: 'ui'
 }
 
 export default Text

--- a/src/typography/src/UnorderedList.js
+++ b/src/typography/src/UnorderedList.js
@@ -12,7 +12,7 @@ const styles = {
 
 const UnorderedList = memo(
   forwardRef((props, ref) => {
-    const { children, size, icon, ...rest } = props
+    const { children, size = 400, icon, ...rest } = props
 
     const enrichedChildren = React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -42,17 +42,13 @@ UnorderedList.propTypes = {
    * Size of the text used in a list item.
    * Can be: 300, 400, 500, 600.
    */
-  size: PropTypes.oneOf([300, 400, 500, 600]).isRequired,
+  size: PropTypes.oneOf([300, 400, 500, 600]),
 
   /**
    * When passed, adds a icon before each list item in the list
    * You can override this on a individual list item.
    */
   icon: PropTypes.node
-}
-
-UnorderedList.defaultProps = {
-  size: 400
 }
 
 export default UnorderedList


### PR DESCRIPTION
## Overview 
No-op change that moves `Component.defaultProps` into default value assignment instead (since defaultProps are not respected or supported for memo/forwardRef/React.FC, technically.

## Screenshots (if applicable) 
NA

## Testing
- [ ] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
