### PR TITLE
V5 bubble ref

### DIFF
--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -77,7 +77,7 @@ const Avatar = memo(
         justifyContent="center"
         backgroundColor={colorProps.backgroundColor}
         title={name}
-        innerRef={ref}
+        ref={ref}
         {...restProps}
       >
         {(imageUnavailable || forceShowInitials) && (

--- a/src/lib/bubble-ref.js
+++ b/src/lib/bubble-ref.js
@@ -1,0 +1,7 @@
+export default (ref, node) => {
+  if (typeof ref === 'function') {
+    ref(node)
+  } else if (ref && 'current' in ref) {
+    ref.current = node
+  }
+}

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -4,7 +4,7 @@ import { Transition } from 'react-transition-group'
 import { Portal } from '../../portal'
 import { Stack } from '../../stack'
 import { StackingOrder, Position } from '../../constants'
-import safeInvoke from '../../lib/safe-invoke'
+import bubbleRef from '../../lib/bubble-ref'
 import getPosition from './getPosition'
 
 const animationEasing = {
@@ -73,7 +73,7 @@ const Positioner = memo(
 
     const getRef = newRef => {
       setPositionerRef(newRef)
-      safeInvoke(ref, newRef)
+      bubbleRef(ref, newRef)
     }
 
     const handleEnter = () => {

--- a/src/table/src/TableCell.js
+++ b/src/table/src/TableCell.js
@@ -5,6 +5,7 @@ import { toaster } from '../../toaster'
 import { useTheme } from '../../theme'
 import { Pane } from '../../layers'
 import safeInvoke from '../../lib/safe-invoke'
+import bubbleRef from '../../lib/bubble-ref'
 import { TableRowConsumer } from './TableRowContext'
 import manageTableCellFocusInteraction from './manageTableCellFocusInteraction'
 
@@ -89,7 +90,7 @@ const TableCell = memo(
 
     const handleRef = newRef => {
       setCellRef(newRef)
-      safeInvoke(ref, newRef)
+      bubbleRef(ref, newRef)
     }
 
     const themedClassName = theme.getTableCellClassName(appearance)

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { Pane } from '../../layers'
 import { useTheme } from '../../theme'
-import safeInvoke from '../../lib/safe-invoke'
+import bubbleRef from '../../lib/bubble-ref'
 import { TableRowProvider } from './TableRowContext'
 import manageTableRowFocusInteraction from './manageTableRowFocusInteraction'
 
@@ -66,7 +66,7 @@ const TableRow = memo(forwardRef((props, ref) => {
 
   const onRef = newRef => {
     setMainRef(newRef)
-    safeInvoke(ref, newRef)
+    bubbleRef(ref, newRef)
   }
 
   const themedClassName = theme.getRowClassName(appearance, intent)

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -10,6 +10,7 @@ import { Text } from '../../typography'
 import { withTheme } from '../../theme'
 import { majorScale } from '../../scales'
 import safeInvoke from '../../lib/safe-invoke'
+import bubbleRef from '../../lib/bubble-ref'
 import Tag from './Tag'
 
 let inputId = 1
@@ -219,7 +220,7 @@ class TagInput extends React.Component {
 
   setRef = node => {
     this.input = node
-    safeInvoke(this.props.inputRef, node)
+    bubbleRef(this.props.inputRef, node)
   }
 
   render() {


### PR DESCRIPTION
<!-- 
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
 -->
 
## Overview 
Update the way we bubble ref
- Create bubbleRef method
- Update components using forwardRef and have handler within the component to use bubbleRef instead of safeInvoke
- Update one missed innerRef to ref
 
## Screenshots (if applicable) 
N/A

## Testing
- [x] bubbleRef accepts callback ref
- [x] bubbleRef accepts useRef ref
- [x] bubbleRef accepts React.createRef ref
- [x] components bubble ref as expected
