### PR TITLE
fix autocomplete itemToString

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -149,6 +149,7 @@ const Autocomplete = memo(
       <Downshift
         stateReducer={stateReducer}
         scrollIntoView={noop}
+        itemToString={itemToString}
         ref={ref}
         {...restProps}
       >


### PR DESCRIPTION
## Overview
This PR fixes an issue with how `itemToString` was no longer being passed to Downshift in `Combobox` and `Autocomplete`

## Screenshots (if applicable)
**Before**
![image](https://user-images.githubusercontent.com/710752/89343225-95b81200-d669-11ea-9233-dfcc6a53dfd3.png)

**After**
![image](https://user-images.githubusercontent.com/710752/89343241-9cdf2000-d669-11ea-9c15-ffaaecfe8aa5.png)


## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
