### PR TITLE
fix input height regression on text field

### DIFF
--- a/src/text-input/src/TextInputField.js
+++ b/src/text-input/src/TextInputField.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { splitBoxProps } from 'ui-box'
 import { FormField } from '../../form-field'
 import { useId } from '../../hooks'
+import { majorScale } from '../../scales'
 import TextInput from './TextInput'
 
 const TextInputField = memo(
@@ -26,7 +27,7 @@ const TextInputField = memo(
       appearance,
       placeholder,
       spellCheck,
-      inputHeight = 40,
+      inputHeight = majorScale(4),
       inputWidth = '100%',
 
       // Rest props are spread on the FormField


### PR DESCRIPTION
## Overview
In v5 we introduced an unintentional change to the `TextInputField` height (32px -> 40px) that was inconsistent with other *Field inputs.


## Screenshots (if applicable)
<img width="420" alt="Screen Shot 2020-08-29 at 2 53 54 PM" src="https://user-images.githubusercontent.com/710752/91645050-7f526b80-ea07-11ea-9f33-2e24f493a72f.png">
<img width="462" alt="Screen Shot 2020-08-29 at 2 53 58 PM" src="https://user-images.githubusercontent.com/710752/91645051-7feb0200-ea07-11ea-928a-b70267595510.png">


## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
