### PR TITLE
Call `onStateChange` if passed to `<Combobox>`

### DIFF
--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -28,11 +28,18 @@ const Combobox = memo(function Combobox(props) {
 
   const [isOpenedByButton, setIsOpenedByButton] = useState(false)
 
-  const handleStateChange = changes => {
+  const handleStateChange = (changes, stateAndHelpers) => {
     if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
       if (!changes.isOpen) {
         setIsOpenedByButton(false)
       }
+    }
+
+    if (
+      autocompleteProps &&
+      typeof autocompleteProps.onStateChange === 'function'
+    ) {
+      autocompleteProps.onStateChange(changes, stateAndHelpers)
     }
   }
 
@@ -43,9 +50,9 @@ const Combobox = memo(function Combobox(props) {
       initialSelectedItem={initialSelectedItem}
       itemToString={itemToString}
       onChange={onChange}
-      onStateChange={handleStateChange}
       isFilterDisabled={isOpenedByButton}
       {...autocompleteProps}
+      onStateChange={handleStateChange}
     >
       {({
         getRef,

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react'
-import React from 'react'
+import React, { useState } from 'react'
 import Box from 'ui-box'
 import starWarsNames from 'starwars-names'
 import { Heading } from '../../typography'
@@ -27,95 +27,115 @@ const handleChange = selectedItem => {
   console.log(selectedItem)
 }
 
-storiesOf('combobox', module).add('Combobox', () => (
-  <Box padding={40}>
-    {(() => {
-      document.body.style.margin = '0'
-      document.body.style.height = '100vh'
-    })()}
-    <Box marginBottom={16}>
-      <Heading>Default usage</Heading>
-      <Combobox items={items} onChange={handleChange} />
-    </Box>
-    <Box marginBottom={16}>
-      <Heading>Custom width</Heading>
-      <Combobox width={120} items={items} onChange={handleChange} />
-    </Box>
-    <Box marginBottom={16} marginLeft={400}>
-      <Heading>Custom width + offset</Heading>
-      <Combobox width={120} items={items} onChange={handleChange} />
-    </Box>
-    <Box marginBottom={16}>
-      <Heading>Open on focus</Heading>
-      <Combobox openOnFocus items={items} onChange={handleChange} />
-    </Box>
-    <Box marginBottom={16}>
-      <Heading>Default value</Heading>
-      <Combobox
-        initialSelectedItem="Yoda"
-        items={items}
-        onChange={handleChange}
-      />
-    </Box>
-    <Box marginBottom={16}>
-      <Heading>Custom item objects</Heading>
-      <Combobox
-        initialSelectedItem={customItems[0]}
-        items={customItems}
-        itemToString={i => (i ? i.label : '')}
-        onChange={handleChange}
-      />
-    </Box>
-    <Box marginBottom={16}>
-      <Heading>Disabled usage</Heading>
-      <Combobox items={items} onChange={handleChange} disabled />
-    </Box>
-    <Box marginBottom={16}>
-      <Heading>Loading usage</Heading>
-      <Combobox items={items} onChange={handleChange} isLoading />
-    </Box>
+storiesOf('combobox', module).add('Combobox', () => {
+  const [value, setValue] = useState('')
 
-    <Box marginBottom={16}>
-      <Heading>Full width combobox</Heading>
-
-      <Pane display="flex" background="tint1" padding={16}>
+  return (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <Box marginBottom={16}>
+        <Heading>Default usage</Heading>
+        <Combobox items={items} onChange={handleChange} />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Custom width</Heading>
+        <Combobox width={120} items={items} onChange={handleChange} />
+      </Box>
+      <Box marginBottom={16} marginLeft={400}>
+        <Heading>Custom width + offset</Heading>
+        <Combobox width={120} items={items} onChange={handleChange} />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Open on focus</Heading>
+        <Combobox openOnFocus items={items} onChange={handleChange} />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Default value</Heading>
         <Combobox
-          width="100%"
+          initialSelectedItem="Yoda"
+          items={items}
+          onChange={handleChange}
+        />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Any value</Heading>
+        <Combobox
+          items={items}
+          selectedItem={value}
+          autocompleteProps={{
+            onStateChange: changes => {
+              if (changes.selectedItem) {
+                setValue(changes.selectedItem)
+              } else if (changes.inputValue) {
+                setValue(changes.inputValue)
+              }
+            }
+          }}
+        />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Custom item objects</Heading>
+        <Combobox
           initialSelectedItem={customItems[0]}
           items={customItems}
           itemToString={i => (i ? i.label : '')}
           onChange={handleChange}
         />
-      </Pane>
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Disabled usage</Heading>
+        <Combobox items={items} onChange={handleChange} disabled />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Loading usage</Heading>
+        <Combobox items={items} onChange={handleChange} isLoading />
+      </Box>
 
-      <Heading>Pane has 75% width</Heading>
-      <Pane display="flex" background="tint2" width="75%" padding={16}>
-        <Combobox
-          width="100%"
-          initialSelectedItem={customItems[0]}
-          items={customItems}
-          itemToString={i => (i ? i.label : '')}
-          onChange={handleChange}
-        />
-      </Pane>
+      <Box marginBottom={16}>
+        <Heading>Full width combobox</Heading>
 
-      <Heading>
-        Pane is a column flexbox and Combobox is set to 100% width
-      </Heading>
-      <Pane
-        flexDirection="column"
-        display="flex"
-        background="greenTint"
-        padding={16}
-      >
-        <Combobox
-          width="100%"
-          initialSelectedItem={customItems[0]}
-          items={customItems}
-          itemToString={i => (i ? i.label : '')}
-          onChange={handleChange}
-        />
-      </Pane>
+        <Pane display="flex" background="tint1" padding={16}>
+          <Combobox
+            width="100%"
+            initialSelectedItem={customItems[0]}
+            items={customItems}
+            itemToString={i => (i ? i.label : '')}
+            onChange={handleChange}
+          />
+        </Pane>
+
+        <Heading>Pane has 75% width</Heading>
+        <Pane display="flex" background="tint2" width="75%" padding={16}>
+          <Combobox
+            width="100%"
+            initialSelectedItem={customItems[0]}
+            items={customItems}
+            itemToString={i => (i ? i.label : '')}
+            onChange={handleChange}
+          />
+        </Pane>
+
+        <Heading>
+          Pane is a column flexbox and Combobox is set to 100% width
+        </Heading>
+        <Pane
+          flexDirection="column"
+          display="flex"
+          background="greenTint"
+          padding={16}
+        >
+          <Combobox
+            width="100%"
+            initialSelectedItem={customItems[0]}
+            items={customItems}
+            itemToString={i => (i ? i.label : '')}
+            onChange={handleChange}
+          />
+        </Pane>
+      </Box>
     </Box>
-  </Box>
-))
+  )
+})


### PR DESCRIPTION
## Overview

Because `onStateChange` is being overriden inside `<Combobox>`, it's not possible to customize Downshift's behavior. This PR checks if `onStateChange` function is passed inside `autocompleteProps` and calls it if it is.

Use case for this in particular is typeahead - autocomplete, but without forcing user to select one of the `items`. User can type any value and autocomplete is optional. See "Any value" example in `src/combobox/stories/index.stories.js`.

## Testing

- [ ] Updated Typescript types and/or component PropTypes (no need)
- [ ] Added / modified component docs (no need)
- [x] Added / modified Storybook stories
