### PR TITLE
Add missing disabled property to SegmentedControlOwnProps interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1405,12 +1405,40 @@ export type SearchTableHeaderCellProps = PolymorphicBoxProps<'div', SearchTableH
 export declare const SearchTableHeaderCell: BoxComponent<SearchTableHeaderCellOwnProps, 'div'>
 
 export interface SegmentedControlOwnProps {
+  /**
+   * The options (elements) displayed by the segmented control
+   */
   options: Array<{ label: string, value: NonNullable<SegmentedControlOwnProps['value']> }>
+  
+  /**
+   * The value of the segmented control
+   */
   value?: number | string | boolean
+  
+  /**
+   * The initial value of an uncontrolled segmented control
+   */
   defaultValue?: number | string | boolean
+  
+  /**
+   * Function called when value changes.
+   */
   onChange: (value: NonNullable<SegmentedControlOwnProps['value']>) => void
+
+  /**
+   * The name attribute of the segmented control
+   */
   name?: string
+
+  /**
+   * The height of the segmented control
+   */
   height?: number
+
+  /**
+   * Whether or not the component is disabled
+   */
+  disabled?: boolean
 }
 
 export type SegmentedControlProps = PolymorphicBoxProps<'div', SegmentedControlOwnProps>


### PR DESCRIPTION
First of all congrats on releasing v5! The Icon changes are especially welcome.

After upgrading my project to v5 I'm no longer able to build the code as TS complains about an invalid `disabled` prop I'm providing to `SegmentedControl`. As far as I could see the feature is still there, so I've added the missing disabled prop to the appropriate interface.