### PR TITLE
V5 box types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,7 @@
 /* tslint:disable:interface-name max-classes-per-file no-empty-interface */
 
 import * as React from 'react'
-import Box, { extractStyles as boxExtractStyles } from 'ui-box'
-import { BoxProps } from 'ui-box/dist/types/box-types'
+import Box, { extractStyles as boxExtractStyles, BoxProps } from 'ui-box'
 import { StyleAttribute, CSSProperties } from 'glamor'
 import { DownshiftProps } from 'downshift'
 import { TransitionProps, TransitionStatus } from 'react-transition-group/Transition'
@@ -1818,17 +1817,17 @@ export interface TableProps extends PaneProps {
 }
 
 export declare const Table: React.FC<TableProps> & {
-  public static Body: TableBody
-  public static VirtualBody: React.FC<TableVirtualBodyProps>
-  public static Head: TableHead
-  public static HeaderCell: TableHeaderCell
-  public static TextHeaderCell: TextTableHeaderCell
-  public static SearchHeaderCell: SearchTableHeaderCell
-  public static Row: TableRow
-  public static Cell: TableCell
-  public static TextCell: TextTableCell
-  public static EditableCell: React.FC<TableEditableCellProps>
-  public static SelectMenuCell: React.FC<TableSelectMenuCellProps>
+  Body: typeof TableBody
+  VirtualBody: React.FC<TableVirtualBodyProps>
+  Head: typeof TableHead
+  HeaderCell: typeof TableHeaderCell
+  TextHeaderCell: typeof TextTableHeaderCell
+  SearchHeaderCell: typeof SearchTableHeaderCell
+  Row: typeof TableRow
+  Cell: typeof TableCell
+  TextCell: typeof TextTableCell
+  EditableCell: React.FC<TableEditableCellProps>
+  SelectMenuCell: React.FC<TableSelectMenuCellProps>
 }
 
 export interface TabProps extends TextProps {
@@ -1974,7 +1973,7 @@ export interface TextTableHeaderCellProps extends PaneProps {
 
 export declare const TextTableHeaderCell: React.FC<TextTableHeaderCellProps>
 
-export type TextProps = BoxProps<'span'> & {
+export type TextProps = React.ComponentProps<typeof Box> & {
   size?: keyof Typography['text']
   fontFamily?: FontFamily | string
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,19 @@
 /* tslint:disable:interface-name max-classes-per-file no-empty-interface */
 
 import * as React from 'react'
-import { extractStyles as boxExtractStyles, BoxProps } from 'ui-box'
+import { extractStyles as boxExtractStyles, BoxProps, BoxOwnProps } from 'ui-box'
 import { StyleAttribute, CSSProperties } from 'glamor'
 import { DownshiftProps } from 'downshift'
 import { TransitionProps, TransitionStatus } from 'react-transition-group/Transition'
 
-export { configureSafeHref } from 'ui-box'
+export { configureSafeHref, BoxProps } from 'ui-box'
 
 /**
  * Convenience method for defining your own components that extend Box and pass-through props
  */
-export type BoxComponent<P, D extends React.ElementType = React.ElementType> = <
+export type BoxComponent<P = {}, D extends React.ElementType = React.ElementType> = <
   E extends React.ElementType = D
->(props: P & BoxProps<E>) => JSX.Element
+>(props: P & Omit<BoxProps<E>, keyof P>) => JSX.Element
 
 type PositionTypes = 'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'
 type IntentTypes = 'none' | 'success' | 'warning' | 'danger'
@@ -532,7 +532,7 @@ export interface BadgeProps extends StrongProps {
   isSolid?: boolean
 }
 
-export declare const Badge: ForwardRefComponent<BadgeProps>
+export declare const Badge: BoxComponent<BadgeProps, 'strong'>
 
 export interface ButtonProps extends TextProps {
   intent?: IntentTypes
@@ -623,7 +623,7 @@ export declare const Checkbox: BoxComponent<CheckboxProps, 'input'>
 export type CodeProps = TextProps
 
 
-export declare const Code: ForwardRefComponent<CodeProps>
+export declare const Code: BoxComponent<CodeProps, 'code'>
 
 export interface ComboboxProps {
   /**
@@ -745,10 +745,10 @@ export interface CornerDialogProps {
   /**
    * Props that are passed to the dialog container.
    */
-  containerProps?: CardProps
+  containerProps?: CardProps & BoxOwnProps<'div'>
 }
 
-export declare const CornerDialog: ForwardRefComponent<CornerDialogProps>
+export declare const CornerDialog: React.FC<CornerDialogProps>
 
 export interface DialogProps {
   /**
@@ -884,7 +884,32 @@ export interface DialogProps {
   preventBodyScrolling?: boolean
 }
 
-export declare const Dialog: ForwardRefComponent<DialogProps>
+export declare const Dialog: React.FC<DialogProps>
+
+export interface FilePickerProps {
+  /** the name attribute of the input */
+  name?: string
+  /** the accept attribute of the input */
+  accept?: string | string[]
+  /** whether or not the field is required */
+  required?: boolean
+  /** whether or not the file input accepts multiple files */
+  multiple?: boolean
+  /** whether or not the filepicker is disabled */
+  disabled?: boolean
+  /** the capture attribute of the input */
+  capture?: boolean
+  /** the height of the filepicker */
+  height?: number
+  /** function called when onChange is fired */
+  onChange?: () => void
+  /** function called when onBlur is fired */
+  onBlur?: () => void
+  /** placeholder of the text input */
+  placeholder?: string
+}
+
+export declare const FilePicker: BoxComponent<FilePickerProps, 'div'>
 
 export interface FormFieldProps {
   /**
@@ -927,13 +952,13 @@ export declare const FormField: BoxComponent<FormFieldProps>
 export interface FormFieldDescriptionProps extends ParagraphProps {
 }
 
-export declare const FormFieldDescription: ForwardRefComponent<FormFieldDescriptionProps>
+export declare const FormFieldDescription: BoxComponent<FormFieldDescriptionProps, 'p'>
 
 
 export interface FormFieldHintProps extends ParagraphProps {
 }
 
-export declare const FormFieldHint: ForwardRefComponent<ParagraphProps>
+export declare const FormFieldHint: BoxComponent<FormFieldHintProps, 'p'>
 
 
 export interface FormFieldLabelProps extends LabelProps {
@@ -943,13 +968,13 @@ export interface FormFieldLabelProps extends LabelProps {
   isAstrixShown?: boolean
 }
 
-export declare const FormFieldLabel: ForwardRefComponent<FormFieldLabelProps>
+export declare const FormFieldLabel: BoxComponent<FormFieldLabelProps, 'label'>
 
 
 export interface FormFieldValidationMessageProps extends PaneProps {
 }
 
-export declare const FormFieldValidationMessage: ForwardRefComponent<FormFieldValidationMessageProps>
+export declare const FormFieldValidationMessage: BoxComponent<FormFieldValidationMessageProps, 'div'>
 
 export interface HeadingProps {
   size?: keyof Typography['headings']
@@ -990,7 +1015,7 @@ export interface IconButtonProps extends ButtonProps {
   className?: string
 }
 
-export declare const IconButton: ForwardRefComponent<IconButtonProps>
+export declare const IconButton: BoxComponent<IconButtonProps, 'button'>
 
 export interface ImageProps {
   src?: string
@@ -1012,7 +1037,7 @@ export interface InlineAlertProps extends PaneProps {
   size?: keyof Typography['text']
 }
 
-export declare const InlineAlert: ForwardRefComponent<InlineAlertProps>
+export declare const InlineAlert: BoxComponent<InlineAlertProps, 'div'>
 
 export type LabelProps = TextProps
 
@@ -1056,8 +1081,8 @@ export interface ListItemProps extends TextProps {
   iconColor?: string
 }
 
-export declare const ListItem: ForwardRefComponent<ListItemProps>
-export declare const Li: ForwardRefComponent<ListItemProps>
+export declare const ListItem: BoxComponent<ListItemProps, 'li'>
+export declare const Li: typeof ListItem
 
 export interface MenuProps {
   children: React.ReactNode[] | React.ReactNode
@@ -1122,7 +1147,7 @@ export declare const Pane: BoxComponent<PaneProps, 'div'>
 
 export type PillProps = BadgeProps
 
-export declare const Pill: ForwardRefComponent<PillProps>
+export declare const Pill: BoxComponent<PillProps, 'strong'>
 
 export type PopoverStatelessProps = BoxProps<'div'>
 
@@ -1148,7 +1173,7 @@ export interface PopoverProps {
   statelessProps?: PopoverStatelessProps
 }
 
-export declare const Popover: ForwardRefComponent<PopoverProps>
+export declare const Popover: React.FC<PopoverProps>
 
 export type ParagraphProps = {
   size?: keyof Typography['paragraph']
@@ -1186,11 +1211,11 @@ export interface PositionerProps {
   onOpenComplete?: () => void
 }
 
-export declare const Positioner: ForwardRefComponent<PositionerProps>
+export declare const Positioner: React.FC<PositionerProps>
 
 type PreProps = TextProps
 
-export declare const Pre: ForwardRefComponent<PreProps>
+export declare const Pre: BoxComponent<PreProps, 'pre'>
 
 export interface RadioProps {
   /**
@@ -1241,7 +1266,7 @@ export interface RadioProps {
   appearance?: DefaultAppearance
 }
 
-export declare const Radio: ForwardRefComponent<RadioProps>
+export declare const Radio: BoxComponent<RadioProps, 'label'>
 
 interface RadioGroupOption {
   label: React.ReactNode
@@ -1249,7 +1274,7 @@ interface RadioGroupOption {
   isDisabled?: boolean
 }
 
-export interface RadioGroupProps extends Omit<PaneProps, 'onChange'> {
+export interface RadioGroupProps extends PaneProps {
   /**
    * The default value of the Radio Group when uncontrolled.
    */
@@ -1277,10 +1302,10 @@ export interface RadioGroupProps extends Omit<PaneProps, 'onChange'> {
   /**
    * Function called when state changes.
    */
-  onChange?(value: string): void
+  onChange?(event: React.ChangeEvent<HTMLInputElement>): void
 }
 
-export declare const RadioGroup: ForwardRefComponent<RadioGroupProps>
+export declare const RadioGroup: BoxComponent<RadioGroupProps, 'div'>
 
 export interface Option {
   label?: string
@@ -1327,9 +1352,9 @@ export interface SearchInputProps extends TextInputProps {
   height?: number
 }
 
-export declare const SearchInput: ForwardRefComponent<SearchInputProps>
+export declare const SearchInput: BoxComponent<SearchInputProps, 'div'>
 
-export interface SearchTableHeaderCellProps extends Omit<TableHeaderCellProps, 'onChange'> {
+export interface SearchTableHeaderCellProps extends TableHeaderCellProps {
   /**
    * The value of the input.
    */
@@ -1356,7 +1381,7 @@ export interface SearchTableHeaderCellProps extends Omit<TableHeaderCellProps, '
   icon?: React.ReactElement | null | false
 }
 
-export declare const SearchTableHeaderCell: ForwardRefComponent<SearchTableHeaderCellProps>
+export declare const SearchTableHeaderCell: React.FC<SearchTableHeaderCellProps>
 
 export interface SegmentedControlProps {
   options: Array<{ label: string, value: NonNullable<SegmentedControlProps['value']> }>
@@ -1525,7 +1550,7 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
   closeOnSelect?: boolean
 }
 
-export declare const SelectMenu: ForwardRefComponent<SelectMenuProps>
+export declare const SelectMenu: React.FC<SelectMenuProps>
 
 export interface SideSheetProps {
   children: React.ReactNode | (() => React.ReactNode)
@@ -1542,11 +1567,11 @@ export interface SideSheetProps {
   preventBodyScrolling?: boolean
 }
 
-export declare const SideSheet: ForwardRefComponent<SideSheetProps>
+export declare const SideSheet: React.FC<SideSheetProps>
 
 export type SidebarTabProps = TabProps
 
-export declare const SidebarTab: ForwardRefComponent<SidebarTabProps>
+export declare const SidebarTab: BoxComponent<SidebarTabProps, 'span'>
 
 export interface SmallProps {}
 
@@ -1574,9 +1599,9 @@ export declare const Stack: React.FC<StackProps>
 
 export declare const StackingContext: React.Context<number>
 
-export type StrongProps = BoxProps<'strong'>
+export type StrongProps = TextProps
 
-export declare const Strong: ForwardRefComponent<StrongProps>
+export declare const Strong: BoxComponent<StrongProps, 'strong'>
 
 export interface SwitchProps {
   /**
@@ -1752,7 +1777,7 @@ export interface TableRowProps extends PaneProps {
   onDeselect?(): void
 }
 
-export declare const TableRow: ForwardRefComponent<TableRowProps>
+export declare const TableRow: BoxComponent<TableRowProps, 'div'>
 
 export interface TableSelectMenuCellProps extends Omit<TextTableCellProps, 'placeholder'> {
   /**
@@ -1957,7 +1982,7 @@ export interface TextDropdownButtonProps extends TextProps {
   className?: string
 }
 
-export declare const TextDropdownButton: ForwardRefComponent<TextDropdownButtonProps>
+export declare const TextDropdownButton: BoxComponent<TextDropdownButtonProps, 'button'>
 
 export interface TextTableCellProps extends TableCellProps {
   /**
@@ -1985,7 +2010,7 @@ export type TextProps = {
 
 export declare const Text: BoxComponent<TextProps, 'span'>
 
-export type TextInputProps = React.ComponentProps<typeof Text> & {
+export interface TextInputProps extends TextProps {
   /**
    * Makes the input element required.
    */
@@ -2021,9 +2046,9 @@ export type TextInputProps = React.ComponentProps<typeof Text> & {
   className?: string
 }
 
-export declare const TextInput: ForwardRefComponent<TextInputProps>
+export declare const TextInput: BoxComponent<TextInputProps, 'input'>
 
-export interface TextInputFieldProps extends TextInputProps {
+export interface TextInputFieldProps extends FormFieldProps {
   /**
    * The label used above the input element.
    */
@@ -2059,7 +2084,7 @@ export interface TextInputFieldProps extends TextInputProps {
   inputWidth?: number | string
 }
 
-export declare const TextInputField: ForwardRefComponent<TextInputFieldProps>
+export declare const TextInputField: BoxComponent<TextInputFieldProps, 'input'>
 
 export interface TooltipStatelessProps extends PaneProps {
   /**
@@ -2245,7 +2270,7 @@ interface OverlayProps {
   onEntered?: TransitionProps['onEntered'];
 }
 
-export declare const Overlay: ForwardRefComponent<OverlayProps>
+export declare const Overlay: React.FC<OverlayProps>
 
 export declare const ThemeContext: React.Context<Theme>
 export declare const ThemeProvider: React.Context<Theme>['Provider']
@@ -2774,7 +2799,5 @@ export declare const ZoomToFitIcon: IconComponent
 // The following component types have yet to be defined
 // ====================================================
 
-type UnknownProps = Record<string, any>
-export declare const FilePicker: ForwardRefComponent<UnknownProps>
 export declare const OptionShapePropType: unknown
 export declare const SelectedPropType: unknown

--- a/index.d.ts
+++ b/index.d.ts
@@ -1358,7 +1358,7 @@ export interface SearchTableHeaderCellProps extends Omit<TableHeaderCellProps, '
 
 export declare const SearchTableHeaderCell: ForwardRefComponent<SearchTableHeaderCellProps>
 
-export interface SegmentedControlProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'defaultValue' | 'onChange'> {
+export interface SegmentedControlProps {
   options: Array<{ label: string, value: NonNullable<SegmentedControlProps['value']> }>
   value?: number | string | boolean
   defaultValue?: number | string | boolean
@@ -1367,9 +1367,9 @@ export interface SegmentedControlProps extends Omit<React.ComponentPropsWithoutR
   height?: number
 }
 
-export declare const SegmentedControl: ForwardRefComponent<SegmentedControlProps>
+export declare const SegmentedControl: BoxComponent<SegmentedControlProps, 'div'>
 
-export interface SelectProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
+export interface SelectProps {
   /**
    * The initial value of an uncontrolled select
    */
@@ -1406,7 +1406,7 @@ export interface SelectProps extends Omit<React.ComponentPropsWithoutRef<typeof 
   onChange?(event: React.ChangeEvent<HTMLSelectElement>): void
 }
 
-export declare const Select: ForwardRefComponent<SelectProps>
+export declare const Select: BoxComponent<SelectProps, 'div'>
 
 export type SelectFieldProps = FormFieldProps
 
@@ -1552,7 +1552,7 @@ export interface SmallProps {}
 
 export declare const Small: BoxComponent<SmallProps, 'small'>
 
-export interface SpinnerProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface SpinnerProps {
   /**
    * Delay after which spinner should be visible.
    */
@@ -1563,7 +1563,7 @@ export interface SpinnerProps extends React.ComponentPropsWithoutRef<typeof Box>
   size?: number
 }
 
-export declare const Spinner: ForwardRefComponent<SpinnerProps>
+export declare const Spinner: BoxComponent<SpinnerProps, 'div'>
 
 export interface StackProps {
   children: (zIndex: number) => React.ReactNode
@@ -1862,13 +1862,13 @@ export type TabNavigationProps = BoxProps<'nav'>
 
 export declare const TabNavigation: BoxComponent<{}, 'nav'>
 
-export interface TagInputProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
+export interface TagInputProps {
   addOnBlur?: boolean
   className?: string
   disabled?: boolean
   height?: number
   inputProps?: TextProps
-  inputRef?: (input: HTMLInputElement | null) => void
+  inputRef?: React.Ref<HTMLInputElement>
   onAdd?: (values: string[]) => void | false
   onBlur?: (event: React.FocusEvent) => void
   onChange?: (values: string[]) => void | false
@@ -1881,7 +1881,7 @@ export interface TagInputProps extends Omit<React.ComponentPropsWithoutRef<typeo
   values?: string[]
 }
 
-export declare const TagInput: React.FC<TagInputProps>
+export declare const TagInput: BoxComponent<TagInputProps, 'div'>
 
 export interface TextareaProps extends TextProps {
   required?: boolean
@@ -2101,17 +2101,17 @@ export interface TooltipProps {
 
 export declare const Tooltip: React.FC<TooltipProps>
 
-export interface OrderedListProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface OrderedListProps {
   /**
    * Size of the text used in a list item.
    */
   size?: keyof Typography['text']
 }
 
-export declare const OrderedList: ForwardRefComponent<OrderedListProps>
-export declare const Ol: ForwardRefComponent<OrderedListProps>
+export declare const OrderedList: BoxComponent<OrderedListProps, 'ol'>
+export declare const Ol: typeof OrderedList
 
-export interface UnorderedListProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface UnorderedListProps {
   /**
    * Size of the text used in a list item.
    */
@@ -2127,8 +2127,8 @@ export interface UnorderedListProps extends React.ComponentPropsWithoutRef<typeo
   iconColor?: string
 }
 
-export declare const UnorderedList: ForwardRefComponent<UnorderedListProps>
-export declare const Ul: ForwardRefComponent<UnorderedListProps>
+export declare const UnorderedList: BoxComponent<UnorderedListProps, 'ul'>
+export declare const Ul: typeof UnorderedList
 
 export function majorScale(x: number): number
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,13 @@ import { TransitionProps, TransitionStatus } from 'react-transition-group/Transi
 
 export { configureSafeHref } from 'ui-box'
 
+/**
+ * Convenience method for defining your own components that extend Box and pass-through props
+ */
+export type BoxComponent<P, D extends React.ElementType = React.ElementType> = <
+  E extends React.ElementType = D
+>(props: P & BoxProps<E>) => JSX.Element
+
 type PositionTypes = 'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'
 type IntentTypes = 'none' | 'success' | 'warning' | 'danger'
 type DefaultAppearance = 'default'
@@ -491,7 +498,7 @@ export interface AutocompleteProps extends Omit<DownshiftProps<any>, 'children'>
 
 export declare const Autocomplete: ForwardRefComponent<AutocompleteProps>
 
-export interface AvatarProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface AvatarProps {
   src?: string
   size?: number
   /**
@@ -507,11 +514,11 @@ export interface AvatarProps extends React.ComponentPropsWithoutRef<typeof Box> 
   sizeLimitOneCharacter?: number
 }
 
-export declare const Avatar: ForwardRefComponent<AvatarProps>
+export declare const Avatar: BoxComponent<AvatarProps>
 
 export type BackButtonProps = ButtonProps
 
-export declare const BackButton: ForwardRefComponent<BackButtonProps>
+export declare const BackButton: BoxComponent<BackButtonProps, 'button'>
 
 export interface BadgeProps extends StrongProps {
   /**
@@ -527,7 +534,7 @@ export interface BadgeProps extends StrongProps {
 
 export declare const Badge: ForwardRefComponent<BadgeProps>
 
-export interface ButtonProps extends React.ComponentPropsWithoutRef<typeof Text> {
+export interface ButtonProps extends TextProps {
   intent?: IntentTypes
   appearance?: ButtonAppearance
   /**
@@ -559,13 +566,13 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<typeof Text>
   className?: string
 }
 
-export declare const Button: ForwardRefComponent<ButtonProps>
+export declare const Button: BoxComponent<ButtonProps, 'button'>
 
-export type CardProps = React.ComponentProps<typeof Pane>
+export type CardProps = PaneProps
 
-export declare const Card: ForwardRefComponent<CardProps>
+export declare const Card: BoxComponent<CardProps, 'div'>
 
-export interface CheckboxProps extends BoxProps<'input'> {
+export interface CheckboxProps {
   /**
    * The id attribute of the checkbox.
    */
@@ -611,14 +618,14 @@ export interface CheckboxProps extends BoxProps<'input'> {
   onChange?(event: React.ChangeEvent<HTMLInputElement>): void
 }
 
-export declare const Checkbox: ForwardRefComponent<CheckboxProps>
+export declare const Checkbox: BoxComponent<CheckboxProps, 'input'>
 
 export type CodeProps = TextProps
 
 
 export declare const Code: ForwardRefComponent<CodeProps>
 
-export interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface ComboboxProps {
   /**
    * The options to show in the menu.
    */
@@ -670,7 +677,7 @@ export interface ComboboxProps extends React.ComponentPropsWithoutRef<typeof Box
   isLoading?: boolean
 }
 
-export declare const Combobox: React.FC<ComboboxProps>
+export declare const Combobox: BoxComponent<ComboboxProps>
 
 export interface CornerDialogProps {
   /**
@@ -879,7 +886,7 @@ export interface DialogProps {
 
 export declare const Dialog: ForwardRefComponent<DialogProps>
 
-export interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface FormFieldProps {
   /**
    * The label used above the input element.
    */
@@ -915,7 +922,7 @@ export interface FormFieldProps extends React.ComponentPropsWithoutRef<typeof Bo
   inputWidth?: number | string
 }
 
-export declare const FormField: ForwardRefComponent<FormFieldProps>
+export declare const FormField: BoxComponent<FormFieldProps>
 
 export interface FormFieldDescriptionProps extends ParagraphProps {
 }
@@ -944,11 +951,11 @@ export interface FormFieldValidationMessageProps extends PaneProps {
 
 export declare const FormFieldValidationMessage: ForwardRefComponent<FormFieldValidationMessageProps>
 
-export interface HeadingProps extends React.ComponentPropsWithoutRef<typeof Box> {
+export interface HeadingProps {
   size?: keyof Typography['headings']
 }
 
-export declare const Heading: ForwardRefComponent<HeadingProps>
+export declare const Heading: BoxComponent<HeadingProps, 'h2'>
 
 export interface IconButtonProps extends ButtonProps {
   /**
@@ -985,11 +992,11 @@ export interface IconButtonProps extends ButtonProps {
 
 export declare const IconButton: ForwardRefComponent<IconButtonProps>
 
-export interface ImageProps extends BoxProps<'img'> {
+export interface ImageProps {
   src?: string
 }
 
-export declare const Image: ForwardRefComponent<ImageProps>
+export declare const Image: BoxComponent<ImageProps, 'img'>
 
 export interface InlineAlertProps extends PaneProps {
   intent?: IntentTypes
@@ -1009,7 +1016,7 @@ export declare const InlineAlert: ForwardRefComponent<InlineAlertProps>
 
 export type LabelProps = TextProps
 
-export declare const Label: ForwardRefComponent<LabelProps>
+export declare const Label: BoxComponent<LabelProps, 'label'>
 
 export interface LinkProps extends TextProps {
   /**
@@ -1035,7 +1042,7 @@ export interface LinkProps extends TextProps {
   className?: string
 }
 
-export declare const Link: ForwardRefComponent<LinkProps>
+export declare const Link: BoxComponent<LinkProps, 'a'>
 
 export interface ListItemProps extends TextProps {
   /**
@@ -1085,7 +1092,7 @@ export interface MenuOptionsGroupProps<T> {
   options: Array<{ value: T, label: string }>
 }
 
-declare const MenuItem: React.FC<MenuItemProps>
+declare const MenuItem: BoxComponent<MenuItemProps, 'div'>
 declare const MenuDivider: React.FC<{}>
 declare const MenuGroup: React.FC<MenuGroupProps>
 declare const MenuOption: React.FC<MenuOptionProps>
@@ -1099,7 +1106,7 @@ export declare const Menu: React.FC<MenuProps> & {
   OptionsGroup: typeof MenuOptionsGroup
 }
 
-export type PaneProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, 'border' | 'borderTop' | 'borderRight' | 'borderBottom' | 'borderLeft'> & {
+export interface PaneProps {
   background?: keyof Colors['background'] | string
   border?: boolean | string
   borderTop?: boolean | string
@@ -1111,13 +1118,13 @@ export type PaneProps = Omit<React.ComponentPropsWithoutRef<typeof Box>, 'border
   activeElevation?: Elevation
 }
 
-export declare const Pane: ForwardRefComponent<PaneProps>
+export declare const Pane: BoxComponent<PaneProps, 'div'>
 
 export type PillProps = BadgeProps
 
 export declare const Pill: ForwardRefComponent<PillProps>
 
-export type PopoverStatelessProps = React.ComponentPropsWithoutRef<typeof Box>
+export type PopoverStatelessProps = BoxProps<'div'>
 
 export interface PopoverProps {
   position?: PositionTypes
@@ -1143,12 +1150,12 @@ export interface PopoverProps {
 
 export declare const Popover: ForwardRefComponent<PopoverProps>
 
-export type ParagraphProps = React.ComponentPropsWithoutRef<typeof Box> & {
+export type ParagraphProps = {
   size?: keyof Typography['paragraph']
   fontFamily?: FontFamily
 }
 
-export declare const Paragraph: ForwardRefComponent<ParagraphProps>
+export declare const Paragraph: BoxComponent<ParagraphProps, 'p'>
 
 export declare const Portal: React.FC
 
@@ -1185,7 +1192,7 @@ type PreProps = TextProps
 
 export declare const Pre: ForwardRefComponent<PreProps>
 
-export interface RadioProps extends Omit<BoxProps<'input'>, 'onChange'> {
+export interface RadioProps {
   /**
    * The id attribute of the radio.
    */
@@ -1541,11 +1548,9 @@ export type SidebarTabProps = TabProps
 
 export declare const SidebarTab: ForwardRefComponent<SidebarTabProps>
 
-export interface SmallProps extends BoxProps<'small'> {
+export interface SmallProps {}
 
-}
-
-export declare const Small: ForwardRefComponent<SmallProps>
+export declare const Small: BoxComponent<SmallProps, 'small'>
 
 export interface SpinnerProps extends React.ComponentPropsWithoutRef<typeof Box> {
   /**
@@ -1847,15 +1852,15 @@ export interface TabProps extends TextProps {
   appearance?: DefaultAppearance
 }
 
-export declare const Tab: ForwardRefComponent<TabProps>
+export declare const Tab: BoxComponent<TabProps, 'span'>
 
 export type TablistProps = BoxProps<'div'>
 
-export declare const Tablist: ForwardRefComponent<TablistProps>
+export declare const Tablist: BoxComponent<{}>
 
 export type TabNavigationProps = BoxProps<'nav'>
 
-export declare const TabNavigation: ForwardRefComponent<TabNavigationProps>
+export declare const TabNavigation: BoxComponent<{}, 'nav'>
 
 export interface TagInputProps extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange'> {
   addOnBlur?: boolean
@@ -1973,12 +1978,12 @@ export interface TextTableHeaderCellProps extends PaneProps {
 
 export declare const TextTableHeaderCell: React.FC<TextTableHeaderCellProps>
 
-export type TextProps = React.ComponentProps<typeof Box> & {
+export type TextProps = {
   size?: keyof Typography['text']
   fontFamily?: FontFamily | string
 }
 
-export declare const Text: ForwardRefComponent<TextProps>
+export declare const Text: BoxComponent<TextProps, 'span'>
 
 export type TextInputProps = React.ComponentProps<typeof Text> & {
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:interface-name max-classes-per-file no-empty-interface */
 
 import * as React from 'react'
-import Box, { extractStyles as boxExtractStyles, BoxProps } from 'ui-box'
+import { extractStyles as boxExtractStyles, BoxProps } from 'ui-box'
 import { StyleAttribute, CSSProperties } from 'glamor'
 import { DownshiftProps } from 'downshift'
 import { TransitionProps, TransitionStatus } from 'react-transition-group/Transition'
@@ -445,7 +445,7 @@ export interface AlertProps extends Omit<PaneProps, 'title'> {
   appearance?: AlertAppearance
 }
 
-export declare const Alert: ForwardRefComponent<AlertProps>
+export declare const Alert: BoxComponent<AlertProps, 'div'>
 
 interface OptionProps extends TableRowProps {
   height?: number | string
@@ -1578,7 +1578,7 @@ export type StrongProps = BoxProps<'strong'>
 
 export declare const Strong: ForwardRefComponent<StrongProps>
 
-export interface SwitchProps extends Omit<BoxProps<'label'>, 'onChange'> {
+export interface SwitchProps {
   /**
    * The id attribute of the radio.
    */
@@ -1627,12 +1627,12 @@ export interface SwitchProps extends Omit<BoxProps<'label'>, 'onChange'> {
   defaultChecked?: boolean
 }
 
-export declare const Switch: ForwardRefComponent<SwitchProps>
+export declare const Switch: BoxComponent<SwitchProps, 'label'>
 
 export interface TableBodyProps extends PaneProps {
 }
 
-export declare const TableBody: React.FC<TableBodyProps>
+export declare const TableBody: BoxComponent<TableBodyProps, 'div'>
 
 export interface TableCellProps extends PaneProps {
   /**
@@ -1665,7 +1665,7 @@ export interface TableCellProps extends PaneProps {
   className?: string
 }
 
-export declare const TableCell: ForwardRefComponent<TableCellProps>
+export declare const TableCell: BoxComponent<TableCellProps, 'div'>
 
 interface TableEditableCellProps extends Omit<TextTableCellProps, 'placeholder' | 'onChange'> {
   autoFocus?: boolean
@@ -1821,7 +1821,7 @@ interface TableVirtualBodyProps extends PaneProps {
 export interface TableProps extends PaneProps {
 }
 
-export declare const Table: React.FC<TableProps> & {
+export declare const Table: BoxComponent<TableProps, 'div'> & {
   Body: typeof TableBody
   VirtualBody: React.FC<TableVirtualBodyProps>
   Head: typeof TableHead
@@ -1896,7 +1896,7 @@ export interface TextareaProps extends TextProps {
   className?: string
 }
 
-export declare const Textarea: ForwardRefComponent<TextareaProps>
+export declare const Textarea: BoxComponent<TextareaProps, 'textarea'>
 
 export interface TextareaFieldProps extends TextareaProps {
   /**
@@ -1970,7 +1970,7 @@ export interface TextTableCellProps extends TableCellProps {
   textProps?: TextProps
 }
 
-export declare const TextTableCell: ForwardRefComponent<TextTableCellProps>
+export declare const TextTableCell: BoxComponent<TextTableCellProps, 'div'>
 
 export interface TextTableHeaderCellProps extends PaneProps {
   textProps?: TextProps

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-tiny-virtual-list": "^2.1.4",
     "react-transition-group": "^4.4.1",
     "tinycolor2": "^1.4.1",
-    "ui-box": "^4.0.0-0"
+    "ui-box": "^4.0.0-1"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -1,11 +1,10 @@
-import React, { memo, forwardRef, useState, useCallback } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { spacing, position, layout, dimensions } from 'ui-box'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
+import { useId } from '../../hooks'
 import Radio from './Radio'
-
-let radioCount = 1 // Used for generating unique input names
 
 const RadioGroup = memo(
   forwardRef((props, ref) => {
@@ -20,15 +19,7 @@ const RadioGroup = memo(
       ...rest
     } = props
 
-    const [name] = useState(`RadioGroup-${radioCount++}`)
-
-    const handleChange = useCallback(
-      e => {
-        onChange(e.target.value)
-      },
-      [onChange]
-    )
-
+    const name = useId(RadioGroup)
     const selected = value || defaultValue || props.options[0].value
 
     return (
@@ -47,7 +38,7 @@ const RadioGroup = memo(
             label={item.label}
             checked={selected === item.value}
             disabled={item.isDisabled}
-            onChange={handleChange}
+            onChange={onChange}
             isRequired={isRequired}
           />
         ))}

--- a/src/segmented-control/src/SegmentedControl.js
+++ b/src/segmented-control/src/SegmentedControl.js
@@ -2,9 +2,8 @@ import React, { memo, forwardRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout, dimensions } from 'ui-box'
 import safeInvoke from '../../lib/safe-invoke'
+import { useId } from '../../hooks'
 import SegmentedControlRadio from './SegmentedControlRadio'
-
-let radioCount = 1 // Used for generating unique input names
 
 const SegmentedControl = memo(
   forwardRef((props, ref) => {
@@ -19,7 +18,7 @@ const SegmentedControl = memo(
       ...rest
     } = props
 
-    const [groupName] = useState(`SegmentedControl-${radioCount++}`)
+    const groupName = useId('SegmentedControl')
 
     const isControlled = () => {
       return typeof value !== 'undefined' && value !== null

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef } from 'react'
+import React, { memo } from 'react'
 import PropTypes from 'prop-types'
 import arrify from 'arrify'
 import { Popover } from '../../popover'
@@ -36,65 +36,62 @@ const getEmptyView = (close, emptyView) => {
   return {}
 }
 
-const SelectMenu = memo(
-  forwardRef((props, ref) => {
-    const {
-      title,
-      width = 240,
-      height = 248,
-      options,
-      onSelect = () => {},
-      onDeselect = () => {},
-      onFilterChange,
-      selected,
-      position = Position.BOTTOM_LEFT,
-      hasTitle,
-      hasFilter,
-      filterPlaceholder = 'Filter...',
-      filterIcon = <SearchIcon />,
-      detailView,
-      emptyView,
-      titleView,
-      isMultiSelect = false,
-      closeOnSelect = false,
-      ...rest
-    } = props
+const SelectMenu = memo(props => {
+  const {
+    title,
+    width = 240,
+    height = 248,
+    options,
+    onSelect = () => {},
+    onDeselect = () => {},
+    onFilterChange,
+    selected,
+    position = Position.BOTTOM_LEFT,
+    hasTitle,
+    hasFilter,
+    filterPlaceholder = 'Filter...',
+    filterIcon = <SearchIcon />,
+    detailView,
+    emptyView,
+    titleView,
+    isMultiSelect = false,
+    closeOnSelect = false,
+    ...rest
+  } = props
 
-    return (
-      <Popover
-        minWidth={width}
-        position={position}
-        minHeight={height}
-        content={({ close }) => (
-          <SelectMenuContent
-            width={width}
-            height={height}
-            options={options}
-            title={title}
-            hasFilter={hasFilter}
-            filterPlaceholder={filterPlaceholder}
-            filterIcon={filterIcon}
-            hasTitle={hasTitle}
-            isMultiSelect={isMultiSelect}
-            titleView={titleView}
-            listProps={{
-              onSelect,
-              onDeselect,
-              onFilterChange,
-              selected: arrify(selected)
-            }}
-            close={close}
-            {...getDetailView(close, detailView)}
-            {...getEmptyView(close, emptyView)}
-            closeOnSelect={closeOnSelect}
-          />
-        )}
-        {...rest}
-        ref={ref}
-      />
-    )
-  })
-)
+  return (
+    <Popover
+      minWidth={width}
+      position={position}
+      minHeight={height}
+      content={({ close }) => (
+        <SelectMenuContent
+          width={width}
+          height={height}
+          options={options}
+          title={title}
+          hasFilter={hasFilter}
+          filterPlaceholder={filterPlaceholder}
+          filterIcon={filterIcon}
+          hasTitle={hasTitle}
+          isMultiSelect={isMultiSelect}
+          titleView={titleView}
+          listProps={{
+            onSelect,
+            onDeselect,
+            onFilterChange,
+            selected: arrify(selected)
+          }}
+          close={close}
+          {...getDetailView(close, detailView)}
+          {...getEmptyView(close, emptyView)}
+          closeOnSelect={closeOnSelect}
+        />
+      )}
+      {...rest}
+    />
+  )
+})
 
 SelectMenu.propTypes = {
   /**

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef } from 'react'
+import React, { memo } from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
@@ -125,64 +125,61 @@ const animationStylesClass = {
   }
 }
 
-const SideSheet = memo(
-  forwardRef((props, ref) => {
-    const {
-      width = 620,
-      isShown,
-      children,
-      containerProps,
-      onOpenComplete = () => {},
-      onCloseComplete = () => {},
-      onBeforeClose,
-      shouldCloseOnOverlayClick = true,
-      shouldCloseOnEscapePress = true,
-      position = Position.RIGHT,
-      preventBodyScrolling
-    } = props
+const SideSheet = memo(props => {
+  const {
+    width = 620,
+    isShown,
+    children,
+    containerProps,
+    onOpenComplete = () => {},
+    onCloseComplete = () => {},
+    onBeforeClose,
+    shouldCloseOnOverlayClick = true,
+    shouldCloseOnEscapePress = true,
+    position = Position.RIGHT,
+    preventBodyScrolling
+  } = props
 
-    return (
-      <Overlay
-        ref={ref}
-        isShown={isShown}
-        shouldCloseOnClick={shouldCloseOnOverlayClick}
-        shouldCloseOnEscapePress={shouldCloseOnEscapePress}
-        onBeforeClose={onBeforeClose}
-        onExited={onCloseComplete}
-        onEntered={onOpenComplete}
-        preventBodyScrolling={preventBodyScrolling}
-      >
-        {({ state, close }) => (
-          <Pane
-            width={width}
-            {...paneProps[position]}
-            css={animationStylesClass[position]}
+  return (
+    <Overlay
+      isShown={isShown}
+      shouldCloseOnClick={shouldCloseOnOverlayClick}
+      shouldCloseOnEscapePress={shouldCloseOnEscapePress}
+      onBeforeClose={onBeforeClose}
+      onExited={onCloseComplete}
+      onEntered={onOpenComplete}
+      preventBodyScrolling={preventBodyScrolling}
+    >
+      {({ state, close }) => (
+        <Pane
+          width={width}
+          {...paneProps[position]}
+          css={animationStylesClass[position]}
+          data-state={state}
+        >
+          <SheetClose
+            position={position}
             data-state={state}
+            isClosing={false}
+            onClick={close}
+          />
+          <Pane
+            elevation={4}
+            backgroundColor="white"
+            overflowY="auto"
+            maxHeight="100vh"
+            data-state={state}
+            width={width}
+            {...subpaneProps[position]}
+            {...containerProps}
           >
-            <SheetClose
-              position={position}
-              data-state={state}
-              isClosing={false}
-              onClick={close}
-            />
-            <Pane
-              elevation={4}
-              backgroundColor="white"
-              overflowY="auto"
-              maxHeight="100vh"
-              data-state={state}
-              width={width}
-              {...subpaneProps[position]}
-              {...containerProps}
-            >
-              {typeof children === 'function' ? children({ close }) : children}
-            </Pane>
+            {typeof children === 'function' ? children({ close }) : children}
           </Pane>
-        )}
-      </Overlay>
-    )
-  })
-)
+        </Pane>
+      )}
+    </Overlay>
+  )
+})
 
 SideSheet.propTypes = {
   /**

--- a/src/typography/src/OrderedList.js
+++ b/src/typography/src/OrderedList.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Box from 'ui-box'
 
 const styles = {
-  is: 'ol',
   margin: 0,
   marginLeft: '1.1em',
   padding: 0,
@@ -26,7 +25,7 @@ const OrderedList = memo(
     })
 
     return (
-      <Box {...styles} {...rest} ref={ref}>
+      <Box is="ol" {...styles} {...rest} ref={ref}>
         {finalChildren}
       </Box>
     )

--- a/src/typography/src/UnorderedList.js
+++ b/src/typography/src/UnorderedList.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Box from 'ui-box'
 
 const styles = {
-  is: 'ul',
   margin: 0,
   marginLeft: '1.1em',
   padding: 0,
@@ -28,7 +27,7 @@ const UnorderedList = memo(
     })
 
     return (
-      <Box {...styles} {...rest} ref={ref}>
+      <Box is="ul" {...styles} {...rest} ref={ref}>
         {enrichedChildren}
       </Box>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -12699,10 +12699,10 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
-ui-box@^4.0.0-0:
-  version "4.0.0-0"
-  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-4.0.0-0.tgz#885c04b71a6f4ab1ccbc5d2204b2b6185380c697"
-  integrity sha512-uW4tPdYILslhhlSbXuamuHKJgLCD8PJJCrcVFs/RIdQPuPXl6i1GIWsd1VhSz/7x/znDIeto9esSDTPmZT7ZqA==
+ui-box@^4.0.0-1:
+  version "4.0.0-1"
+  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-4.0.0-1.tgz#e310a67bbe9015a8b2ecfc3c5c0a9444da256203"
+  integrity sha512-u+W/Rh7BFkvjhGHt6TIh0ZVZrrRaVFz1i/Cka/fLAmQ+UjdDw+xrXSbJ12B0cdYx4RcGU2CE2DtEWMtv9aCK4w==
   dependencies:
     "@emotion/hash" "^0.7.1"
     inline-style-prefixer "^5.0.4"


### PR DESCRIPTION
## Overview 

This improves our typings to support polymorphic box pass-through props. For instance, this now works:

```
<Link is={ReactRouterLink} to="/home" />
```

Both the forwarded `ref` and all ReactRouterLink props will be type-safe.
 
## Screenshots (if applicable)
NA 

## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
