### PR TITLE
Update layout-primitives.mdx

### DIFF
--- a/docs/src/pages/components/layout-primitives.mdx
+++ b/docs/src/pages/components/layout-primitives.mdx
@@ -85,9 +85,9 @@ of a component. The text styles and padding will adjust based on the height you 
 ```jsx
 // import { Pane, Button, TextInput } from 'evergreen-ui'
 
-<Pane>
+<Pane display="flex">
   <TextInput width="100%" height={48} placeholder="Change my height to fit your needs." />
-  <Button height={48} appearance="primary" marginTop={16}>Big Button</Button>
+  <Button height={48} appearance="primary" marginLeft={16}>Big Button</Button>
 </Pane>
 ```
 


### PR DESCRIPTION
<!--
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
-->

## Overview

In the "Use the height property to resize components" section, I assume the margin for the button is supposed to be set for the left side not top and adding a display flex property will make the example look better.

## Screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/13625702/90006558-50c45900-dcc3-11ea-8296-055262b6ec84.png)

After:
![image](https://user-images.githubusercontent.com/13625702/90006532-473af100-dcc3-11ea-888c-e12b2a30e927.png)

## Testing

- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
