### PR TITLE
rm misc .isRequired prop types no longer needed

### DIFF
--- a/src/avatar/src/Avatar.js
+++ b/src/avatar/src/Avatar.js
@@ -139,7 +139,7 @@ Avatar.propTypes = {
    * The color used for the avatar.
    * When the value is `automatic`, use the hash function to determine the color.
    */
-  color: PropTypes.string.isRequired,
+  color: PropTypes.string,
 
   /**
    * Function to get the initials based on the name.

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -96,7 +96,7 @@ Spinner.propTypes = {
   /**
    * The size of the spinner.
    */
-  size: PropTypes.number.isRequired
+  size: PropTypes.number
 }
 
 export default Spinner


### PR DESCRIPTION
<!-- 
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
 -->
 
## Overview 
Remove isRequired proptypes where there is a default value set within the component 

## Screenshots (if applicable) 
N/A

## Testing
- [x] Component renders as expected, without throwing error of expecting required prop that is no longer required
