### PR TITLE
fix menu disable items functionality and appearence

### DIFF
--- a/docs/src/pages/components/menu.mdx
+++ b/docs/src/pages/components/menu.mdx
@@ -122,6 +122,32 @@ The `onSelect` handlers are omitted for brevity.
 </Popover>
 ```
 
+## Menu with disabled items
+
+```jsx
+<Popover
+  position={Position.BOTTOM_LEFT}
+  content={
+    <Menu>
+      <Menu.Group>
+        <Menu.Item disabled icon={PeopleIcon}>Share...</Menu.Item>
+        <Menu.Item icon={CircleArrowRightIcon}>Move...</Menu.Item>
+        <Menu.Item icon={EditIcon} secondaryText="⌘R">
+          Rename...
+        </Menu.Item>
+      </Menu.Group>
+      <Menu.Divider />
+      <Menu.Group>
+        <Menu.Item disabled icon={TrashIcon} intent="danger">
+          Delete...
+        </Menu.Item>
+      </Menu.Group>
+    </Menu>
+  }
+>
+  <Button marginRight={16}>With Disabled Items</Button>
+</Popover>
+```
 
 ## Groups with titles
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1107,6 +1107,7 @@ export interface MenuItemOwnProps extends PaneOwnProps {
   secondaryText?: JSX.Element
   appearance?: DefaultAppearance
   intent?: IntentTypes
+  disabled?: boolean
 }
 
 export type MenuItemProps = PolymorphicBoxProps<'div', MenuItemOwnProps>

--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -8,89 +8,89 @@ import MenuOption from './MenuOption'
 import MenuOptionsGroup from './MenuOptionsGroup'
 
 const Menu = memo(function Menu(props) {
-  const menuRef = useRef()
+
+  const menuRef = useRef(null)
   const firstItem = useRef()
   const lastItem = useRef()
 
   const menuItems = useRef()
 
   useEffect(() => {
-    if (menuRef && menuRef.current) {
-      menuItems.current = [
-        ...menuRef.current.querySelectorAll(
-          '[role="menuitemradio"], [role="menuitem"]'
-        )
-      ]
 
-      if (menuItems.current.length === 0) {
-        throw new Error('The menu has no menu items')
-      }
+    menuItems.current = menuRef.current ? [
+      ...menuRef.current.querySelectorAll(
+        '[role="menuitemradio"], [role="menuitem"]'
+     )].filter(el => el.getAttribute('disabled') === null)
+    : []
 
-      firstItem.current = menuItems.current[0]
-      lastItem.current = menuItems.current[menuItems.current.length - 1]
+    if (menuItems.current.length === 0) {
+      throw new Error('The menu has no menu items')
+    }
 
-      const focusNext = (currentItem, startItem) => {
-        // Determine which item is the startItem (first or last)
-        const goingDown = startItem === firstItem.current
+    firstItem.current = menuItems.current[0]
+    lastItem.current = menuItems.current[menuItems.current.length - 1]
 
-        // Helper function for getting next legitimate element
-        const move = elem => {
-          const indexOfItem = menuItems.current.indexOf(elem)
+    const focusNext = (currentItem, startItem) => {
 
-          if (goingDown) {
-            if (indexOfItem < menuItems.current.length - 1) {
-              return menuItems.current[indexOfItem + 1]
-            }
+      // Determine which item is the startItem (first or last)
+      const goingDown = startItem === firstItem.current
 
-            return startItem
-          }
+      // Helper function for getting next legitimate element
+      const move = elem => {
+        const indexOfItem = menuItems.current.indexOf(elem)
 
-          if (indexOfItem - 1 > -1) {
-            return menuItems.current[indexOfItem - 1]
+        if (goingDown) {
+          if (indexOfItem < menuItems.current.length - 1) {
+            return menuItems.current[indexOfItem + 1]
           }
 
           return startItem
         }
 
-        // Make first move
-        let nextItem = move(currentItem)
-
-        // If the menuitem is disabled move on
-        while (nextItem.disabled) {
-          nextItem = move(nextItem)
+        if (indexOfItem - 1 > -1) {
+          return menuItems.current[indexOfItem - 1]
         }
 
-        // Focus the first one that's not disabled
-        nextItem.focus()
+        return startItem
       }
 
-      menuItems.current.forEach(menuItem => {
-        // Handle key presses for menuItem
-        menuItem.addEventListener('keydown', e => {
-          // Go to next/previous item if it exists
-          // or loop around
+      // Make first move
+      const nextItem = move(currentItem)
 
-          if (e.key === 'ArrowDown') {
-            e.preventDefault()
-            focusNext(menuItem, firstItem.current)
-          }
+      // Focus the first one that's not disabled
+      nextItem.focus()
+    }
 
-          if (e.key === 'ArrowUp') {
-            e.preventDefault()
-            focusNext(menuItem, lastItem.current)
-          }
+    function onKeyPressListener(e) {
+      // Go to next/previous item if it exists
+      // or loop around
 
-          if (e.key === 'Home') {
-            e.preventDefault()
-            firstItem.current.focus()
-          }
+      const menuItem = e.target
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        focusNext(menuItem, firstItem.current)
+      }
 
-          if (e.key === 'End') {
-            e.preventDefault()
-            lastItem.current.focus()
-          }
-        })
-      })
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        focusNext(menuItem, lastItem.current)
+      }
+
+      if (e.key === 'Home') {
+        e.preventDefault()
+        firstItem.current.focus()
+      }
+
+      if (e.key === 'End') {
+        e.preventDefault()
+        lastItem.current.focus()
+      }
+    }
+
+    menuItems.current.forEach(menuItem => menuItem.addEventListener('keydown', onKeyPressListener))
+
+    return () => {
+      menuItems.current.forEach(menuItem => menuItem.removeEventListener('keydown', onKeyPressListener))
     }
   }, [menuRef])
 

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, useCallback } from 'react'
+import React, { memo, forwardRef, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { IconWrapper } from '../../icons/src/IconWrapper'
@@ -20,6 +20,7 @@ const MenuItem = memo(
       icon,
       onSelect = noop,
       onKeyPress,
+      disabled,
       ...passthroughProps
     } = props
 
@@ -46,6 +47,29 @@ const MenuItem = memo(
 
     const themedClassName = theme.getMenuItemClassName(appearance, 'none')
 
+    let iconColor = intent === 'none' ? 'default' : intent
+
+    if(disabled) {
+      iconColor = 'disabled'
+    }
+
+    const textColor = disabled ? theme.colors.icon.disabled : intent
+
+    const secondaryTextColor = disabled ? textColor : 'muted'
+
+    const disabledProps = useMemo(() => {
+      return disabled ? {
+        backgroundColor: theme.colors.background.tint1,
+        cursor: 'not-allowed',
+        disabled: true,
+        onClick: null,
+        onKeyPress: null,
+        tabIndex: -1,
+        'aria-disabled': 'true',
+        'data-isselectable': 'false'
+      } : {}
+    }, [disabled])
+
     return (
       <Pane
         is={is}
@@ -59,21 +83,22 @@ const MenuItem = memo(
         display="flex"
         alignItems="center"
         ref={ref}
+        {...disabledProps}
         {...passthroughProps}
       >
         <IconWrapper
           icon={icon}
-          color={intent === 'none' ? 'default' : intent}
+          color={iconColor}
           marginLeft={16}
           marginRight={-4}
           size={16}
           flexShrink={0}
         />
-        <Text color={intent} marginLeft={16} marginRight={16} flex={1}>
+        <Text color={textColor} marginLeft={16} marginRight={16} flex={1}>
           {children}
         </Text>
         {secondaryText && (
-          <Text marginRight={16} color="muted">
+          <Text marginRight={16} color={secondaryTextColor}>
             {secondaryText}
           </Text>
         )}
@@ -122,7 +147,12 @@ MenuItem.propTypes = {
   /**
    * Callback to invoke onkeypress
    */
-  onKeyPress: PropTypes.func
+  onKeyPress: PropTypes.func,
+
+  /**
+   * Flag to indicate whether the menu item is disabled or not
+   */
+  disabled: PropTypes.bool
 }
 
 export default MenuItem

--- a/src/menu/stories/index.stories.js
+++ b/src/menu/stories/index.stories.js
@@ -83,6 +83,28 @@ storiesOf('menu', module)
         position={Position.BOTTOM_LEFT}
         content={
           <Menu>
+            <Menu.Group title="Actions">
+              <Menu.Item icon={PeopleIcon}>Share...</Menu.Item>
+              <Menu.Item icon={CircleArrowRightIcon}>Move...</Menu.Item>
+              <Menu.Item disabled icon={EditIcon} secondaryText="⌘R">
+                Rename...
+              </Menu.Item>
+            </Menu.Group>
+            <Menu.Divider />
+            <Menu.Group title="destructive">
+              <Menu.Item disabled icon={TrashIcon} intent="danger">
+                Delete...
+              </Menu.Item>
+            </Menu.Group>
+          </Menu>
+        }
+      >
+        <Button marginRight={16}>With Disabled Items</Button>
+      </Popover>
+      <Popover
+        position={Position.BOTTOM_LEFT}
+        content={
+          <Menu>
             <Component
               initialState={{
                 selected: 'asc'

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -77,13 +77,13 @@ const Popover = memo(
           document.activeElement
         )
         if (isFocusOutsideModal) {
-          // Element marked autofocus has higher priority than the other clowns
+          // Element marked autofocus has higher priority than the other elements
           const autofocusElement = popoverNode.current.querySelector(
-            '[autofocus]'
+            '[autofocus]:not([disabled])'
           )
-          const wrapperElement = popoverNode.current.querySelector('[tabindex]')
+          const wrapperElement = popoverNode.current.querySelector('[tabindex]:not([disabled])')
           const buttonElements = popoverNode.current.querySelectorAll(
-            'button, a, [role="menuitem"], [role="menuitemradio"]'
+            'button:not([disabled]), a:not([disabled]), [role="menuitem"]:not([disabled]), [role="menuitemradio"]:not([disabled])'
           )
 
           if (autofocusElement) {


### PR DESCRIPTION
## Overview

Hi there, this PR addresses this (#796 ) issue by fixing the menu disabled functionality. This PR makes the following changes.

- Gives a disabled appearance to a menu item when `disabled` prop is true.
- Fixes memory leaks in the Menu component (`keydown` listeners were note being deregistered on component unmount)
- Fixes an issue when Popover won't bring the focus to the MenuItem if the first menu item is disabled.
- Modifies the query selector in Popover to only select children that are not disabled thus no need to skip any elements when navigating through keys.

## Screenshots (if applicable)

https://www.loom.com/share/9055c6fdfb3c4011ae8579b7f19fa784

## Note

Since this PR also modifies the Popover component and another PR #945 makes some major changes to that component so this might result in a merge conflict. In that case, I would suggest merging that PR first.

## Testing

- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
