### PR TITLE
Fix broken Icon docs with non-existent condition

### DIFF
--- a/docs/src/pages/components/icons.mdx
+++ b/docs/src/pages/components/icons.mdx
@@ -49,7 +49,7 @@ There are a couple of presets available: `default`, `muted`, `disabled`, `select
 There is an exported `Icon` component which acts as a convenient wrapper around icons so you can dynamically pass icons to it:
 
 ```jsx
-<Icon icon={someCondition ? CogIcon : NotificationsIcon} size={12} />
+<Icon icon={CogIcon} size={12} />
 ```
 
 


### PR DESCRIPTION
## Overview
Quick fix -- there was no variable called `someCondition`, breaking the Icon docs at the very bottom 

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/5349500/91332293-d09cf980-e780-11ea-9045-05d3e34fbfea.png)


## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
