### PR TITLE
fix undefined props merging and list styles

### DIFF
--- a/src/lib/remove-undefined.js
+++ b/src/lib/remove-undefined.js
@@ -1,0 +1,14 @@
+/**
+ * Cleans an object of undefined values
+ */
+export default function removeUndefined(input = {}) {
+  const obj = { ...input }
+
+  Object.keys(obj).forEach(key => {
+    if (obj[key] === undefined) {
+      delete obj[key]
+    }
+  })
+
+  return obj
+}

--- a/src/typography/src/ListItem.js
+++ b/src/typography/src/ListItem.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { forwardRef, memo } from 'react'
 import { IconWrapper } from '../../icons/src/IconWrapper'
+import { minorScale } from '../../scales'
 import Text from './Text'
 
 const ListItem = memo(
@@ -8,10 +9,10 @@ const ListItem = memo(
     const { children, size, icon, iconColor, ...rest } = props
 
     let paddingLeft
-    if (size === 300) paddingLeft = 4
-    if (size === 400) paddingLeft = 8
-    if (size === 500) paddingLeft = 8
-    if (size === 600) paddingLeft = 12
+    if (size === 300) paddingLeft = minorScale(1)
+    if (size === 400) paddingLeft = minorScale(2)
+    if (size === 500) paddingLeft = minorScale(2)
+    if (size === 600) paddingLeft = minorScale(3)
 
     let iconTop
     if (size === 300) iconTop = 1

--- a/src/typography/src/UnorderedList.js
+++ b/src/typography/src/UnorderedList.js
@@ -1,13 +1,7 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-
-const styles = {
-  margin: 0,
-  marginLeft: '1.1em',
-  padding: 0,
-  listStyle: 'disc'
-}
+import removeUndefined from '../../lib/remove-undefined'
 
 const UnorderedList = memo(
   forwardRef(function UnorderedList(props, ref) {
@@ -18,17 +12,34 @@ const UnorderedList = memo(
         return child
       }
 
-      return React.cloneElement(child, {
-        icon,
-        size,
-        iconColor,
-        // Prefer more granularly defined props if present
-        ...child.props
-      })
+      return React.cloneElement(
+        child,
+        removeUndefined({
+          icon,
+          size,
+          iconColor,
+          // Prefer more granularly defined props if present
+          ...child.props
+        })
+      )
     })
 
+    let marginLeft
+    if (size === 300) marginLeft = 16
+    if (size === 400) marginLeft = 18
+    if (size === 500) marginLeft = 18
+    if (size === 600) marginLeft = 20
+
     return (
-      <Box is="ul" {...styles} {...rest} ref={ref}>
+      <Box
+        is="ul"
+        listStyle="disc"
+        padding={0}
+        margin={0}
+        marginLeft={marginLeft}
+        {...rest}
+        ref={ref}
+      >
         {enrichedChildren}
       </Box>
     )


### PR DESCRIPTION
# Overview
This PR fixes an issue where our list items were getting props overridden with `undefined` values – we shouldn't pass in undefined to child components if we can avoid it. There was also a style issue because we are using `em` for the list style margin, but that's not reliable (different apps could have different relative units).

## Screenshots (if applicable)
**Before (ignore the icon, look at the left alignment)**
<img width="82" alt="Screen Shot 2020-08-28 at 10 44 38 AM" src="https://user-images.githubusercontent.com/710752/91590733-6a031180-e921-11ea-8066-94177285b7e8.png">

**After**
![Screen Shot 2020-08-28 at 11 29 08 AM](https://user-images.githubusercontent.com/710752/91591745-024dc600-e923-11ea-96db-f0ffb8afe3af.png)


## Testing
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
