### PR TITLE
fix icon button size

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -40,7 +40,7 @@ export const internalStyles = {
   whiteSpace: 'nowrap'
 }
 
-const getIconSizeForButton = height => {
+export const getIconSizeForButton = height => {
   if (height <= 28) return 12
   if (height <= 32) return 14
   if (height <= 40) return 16

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -2,11 +2,17 @@ import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { dimensions, spacing, position, layout } from 'ui-box'
 import { IconWrapper } from '../../icons/src/IconWrapper'
-import Button from './Button'
+import useButtonAppearance from '../../theme/src/hooks/useButtonAppearance'
+import Button, { getIconSizeForButton } from './Button'
 
 const IconButton = memo(
   forwardRef(function IconButton(props, ref) {
-    const { icon, iconSize, ...restProps } = props
+    const { icon, iconSize, size = 'medium', ...restProps } = props
+    // TODO figure out a better solution for dynamically relative values
+    const { boxProps } = useButtonAppearance({ size })
+    const relativeIconSize = getIconSizeForButton(
+      restProps.height || boxProps.height
+    )
 
     return (
       <Button
@@ -14,9 +20,14 @@ const IconButton = memo(
         paddingLeft={0}
         paddingRight={0}
         flex="none"
+        size={size}
         {...restProps}
       >
-        <IconWrapper icon={icon} color="currentColor" size={iconSize} />
+        <IconWrapper
+          icon={icon}
+          color="currentColor"
+          size={iconSize || relativeIconSize}
+        />
       </Button>
     )
   })


### PR DESCRIPTION
## Overview
This fixes the `iconSize` that I messed up when I moved sizing into the theme modifiers. I don't love this, but it fixes the issue until we can think about dynamic/relative sizing.

## Screenshots (if applicable)
<img width="1792" alt="Screen Shot 2020-09-03 at 5 40 17 PM" src="https://user-images.githubusercontent.com/710752/92180559-f5dad900-ee0c-11ea-9e27-13c85c7b37b8.png">


## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
