### PR TITLE
Fix itemToString for Autocomplete & Combobox (#930)

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -43,7 +43,7 @@ const AutocompleteItems = ({
   highlightedIndex,
   inputValue,
   isFilterDisabled,
-  itemsFilter = fuzzyFilter(itemToString),
+  itemsFilter,
   itemSize,
   itemToString,
   originalItems,
@@ -53,6 +53,7 @@ const AutocompleteItems = ({
   title,
   width
 }) => {
+  itemsFilter = itemsFilter || fuzzyFilter(itemToString)
   const items =
     isFilterDisabled || inputValue.trim() === ''
       ? originalItems


### PR DESCRIPTION
## Overview
Fixes #930.

## Testing
- [ ] ~Updated Typescript types and/or component PropTypes~ --> No changes to the interface.
- [ ] ~Added / modified component docs~ --> No changes to the interface.
- [ ] ~Added / modified Storybook stories~ --> There was already a story displaying this behaviour: the combobox with custom items. It works again now.
