### PR TITLE
V5 react transition group

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { extractStyles as boxExtractStyles, BoxProps, BoxOwnProps, BoxComponent, PolymorphicBoxProps } from 'ui-box'
 import { StyleAttribute, CSSProperties } from 'glamor'
 import { DownshiftProps } from 'downshift'
-import { TransitionProps, TransitionStatus } from 'react-transition-group/Transition'
 
 export { configureSafeHref, BoxProps, BoxComponent } from 'ui-box'
 
@@ -489,7 +488,7 @@ export interface AutocompleteProps extends Omit<DownshiftProps<any>, 'children'>
   onChange: (selectedItem: any) => void
 }
 
-export declare const Autocomplete: ForwardRefComponent<AutocompleteProps>
+export declare const Autocomplete: React.FC<AutocompleteProps>
 
 export interface AvatarProps {
   src?: string
@@ -1175,7 +1174,7 @@ export type ParagraphProps = {
 
 export declare const Paragraph: BoxComponent<ParagraphProps, 'p'>
 
-export declare const Portal: React.FC
+export class Portal extends React.Component<{}> {}
 
 export interface PositionerProps {
   position?: PositionTypes
@@ -2257,8 +2256,16 @@ export const toaster: {
   getToasts: () => Toast[]
 }
 
+export enum TransitionState {
+  unmounted = 'unmounted',
+  entering = 'entering',
+  entered = 'entered',
+  exiting = 'exiting',
+  exited = 'exited'
+}
+
 interface OverlayProps {
-  children: React.ReactNode | ((props: { state: TransitionStatus, close: () => void }) => JSX.Element);
+  children: React.ReactNode | ((props: { state: TransitionState, close: () => void }) => JSX.Element);
 
   isShown?: boolean;
   containerProps?: BoxProps<'div'>;
@@ -2266,12 +2273,12 @@ interface OverlayProps {
   shouldCloseOnClick?: boolean;
   shouldCloseOnEscapePress?: boolean;
   onBeforeClose?: () => void;
-  onExit?: TransitionProps['onExit'];
-  onExiting?: TransitionProps['onExiting'];
-  onExited?: TransitionProps['onExited'];
-  onEnter?: TransitionProps['onEnter'];
-  onEntering?: TransitionProps['onEntering'];
-  onEntered?: TransitionProps['onEntered'];
+  onExit?: () => void
+  onExiting?: () => void
+  onExited?: () => void
+  onEnter?: () => void
+  onEntering?: () => void
+  onEntered?: () => void
 }
 
 export declare const Overlay: React.FC<OverlayProps>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "@types/react": "^16.9.5",
-    "@types/react-transition-group": "^4.4.0",
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.2.1",
@@ -63,7 +62,6 @@
     "prop-types": "^15.6.2",
     "react-scrollbar-size": "^2.0.2",
     "react-tiny-virtual-list": "^2.1.4",
-    "react-transition-group": "^4.4.1",
     "tinycolor2": "^1.4.1",
     "ui-box": "^4.0.0-3"
   },

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -1,10 +1,4 @@
-import React, {
-  memo,
-  forwardRef,
-  useState,
-  useEffect,
-  useCallback
-} from 'react'
+import React, { memo, useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import fuzzaldrin from 'fuzzaldrin-plus'
 import Downshift from 'downshift'
@@ -102,120 +96,113 @@ const AutocompleteItems = ({
 }
 /* eslint-enable react/prop-types */
 
-const Autocomplete = memo(
-  forwardRef((props, ref) => {
-    const {
-      children,
-      itemSize = 32,
-      position,
-      renderItem = autocompleteItemRenderer,
-      isFilterDisabled = false,
-      itemsFilter,
-      itemToString = i => (i ? String(i) : ''),
-      popoverMaxHeight = 240,
-      popoverMinWidth = 240,
-      ...restProps
-    } = props
+const Autocomplete = memo(props => {
+  const {
+    children,
+    itemSize = 32,
+    position,
+    renderItem = autocompleteItemRenderer,
+    isFilterDisabled = false,
+    itemsFilter,
+    itemToString = i => (i ? String(i) : ''),
+    popoverMaxHeight = 240,
+    popoverMinWidth = 240,
+    ...restProps
+  } = props
 
-    const [targetWidth, setTargetWidth] = useState(0)
-    const [targetRef, setTargetRef] = useState()
+  const [targetWidth, setTargetWidth] = useState(0)
+  const [targetRef, setTargetRef] = useState()
 
-    useEffect(() => {
-      if (targetRef) {
-        setTargetWidth(targetRef.getBoundingClientRect().width)
-      }
-    }, [targetRef])
+  useEffect(() => {
+    if (targetRef) {
+      setTargetWidth(targetRef.getBoundingClientRect().width)
+    }
+  }, [targetRef])
 
-    const stateReducer = useCallback(
-      (state, changes) => {
-        const { items } = props
+  const stateReducer = useCallback(
+    (state, changes) => {
+      const { items } = props
 
-        if (
-          Object.prototype.hasOwnProperty.call(changes, 'isOpen') &&
-          changes.isOpen
-        ) {
-          return {
-            ...changes,
-            highlightedIndex: items.indexOf(state.selectedItem)
-          }
+      if (
+        Object.prototype.hasOwnProperty.call(changes, 'isOpen') &&
+        changes.isOpen
+      ) {
+        return {
+          ...changes,
+          highlightedIndex: items.indexOf(state.selectedItem)
         }
+      }
 
-        return changes
-      },
-      [props.items]
-    )
+      return changes
+    },
+    [props.items]
+  )
 
-    return (
-      <Downshift
-        stateReducer={stateReducer}
-        scrollIntoView={noop}
-        ref={ref}
-        {...restProps}
-      >
-        {({
-          isOpen: isShown,
-          inputValue,
-          getItemProps,
-          getMenuProps,
-          selectedItem,
-          highlightedIndex,
-          getRootProps,
-          ...restDownshiftProps
-        }) => (
-          <div style={{ width: '100%' }}>
-            <Popover
-              bringFocusInside={false}
-              isShown={isShown}
-              minWidth={popoverMinWidth}
-              position={
-                position ||
-                (targetWidth < popoverMinWidth
-                  ? Position.BOTTOM_LEFT
-                  : Position.BOTTOM)
-              }
-              content={() => (
-                <AutocompleteItems
-                  getItemProps={getItemProps}
-                  getMenuProps={getMenuProps}
-                  highlightedIndex={highlightedIndex}
-                  inputValue={inputValue}
-                  isFilterDisabled={isFilterDisabled}
-                  itemsFilter={itemsFilter}
-                  itemSize={itemSize}
-                  itemToString={itemToString}
-                  originalItems={props.items}
-                  popoverMaxHeight={popoverMaxHeight}
-                  renderItem={renderItem}
-                  selectedItem={selectedItem}
-                  title={props.title}
-                  width={Math.max(targetWidth, popoverMinWidth)}
-                />
-              )}
-              minHeight={0}
-              animationDuration={0}
-            >
-              {({ isShown: isShownPopover, toggle, getRef }) =>
-                children({
-                  isShown: isShownPopover,
-                  toggle,
-                  getRef: ref => {
-                    // Use the ref internally to determine the width
-                    setTargetRef(ref)
-                    getRef(ref)
-                  },
-                  inputValue,
-                  selectedItem,
-                  highlightedIndex,
-                  ...restDownshiftProps
-                })
-              }
-            </Popover>
-          </div>
-        )}
-      </Downshift>
-    )
-  })
-)
+  return (
+    <Downshift stateReducer={stateReducer} scrollIntoView={noop} {...restProps}>
+      {({
+        isOpen: isShown,
+        inputValue,
+        getItemProps,
+        getMenuProps,
+        selectedItem,
+        highlightedIndex,
+        getRootProps,
+        ...restDownshiftProps
+      }) => (
+        <div style={{ width: '100%' }}>
+          <Popover
+            bringFocusInside={false}
+            isShown={isShown}
+            minWidth={popoverMinWidth}
+            position={
+              position ||
+              (targetWidth < popoverMinWidth
+                ? Position.BOTTOM_LEFT
+                : Position.BOTTOM)
+            }
+            content={() => (
+              <AutocompleteItems
+                getItemProps={getItemProps}
+                getMenuProps={getMenuProps}
+                highlightedIndex={highlightedIndex}
+                inputValue={inputValue}
+                isFilterDisabled={isFilterDisabled}
+                itemsFilter={itemsFilter}
+                itemSize={itemSize}
+                itemToString={itemToString}
+                originalItems={props.items}
+                popoverMaxHeight={popoverMaxHeight}
+                renderItem={renderItem}
+                selectedItem={selectedItem}
+                title={props.title}
+                width={Math.max(targetWidth, popoverMinWidth)}
+              />
+            )}
+            minHeight={0}
+            animationDuration={0}
+          >
+            {({ isShown: isShownPopover, toggle, getRef }) =>
+              children({
+                isShown: isShownPopover,
+                toggle,
+                getRef: ref => {
+                  // Use the ref internally to determine the width
+                  setTargetRef(ref)
+                  getRef(ref)
+                },
+                inputValue,
+                selectedItem,
+                highlightedIndex,
+                ...restDownshiftProps
+              })
+            }
+          </Popover>
+        </div>
+      )}
+    </Downshift>
+  )
+})
 
 Autocomplete.propTypes = {
   /**

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
 export * from './use-force-update'
 export * from './use-id'
 export * from './use-merged-ref'
+export * from './use-transition'

--- a/src/hooks/use-transition.js
+++ b/src/hooks/use-transition.js
@@ -17,6 +17,7 @@ export const TRANSITION_STATES = {
  */
 export function useTransition(isActive, timeout, options = {}) {
   const unmountOnExit = Boolean(options.unmountOnExit)
+  const appear = Boolean(options.appear)
   const onEnter = useRef(options.onEnter || null)
   const onExit = useRef(options.onExit || null)
 
@@ -27,8 +28,7 @@ export function useTransition(isActive, timeout, options = {}) {
 
   const [state, setState] = useState(() => {
     if (isActive) {
-      // Simulates Transition's `appear={true}` prop
-      return TRANSITION_STATES.exited
+      return appear ? TRANSITION_STATES.exited : TRANSITION_STATES.entered
     }
 
     return unmountOnExit

--- a/src/hooks/use-transition.js
+++ b/src/hooks/use-transition.js
@@ -1,0 +1,91 @@
+import { useState, useEffect, useRef } from 'react'
+import safeInvoke from '../lib/safe-invoke'
+
+export const TRANSITION_STATES = {
+  unmounted: 'unmounted',
+  entering: 'entering',
+  entered: 'entered',
+  exiting: 'exiting',
+  exited: 'exited'
+}
+
+/**
+ * React hook that replaces react-transition-group functionality
+ * @param {boolean} isActive
+ * @param {number} timeout
+ * @param {object} [options]
+ */
+export function useTransition(isActive, timeout, options = {}) {
+  const unmountOnExit = Boolean(options.unmountOnExit)
+  const onEnter = useRef(options.onEnter || null)
+  const onExit = useRef(options.onExit || null)
+
+  useEffect(() => {
+    onEnter.current = options.onEnter
+    onExit.current = options.onExit
+  }, [options.onEnter, options.onExit])
+
+  const [state, setState] = useState(() => {
+    if (isActive) {
+      // Simulates Transition's `appear={true}` prop
+      return TRANSITION_STATES.exited
+    }
+
+    return unmountOnExit
+      ? TRANSITION_STATES.unmounted
+      : TRANSITION_STATES.exited
+  })
+
+  useEffect(() => {
+    if (isActive) {
+      switch (state) {
+        case TRANSITION_STATES.unmounted:
+          setState(TRANSITION_STATES.exited)
+          break
+        case TRANSITION_STATES.exited:
+        case TRANSITION_STATES.exiting:
+          safeInvoke(onEnter.current)
+          setState(TRANSITION_STATES.entering)
+          break
+        case TRANSITION_STATES.entering: {
+          const timer = setTimeout(() => {
+            setState(TRANSITION_STATES.entered)
+          }, timeout)
+
+          return () => clearTimeout(timer)
+        }
+
+        default:
+          break
+      }
+    } else {
+      switch (state) {
+        case TRANSITION_STATES.entered:
+        case TRANSITION_STATES.entering:
+          safeInvoke(onExit.current)
+          setState(TRANSITION_STATES.exiting)
+          break
+        case TRANSITION_STATES.exiting: {
+          const timer = setTimeout(() => {
+            setState(TRANSITION_STATES.exited)
+          }, timeout)
+
+          return () => clearTimeout(timer)
+        }
+
+        case TRANSITION_STATES.exited: {
+          if (unmountOnExit) {
+            setState(TRANSITION_STATES.unmounted)
+          }
+
+          break
+        }
+
+        default:
+          break
+      }
+    }
+  }, [isActive, state, timeout, unmountOnExit])
+
+  return state
+}

--- a/src/lib/tababble.js
+++ b/src/lib/tababble.js
@@ -1,0 +1,32 @@
+/**
+ * Sets of tababble selectors in order of priority
+ * querySelectorAll reflects DOM order, not selector order
+ * so we have to maintain order ourselves
+ */
+const tababbles = [
+  ['[autofocus]'],
+  ['[tabindex]:not([tabindex="-1"])'],
+  [
+    'button:enabled:not([readonly])',
+    'select:enabled:not([readonly])',
+    'input:enabled:not([readonly])',
+    'textarea:enabled:not([readonly])',
+    'a[href]',
+    '[role="menuitem"]',
+    '[role="menuitemradio"]',
+    'area[href]',
+    '[contenteditable]'
+  ]
+]
+
+/**
+ * Gets the first keyboard-focusable element within a specified element
+ * @param {HTMLElement} element element
+ * @returns {HTMLElement|null}
+ */
+export function findTababble(node) {
+  const elements = tababbles
+    .map(tababble => node.querySelector(tababble.join(' ')))
+    .filter(el => el && !el.hasAttribute('disabled'))
+  return elements[0] || null
+}

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -1,271 +1,300 @@
-import React, { memo, forwardRef, useState, useEffect, useImperativeHandle } from 'react'
+import React, {
+  memo,
+  forwardRef,
+  useRef,
+  useState,
+  useEffect,
+  useImperativeHandle
+} from 'react'
 import cx from 'classnames'
 import { css as glamorCss } from 'glamor'
 import PropTypes from 'prop-types'
 import { Positioner } from '../../positioner'
 import { Tooltip } from '../../tooltip'
 import { Position } from '../../constants'
+import { findTababble } from '../../lib/tababble'
+import { useMergedRef } from '../../hooks'
 import PopoverStateless from './PopoverStateless'
 
-const Popover = memo(forwardRef
-  (({
-    animationDuration = 300,
-    bringFocusInside: shouldBringFocusInside = false,
-    children,
-    content,
-    display,
-    minHeight = 40,
-    minWidth = 200,
-    onBodyClick = () => {},
-    onClose = () => {},
-    onCloseComplete = () => {},
-    onOpen = () => {},
-    onOpenComplete = () => {},
-    position = Position.BOTTOM,
-    shouldCloseOnExternalClick = true,
-    statelessProps = {},
-    trigger = 'click',
-    ...props
-  }, forwardedRef) => {
-    const [isShown, setIsShown] = useState(props.isShown)
-    const [popoverNode, setPopoverNode] = useState(null)
-    const [targetRef, setTargetRef] = useState(null)
+const Popover = memo(
+  forwardRef(
+    (
+      {
+        animationDuration = 300,
+        bringFocusInside: shouldBringFocusInside = false,
+        children,
+        content,
+        display,
+        minHeight = 40,
+        minWidth = 200,
+        onBodyClick = () => {},
+        onClose = () => {},
+        onCloseComplete = () => {},
+        onOpen = () => {},
+        onOpenComplete = () => {},
+        position = Position.BOTTOM,
+        shouldCloseOnExternalClick = true,
+        statelessProps = {},
+        trigger = 'click',
+        ...props
+      },
+      forwardedRef
+    ) => {
+      const [isShown, setIsShown] = useState(props.isShown)
 
-    useImperativeHandle(forwardedRef, () => ({
-      open,
-      close
-    }), [popoverNode])
+      const focusInRAF = useRef(null)
+      const focusBackRAF = useRef(null)
+      useEffect(
+        () => () => {
+          if (focusInRAF.current) {
+            cancelAnimationFrame(focusInRAF.current)
+          }
 
-    /**
-     * Methods borrowed from BlueprintJS
-     * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
-     */
-    const bringFocusInside = () => {
-      // Always delay focus manipulation to just before repaint to prevent scroll jumping
-      return requestAnimationFrame(() => {
-        // Container ref may be undefined between component mounting and Portal rendering
-        // activeElement may be undefined in some rare cases in IE
-        if (
-          popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
-          document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
-          !isShown
-        ) {
-          return
-        }
+          if (focusBackRAF.current) {
+            cancelAnimationFrame(focusBackRAF.current)
+          }
+        },
+        []
+      )
 
-        const isFocusOutsideModal = !popoverNode.contains(
-          document.activeElement
-        )
-        if (isFocusOutsideModal) {
-          // Element marked autofocus has higher priority than the other clowns
-          const autofocusElement = popoverNode.querySelector('[autofocus]')
-          const wrapperElement = popoverNode.querySelector('[tabindex]')
-          const buttonElements = popoverNode.querySelectorAll(
-            'button, a, [role="menuitem"], [role="menuitemradio"]'
+      const popoverNode = useRef()
+      const setPopoverNode = useMergedRef(popoverNode)
+
+      const targetRef = useRef()
+      const setTargetRef = useMergedRef(targetRef)
+
+      useImperativeHandle(
+        forwardedRef,
+        () => ({
+          open,
+          close
+        }),
+        [popoverNode]
+      )
+
+      /**
+       * Methods borrowed from BlueprintJS
+       * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
+       */
+      const bringFocusInside = () => {
+        // Always delay focus manipulation to just before repaint to prevent scroll jumping
+        focusInRAF.current = requestAnimationFrame(() => {
+          // Container ref may be undefined between component mounting and Portal rendering
+          // activeElement may be undefined in some rare cases in IE
+          if (
+            popoverNode.current == null || // eslint-disable-line eqeqeq, no-eq-null
+            document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
+            !isShown
+          ) {
+            return
+          }
+
+          const isFocusOutsideModal = !popoverNode.current.contains(
+            document.activeElement
+          )
+          if (isFocusOutsideModal) {
+            const element = findTababble(popoverNode.current)
+            if (element) {
+              element.focus()
+            }
+          }
+        })
+      }
+
+      const bringFocusBackToTarget = () => {
+        focusBackRAF.current = requestAnimationFrame(() => {
+          if (
+            targetRef.current == null || // eslint-disable-line eqeqeq, no-eq-null
+            popoverNode.current == null || // eslint-disable-line eqeqeq, no-eq-null
+            document.activeElement == null // eslint-disable-line eqeqeq, no-eq-null
+          ) {
+            return
+          }
+
+          const isFocusInsideModal = popoverNode.current.contains(
+            document.activeElement
           )
 
-          if (autofocusElement) {
-            autofocusElement.focus()
-          } else if (wrapperElement) {
-            wrapperElement.focus()
-          } else if (buttonElements.length > 0) {
-            buttonElements[0].focus()
+          // Bring back focus on the target.
+          if (document.activeElement === document.body || isFocusInsideModal) {
+            targetRef.current.focus()
           }
-        }
-      })
-    }
+        })
+      }
 
-    const bringFocusBackToTarget = () => {
-      return requestAnimationFrame(() => {
-        if (
-          targetRef == null || // eslint-disable-line eqeqeq, no-eq-null
-          popoverNode == null || // eslint-disable-line eqeqeq, no-eq-null
-          document.activeElement == null // eslint-disable-line eqeqeq, no-eq-null
-        ) {
+      const open = () => {
+        if (isShown) {
           return
         }
 
-        const isFocusInsideModal = popoverNode.contains(document.activeElement)
+        setIsShown(true)
+        onOpen()
+      }
 
-        // Bring back focus on the target.
-        if (document.activeElement === document.body || isFocusInsideModal) {
-          targetRef.focus()
+      const close = () => {
+        if (!isShown) {
+          return
         }
-      })
-    }
 
-    const open = () => {
-      if (isShown) {
-        return
+        setIsShown(false)
+        bringFocusBackToTarget()
+        onClose()
       }
 
-      setIsShown(true)
-      onOpen()
-    }
+      // If `props.isShown` is a boolean, treat as a controlled component
+      // `open` and `close` should be applied when it changes
+      useEffect(() => {
+        if (typeof props.isShown !== 'boolean' || props.isShown === isShown) {
+          return
+        }
 
-    const close = () => {
-      if (!isShown) {
-        return
+        if (props.isShown) {
+          open()
+        } else {
+          close()
+        }
+      }, [props.isShown])
+
+      const toggle = () => (isShown ? close() : open())
+      const handleOpenHover = trigger === 'hover' ? open : undefined
+      const handleCloseHover = trigger === 'hover' ? close : undefined
+      const handleKeyDown = event =>
+        event.key === 'ArrowDown' ? bringFocusInside() : undefined
+      const onEsc = event => (event.key === 'Escape' ? close() : undefined)
+
+      const handleBodyClick = event => {
+        // Ignore clicks on the popover or button
+        if (targetRef.current && targetRef.current.contains(event.target)) {
+          return
+        }
+
+        if (popoverNode.current && popoverNode.current.contains(event.target)) {
+          return
+        }
+
+        // Notify body click
+        onBodyClick(event)
+
+        if (shouldCloseOnExternalClick !== false) {
+          close()
+        }
       }
 
-      setIsShown(false)
-      bringFocusBackToTarget()
-      onClose()
-    }
-
-    // If `props.isShown` is a boolean, treat as a controlled component
-    // `open` and `close` should be applied when it changes
-    useEffect(() => {
-      if (typeof props.isShown !== 'boolean' || props.isShown === isShown) {
-        return
+      const handleOpenComplete = () => {
+        if (shouldBringFocusInside) bringFocusInside()
+        onOpenComplete()
       }
 
-      if (props.isShown) {
-        open()
-      } else {
-        close()
-      }
-    }, [props.isShown])
+      useEffect(() => {
+        if (isShown) {
+          document.body.addEventListener('click', handleBodyClick, false)
+          document.body.addEventListener('keydown', onEsc, false)
+        } else {
+          document.body.removeEventListener('click', handleBodyClick, false)
+          document.body.removeEventListener('keydown', onEsc, false)
+        }
 
-    const toggle = () => (isShown ? close() : open())
-    const handleOpenHover = trigger === 'hover' ? open : undefined
-    const handleCloseHover = trigger === 'hover' ? close : undefined
-    const handleKeyDown = event =>
-      event.key === 'ArrowDown' ? bringFocusInside() : undefined
-    const onEsc = event => (event.key === 'Escape' ? close() : undefined)
+        return () => {
+          document.body.removeEventListener('click', handleBodyClick, false)
+          document.body.removeEventListener('keydown', onEsc, false)
+        }
+      }, [isShown, handleBodyClick, onEsc])
 
-    const handleBodyClick = event => {
-      // Ignore clicks on the popover or button
-      if (targetRef && targetRef.contains(event.target)) {
-        return
-      }
+      const renderTarget = ({ getRef, isShown }) => {
+        const isTooltipInside = children && children.type === Tooltip
 
-      if (popoverNode && popoverNode.contains(event.target)) {
-        return
-      }
+        const getTargetRef = ref => {
+          setTargetRef(ref)
+          getRef(ref)
+        }
 
-      // Notify body click
-      onBodyClick(event)
-
-      if (shouldCloseOnExternalClick !== false) {
-        close()
-      }
-    }
-
-    const handleOpenComplete = () => {
-      if (shouldBringFocusInside) bringFocusInside()
-      onOpenComplete()
-    }
-
-    useEffect(() => {
-      if (isShown) {
-        document.body.addEventListener('click', handleBodyClick, false)
-        document.body.addEventListener('keydown', onEsc, false)
-      } else {
-        document.body.removeEventListener('click', handleBodyClick, false)
-        document.body.removeEventListener('keydown', onEsc, false)
-      }
-
-      return () => {
-        document.body.removeEventListener('click', handleBodyClick, false)
-        document.body.removeEventListener('keydown', onEsc, false)
-      }
-    }, [isShown, handleBodyClick, onEsc])
-
-    const renderTarget = ({ getRef, isShown }) => {
-      const isTooltipInside = children && children.type === Tooltip
-
-      const getTargetRef = ref => {
-        setTargetRef(ref)
-        getRef(ref)
-      }
-
-      /**
-       * When a function is passed, you can control the Popover manually.
-       */
-      if (typeof children === 'function') {
-        return children({
-          getRef: getTargetRef,
-          isShown,
-          toggle
-        })
-      }
-
-      const popoverTargetProps = {
-        onClick: toggle,
-        onMouseEnter: handleOpenHover,
-        onKeyDown: handleKeyDown,
-        role: 'button',
-        'aria-expanded': isShown,
-        'aria-haspopup': true
-      }
-
-      /**
-       * Tooltips can be used within a Popover (not the other way around)
-       * In this case the children is the Tooltip instead of a button.
-       * Pass the properties to the Tooltip and let the Tooltip
-       * add the properties to the target.
-       */
-      if (isTooltipInside) {
-        return React.cloneElement(children, {
-          popoverProps: {
-            getTargetRef,
+        /**
+         * When a function is passed, you can control the Popover manually.
+         */
+        if (typeof children === 'function') {
+          return children({
+            getRef: getTargetRef,
             isShown,
+            toggle
+          })
+        }
 
-            // These propeties will be spread as `popoverTargetProps`
-            // in the Tooltip component.
-            ...popoverTargetProps
-          }
+        const popoverTargetProps = {
+          onClick: toggle,
+          onMouseEnter: handleOpenHover,
+          onKeyDown: handleKeyDown,
+          role: 'button',
+          'aria-expanded': isShown,
+          'aria-haspopup': true
+        }
+
+        /**
+         * Tooltips can be used within a Popover (not the other way around)
+         * In this case the children is the Tooltip instead of a button.
+         * Pass the properties to the Tooltip and let the Tooltip
+         * add the properties to the target.
+         */
+        if (isTooltipInside) {
+          return React.cloneElement(children, {
+            popoverProps: {
+              getTargetRef,
+              isShown,
+
+              // These propeties will be spread as `popoverTargetProps`
+              // in the Tooltip component.
+              ...popoverTargetProps
+            }
+          })
+        }
+
+        /**
+         * With normal usage only popover props end up on the target.
+         */
+        return React.cloneElement(children, {
+          ref: getTargetRef,
+          ...popoverTargetProps
         })
       }
 
-      /**
-       * With normal usage only popover props end up on the target.
-       */
-      return React.cloneElement(children, {
-        ref: getTargetRef,
-        ...popoverTargetProps
-      })
+      // If `props.isShown` is a boolean, popover is controlled manually, not via mouse events
+      const shown = typeof props.isShown === 'boolean' ? props.isShown : isShown
+
+      return (
+        <Positioner
+          target={renderTarget}
+          isShown={shown}
+          position={position}
+          animationDuration={animationDuration}
+          onOpenComplete={handleOpenComplete}
+          onCloseComplete={onCloseComplete}
+        >
+          {({ css, style, state, getRef }) => (
+            <PopoverStateless
+              ref={ref => {
+                setPopoverNode(ref)
+                getRef(ref)
+              }}
+              data-state={state}
+              display={display}
+              minWidth={minWidth}
+              minHeight={minHeight}
+              {...statelessProps}
+              className={cx(
+                statelessProps.className,
+                glamorCss(css, style, statelessProps.style).toString()
+              )}
+              // Overwrite `statelessProps.style` since we are including it via className
+              style={undefined}
+              onMouseLeave={handleCloseHover}
+            >
+              {typeof content === 'function' ? content({ close }) : content}
+            </PopoverStateless>
+          )}
+        </Positioner>
+      )
     }
-
-    // If `props.isShown` is a boolean, popover is controlled manually, not via mouse events
-    const shown = typeof props.isShown === 'boolean' ? props.isShown : isShown
-
-    return (
-      <Positioner
-        target={renderTarget}
-        isShown={shown}
-        position={position}
-        animationDuration={animationDuration}
-        onOpenComplete={handleOpenComplete}
-        onCloseComplete={onCloseComplete}
-      >
-        {({ css, style, state, getRef }) => (
-          <PopoverStateless
-            ref={ref => {
-              setPopoverNode(ref)
-              getRef(ref)
-            }}
-            data-state={state}
-            display={display}
-            minWidth={minWidth}
-            minHeight={minHeight}
-            {...statelessProps}
-            className={cx(
-              statelessProps.className,
-              glamorCss(css, style, statelessProps.style).toString()
-            )}
-            // Overwrite `statelessProps.style` since we are including it via className
-            style={undefined}
-            onMouseLeave={handleCloseHover}
-          >
-            {typeof content === 'function' ? content({ close }) : content}
-          </PopoverStateless>
-        )}
-      </Positioner>
-    )
-  }
-))
+  )
+)
 
 Popover.propTypes = {
   /**

--- a/src/toaster/src/Toast.js
+++ b/src/toaster/src/Toast.js
@@ -63,7 +63,9 @@ const Toast = memo(props => {
   const [isShown, setIsShown] = useState(true)
   const [height, setHeight] = useState(0)
   const closeTimer = useRef(null)
-  const state = useTransition(isShown, duration, { unmountOnExit: true })
+  const state = useTransition(isShown, ANIMATION_DURATION, {
+    unmountOnExit: true
+  })
 
   const clearCloseTimer = () => {
     if (closeTimer.current) {

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -125,9 +125,7 @@ const Tooltip = memo(props => {
 
   return (
     <Positioner
-      target={({ getRef }) => {
-        return renderTarget({ getRef })
-      }}
+      target={renderTarget}
       isShown={shown}
       position={position}
       animationDuration={160}

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,19 +60,12 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
   integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
     "@babel/highlight" "^7.10.4"
-
-"@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
-  dependencies:
-    "@babel/highlight" "^7.8.3"
 
 "@babel/compat-data@^7.9.6":
   version "7.9.6"
@@ -292,15 +285,10 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.9.0":
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.9.5":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
-
-"@babel/helper-validator-identifier@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
-  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -321,16 +309,7 @@
     "@babel/traverse" "^7.9.6"
     "@babel/types" "^7.9.6"
 
-"@babel/highlight@^7.0.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
-  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.9.0"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.8.3":
+"@babel/highlight@^7.0.0", "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
   integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
@@ -919,14 +898,7 @@
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.1", "@babel/runtime@^7.9.2":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
-  integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.6.3":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.1", "@babel/runtime@^7.9.2":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
   integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
@@ -1878,13 +1850,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
-  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@^16.9.5":
   version "16.9.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
@@ -2135,12 +2100,7 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
-
-acorn@^7.1.1:
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
@@ -2212,17 +2172,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
-  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.2:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -3217,7 +3167,7 @@ browserslist@4.7.0:
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
 
-browserslist@^4.0.0:
+browserslist@^4.0.0, browserslist@^4.11.1, browserslist@^4.12.0, browserslist@^4.8.3:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.13.0.tgz#42556cba011e1b0a2775b611cba6a8eca18e940d"
   integrity sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==
@@ -3226,16 +3176,6 @@ browserslist@^4.0.0:
     electron-to-chromium "^1.3.488"
     escalade "^3.0.1"
     node-releases "^1.1.58"
-
-browserslist@^4.11.1, browserslist@^4.12.0, browserslist@^4.8.3:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.12.0.tgz#06c6d5715a1ede6c51fc39ff67fd647f740b656d"
-  integrity sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==
-  dependencies:
-    caniuse-lite "^1.0.30001043"
-    electron-to-chromium "^1.3.413"
-    node-releases "^1.1.53"
-    pkg-up "^2.0.0"
 
 buf-compare@^1.0.0:
   version "1.0.1"
@@ -3483,15 +3423,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001093:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001061, caniuse-lite@^1.0.30001093:
   version "1.0.30001100"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001100.tgz#2a58615e0c01cf716ab349b20ca4d86ef944aa4e"
   integrity sha512-0eYdp1+wFCnMlCj2oudciuQn2B9xAFq3WpgpcBIZTxk/1HNA/O2YA7rpeYhnOqsqAJq1AHUgx6i1jtafg7m2zA==
-
-caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001061:
-  version "1.0.30001065"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001065.tgz#e8d7fef61cdfd8a7107493ad6bf551a4eb59c68f"
-  integrity sha512-DDxCLgJ266YnAHQv0jS1wdOaihRFF52Zgmlag39sQJVy2H46oROpJp4hITstqhdB8qnHSrKNoAEkQA9L/oYF9A==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -4269,26 +4204,7 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-css-loader@^3.0.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.5.3.tgz#95ac16468e1adcd95c844729e0bb167639eb0bcf"
-  integrity sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==
-  dependencies:
-    camelcase "^5.3.1"
-    cssesc "^3.0.0"
-    icss-utils "^4.1.1"
-    loader-utils "^1.2.3"
-    normalize-path "^3.0.0"
-    postcss "^7.0.27"
-    postcss-modules-extract-imports "^2.0.0"
-    postcss-modules-local-by-default "^3.0.2"
-    postcss-modules-scope "^2.2.0"
-    postcss-modules-values "^3.0.0"
-    postcss-value-parser "^4.0.3"
-    schema-utils "^2.6.6"
-    semver "^6.3.0"
-
-css-loader@^3.6.0:
+css-loader@^3.0.0, css-loader@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
   integrity sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==
@@ -4430,7 +4346,7 @@ csso@^4.0.2:
   dependencies:
     css-tree "1.0.0-alpha.37"
 
-csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
+csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
@@ -4741,14 +4657,6 @@ dom-helpers@^3.2.1:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-helpers@^5.0.1:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
-  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^2.6.7"
-
 dom-serializer@0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
@@ -4899,12 +4807,7 @@ ejs@^2.6.1, ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.413:
-  version "1.3.451"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.451.tgz#0c075af3e2f06d706670bde0279432802ca8c83f"
-  integrity sha512-2fvco0F2bBIgqzO8GRP0Jt/91pdrf9KfZ5FsmkYkjERmIJG585cFeFZV4+CO6oTmU3HmCTgfcZuEa7kW8VUh3A==
-
-electron-to-chromium@^1.3.488:
+electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488:
   version "1.3.498"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.498.tgz#fd7188c8a49d6d0b5df1df55a1f1a4bf2c177457"
   integrity sha512-W1hGwaQEU8j9su2jeAr3aabkPuuXw+j8t73eajGAkEJWbfWiwbxBwQN/8Qmv2qCy3uCDm2rOAaZneYQM8VGC4w==
@@ -6882,12 +6785,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.5, ignore@^5.1.1:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
-  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
-
-ignore@^5.1.4:
+ignore@^5.0.5, ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -8271,12 +8169,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.5:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -8570,12 +8463,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
-  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
-
-merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -9012,12 +8900,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^1.1.29, node-releases@^1.1.53:
-  version "1.1.56"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.56.tgz#bc054a417d316e3adac90eafb7e1932802f28705"
-  integrity sha512-EVo605FhWLygH8a64TjgpjyHYOihkxECwX1bHHr8tETJKWEiWS2YJjPbvsX2jFjnjTNEgBCmk9mLjKG1Mf11cw==
-
-node-releases@^1.1.58:
+node-releases@^1.1.29, node-releases@^1.1.58:
   version "1.1.59"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.59.tgz#4d648330641cec704bff10f8e4fe28e453ab8e8e"
   integrity sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==
@@ -9828,7 +9711,7 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-up@2.0.0, pkg-up@^2.0.0:
+pkg-up@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
@@ -10208,21 +10091,12 @@ postcss-value-parser@^3.0.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.0.3, postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.30, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.30"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.30.tgz#cc9378beffe46a02cbc4506a0477d05fcea9a8e2"
-  integrity sha512-nu/0m+NtIzoubO+xdAlwZl/u5S5vi/y6BCsoL8D+8IxsD3XvBS8X4YEADNIVXKVuQvduiucnRv+vPIqj56EGMQ==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.1, postcss@^7.0.32:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.30, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
@@ -10809,16 +10683,6 @@ react-tiny-virtual-list@^2.1.4:
   dependencies:
     prop-types "^15.5.7"
 
-react-transition-group@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
-  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-
 react@^16.13.1, react@^16.5.2, react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -10903,16 +10767,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.5.0.tgz#465d70e6d1087f6162d079cd0b5db7fbebfd1606"
-  integrity sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-stream@^3.4.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -11212,14 +11067,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.8.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.0.tgz#063dc704fa3413e13ac1d0d1756a7cbfe95dd1a7"
-  integrity sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.10.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -11438,15 +11286,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.5, schema-utils@^2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
-  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
-  dependencies:
-    ajv "^6.12.0"
-    ajv-keywords "^3.4.1"
-
-schema-utils@^2.7.0:
+schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
   integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
@@ -11663,12 +11503,7 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
-signal-exit@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
@@ -12602,12 +12437,7 @@ ts-dedent@^1.1.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.1.1.tgz#68fad040d7dbd53a90f545b450702340e17d18f3"
   integrity sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==
 
-ts-pnp@^1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
-  integrity sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==
-
-ts-pnp@^1.1.6:
+ts-pnp@^1.1.2, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==


### PR DESCRIPTION
## Overview 
This PR fixes various issues with Autocomplete, Popover, Positioner and removes `react-transition-group` in favor of a simpler `useTransition` hook.
 
## Screenshots (if applicable) 
![stacks](https://user-images.githubusercontent.com/710752/88448485-1e31e980-ce04-11ea-9c49-8aa5fe03968e.gif)
![toasty](https://user-images.githubusercontent.com/710752/88448487-225e0700-ce04-11ea-86fe-29cd51102143.gif)


## Testing
- [x] Updated Typescript types and/or component PropTypes 
- [ ] Added / modified component docs 
- [ ] Added / modified Storybook stories
