### PR TITLE
Fix body click handler for popover

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -170,7 +170,7 @@ const Popover = memo(forwardRef
         document.body.removeEventListener('click', handleBodyClick, false)
         document.body.removeEventListener('keydown', onEsc, false)
       }
-    }, [isShown])
+    }, [isShown, handleBodyClick, onEsc])
 
     const renderTarget = ({ getRef, isShown }) => {
       const isTooltipInside = children && children.type === Tooltip


### PR DESCRIPTION
<!-- 
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
 -->
 
## Overview 
Fix the body click handler to function correctly. Ref was getting cached and not functioning correctly 

## Screenshots (if applicable) 
N/A

## Testing
- [x] Popover opens and you can click inside the popover without it closing
- [x] Clicking outside the popover closes the popover
