### PR TITLE
Add box wrapper to maintain positioning for custom icons

### DIFF
--- a/src/icons/src/IconWrapper.js
+++ b/src/icons/src/IconWrapper.js
@@ -67,5 +67,5 @@ IconWrapper.propTypes = {
    * readers will use it for aural feedback.
    * By default, this is set to the icon's name for accessibility.
    */
-  title: PropTypes.string,
+  title: PropTypes.string
 }

--- a/src/icons/src/IconWrapper.js
+++ b/src/icons/src/IconWrapper.js
@@ -1,13 +1,14 @@
 import React, { forwardRef, memo } from 'react'
 import PropTypes from 'prop-types'
 import ReactIs from 'react-is'
+import Box from 'ui-box'
 
 /**
  * This is an internal helper component for rendering custom or Evergreen icons
  * Box props are applied to the outer Box container, and Evergreen icon-specific props are added to the icon element.
  */
 export const IconWrapper = memo(
-  forwardRef(function Icon({ icon, ...props }, ref) {
+  forwardRef(function Icon({ icon, marginLeft, marginRight, marginTop, marginBottom, ...props }, ref) {
     if (!icon || typeof icon === 'string') {
       return null
     }
@@ -20,7 +21,16 @@ export const IconWrapper = memo(
       iconWithProps = React.cloneElement(icon, { ...props, ...icon.props, ref })
     }
 
-    return iconWithProps
+    return (
+      <Box
+        display="flex"
+        marginLeft={marginLeft}
+        marginRight={marginRight}
+        marginTop={marginTop}
+        marginBottom={marginBottom}>
+        {iconWithProps}
+      </Box>
+    )
   })
 )
 

--- a/src/icons/src/IconWrapper.js
+++ b/src/icons/src/IconWrapper.js
@@ -8,26 +8,30 @@ import Box from 'ui-box'
  * Box props are applied to the outer Box container, and Evergreen icon-specific props are added to the icon element.
  */
 export const IconWrapper = memo(
-  forwardRef(function Icon({ icon, marginLeft, marginRight, marginTop, marginBottom, ...props }, ref) {
+  forwardRef(function Icon(
+    { icon, color, size, title, ...props },
+    ref
+  ) {
     if (!icon || typeof icon === 'string') {
       return null
+    }
+
+    const iconProps = {
+      color,
+      size,
+      title,
     }
 
     let iconWithProps = null
     if (ReactIs.isValidElementType(icon)) {
       const Component = icon
-      iconWithProps = <Component ref={ref} {...props} />
+      iconWithProps = <Component ref={ref} {...iconProps} />
     } else if (React.isValidElement(icon)) {
-      iconWithProps = React.cloneElement(icon, { ...props, ...icon.props, ref })
+      iconWithProps = React.cloneElement(icon, { ...iconProps, ...icon.props, ref })
     }
 
     return (
-      <Box
-        display="flex"
-        marginLeft={marginLeft}
-        marginRight={marginRight}
-        marginTop={marginTop}
-        marginBottom={marginBottom}>
+      <Box display="inline-flex" {...props}>
         {iconWithProps}
       </Box>
     )
@@ -64,12 +68,4 @@ IconWrapper.propTypes = {
    * By default, this is set to the icon's name for accessibility.
    */
   title: PropTypes.string,
-
-  /**
-   * Allows for positioning of the icon via Box
-   */
-  marginLeft: PropTypes.number,
-  marginRight: PropTypes.number,
-  marginTop: PropTypes.number,
-  marginBottom: PropTypes.number
 }

--- a/src/icons/src/IconWrapper.js
+++ b/src/icons/src/IconWrapper.js
@@ -63,5 +63,13 @@ IconWrapper.propTypes = {
    * readers will use it for aural feedback.
    * By default, this is set to the icon's name for accessibility.
    */
-  title: PropTypes.string
+  title: PropTypes.string,
+
+  /**
+   * Allows for positioning of the icon via Box
+   */
+  marginLeft: PropTypes.number,
+  marginRight: PropTypes.number,
+  marginTop: PropTypes.number,
+  marginBottom: PropTypes.number
 }


### PR DESCRIPTION
<!--
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
-->

## Overview
Resolves issue #925 

Added a `ui-box` wrapper to the `IconWrapper` component to help maintain positioning when using custom icons

## Screenshots (if applicable)
**Using FontAwesome**
![image](https://user-images.githubusercontent.com/17129452/89814374-e27f6b00-daf7-11ea-8ec4-2270624d5677.png)
![image](https://user-images.githubusercontent.com/17129452/89814421-f5923b00-daf7-11ea-83ea-7fad839776ba.png)

## Testing
- [x] Third-party icons now get positioned correctly
- [x] Internal icons still get positioned correctly
