### PR TITLE
fix classnames overwrites in Tab, TagInput, FilePicker, TextDropdown

### DIFF
--- a/src/buttons/src/TextDropdownButton.js
+++ b/src/buttons/src/TextDropdownButton.js
@@ -1,5 +1,6 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import { dimensions, spacing, position, layout } from 'ui-box'
 import { IconWrapper } from '../../icons/src/IconWrapper'
 import { CaretDownIcon } from '../../icons'
@@ -38,7 +39,7 @@ const TextDropdownButton = memo(
       ...restProps
     } = props
 
-    const themedClassName = theme.getTextDropdownButtonClassName()
+    const themedClassName = cx(theme.getTextDropdownButtonClassName(), className)
 
     return (
       <Text

--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -1,6 +1,7 @@
 import React, { memo, forwardRef, useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
+import cx from 'classnames'
 import { Button } from '../../buttons'
 import { TextInput } from '../../text-input'
 import safeInvoke from '../../lib/safe-invoke'
@@ -20,6 +21,7 @@ const FilePicker = memo(
       height,
       onChange,
       placeholder = 'Select a file to upload…',
+      className,
       ...rest
     } = props
 
@@ -74,10 +76,12 @@ const FilePicker = memo(
       buttonText = 'Replace files'
     }
 
+    const rootClassNames = cx(`${CLASS_PREFIX}-root`, className)
+
     return (
       <Box
         display="flex"
-        className={`${CLASS_PREFIX}-root`}
+        className={rootClassNames}
         ref={ref}
         {...rest}
       >
@@ -182,7 +186,13 @@ FilePicker.propTypes = {
   /**
    * Placeholder of the text input
    */
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+
+  /**
+   * Class name passed to the FilePicker.
+   * Only use this if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
 export default FilePicker

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import React, { forwardRef, memo } from 'react'
 import safeInvoke from '../../lib/safe-invoke'
 import warning from '../../lib/warning'
@@ -32,6 +33,7 @@ const Tab = memo(
       isSelected,
       onKeyPress = noop,
       onSelect = noop,
+      className,
       ...rest
     } = props
 
@@ -85,9 +87,11 @@ const Tab = memo(
       }
     }
 
+    const classNames = cx(theme.getTabClassName(appearance), className)
+
     return (
       <Text
-        className={theme.getTabClassName(appearance)}
+        className={classNames}
         is={is}
         size={textSize}
         height={height}
@@ -122,7 +126,13 @@ Tab.propTypes = {
    * The appearance of the tab.
    * The default theme only comes with a default style.
    */
-  appearance: PropTypes.string
+  appearance: PropTypes.string,
+
+  /**
+   * Class name passed to the Tab.
+   * Only use this if you know what you are doing.
+   */
+  className: PropTypes.string
 }
 
 export default Tab

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -38,7 +38,7 @@ const TagInput = memo(
       onFocus,
       onInputChange,
       className,
-      inputProps,
+      inputProps = {},
       inputRef,
       ...rest
     } = props
@@ -151,9 +151,9 @@ const TagInput = memo(
     }
 
     const themedContainerClassName = theme.getTagInputClassName('default')
-    const themedInputClassName = theme.getTextInputClassName('none')
     const textSize = theme.getTextSizeForControlHeight(height)
     const borderRadius = theme.getBorderRadiusForControlHeight(height)
+    const themedInputClassName = cx(theme.getTextInputClassName('none'), inputProps.className)
 
     return (
       <Box


### PR DESCRIPTION
## Overview

fixes #946 

Adds `className` prop to some components using the `classnames` library .

The only place where it is missing now is `MenuItem.js`. I did not add it there as another PR is modifying that file which would result in merge conflicts.

## Screenshots (if applicable)

Not applicable.

## Testing

Tested locally. Does not break any existing component styles.
