### PR TITLE
Get rid of `css` prop on `<Pane />` by just composing classnames directly

### DIFF
--- a/docs/src/pages/get-started/v6-migration-guide.mdx
+++ b/docs/src/pages/get-started/v6-migration-guide.mdx
@@ -1,0 +1,27 @@
+import MigrationDocsLayout from '../../components/MigrationDocsLayout'
+
+export default MigrationDocsLayout
+
+## Evergreen v6 Migration Guide
+
+Evergreen v6 is one of the biggest releases of Evergreen yet. We've spent a lot of timing thinking about how to let consumers extend Evergreen,
+and as a result have made quite a few changes to how you might use it. Please follow the guide below, and reach out via GitHub Issues if there's anything
+that you're seeing that we might have missed!
+
+### Breaking Changes
+
+- [No more `css` prop on `<Pane />`](#css-pane)
+
+### innerRef no longer supported {#css-pane}
+
+Previously, `<Pane />` had a `css` prop, which allowed consumers to write arbitrary css styles (including composing pseudoselectors) and pass those
+through to the underlying `<Pane />` element.
+
+With this removed, we encourage either using the standard Evergreen components directly, or taking a CSS-in-JS route to adding those styles previously.
+
+```diff static
+ const MyComponent = () => {
+-  return <Pane css={ {':hover': { backgroundColor: 'red' }}} />
++  return <Pane className={backgroundRedClass} />
+ }
+```

--- a/docs/src/pages/get-started/v6-migration-guide.mdx
+++ b/docs/src/pages/get-started/v6-migration-guide.mdx
@@ -12,7 +12,7 @@ that you're seeing that we might have missed!
 
 - [No more `css` prop on `<Pane />`](#css-pane)
 
-### innerRef no longer supported {#css-pane}
+No more `css` prop on `<Pane />` {#css-pane}
 
 Previously, `<Pane />` had a `css` prop, which allowed consumers to write arbitrary css styles (including composing pseudoselectors) and pass those
 through to the underlying `<Pane />` element.

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -1,5 +1,6 @@
 import React, { memo, useState, useEffect, useCallback } from 'react'
 import { css } from 'glamor'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
 import { Pane, Card } from '../../layers'
@@ -117,6 +118,11 @@ const CornerDialog = memo(function CornerDialog(props) {
     return null
   }
 
+  const {
+    className: containerClassName,
+    ...remainingContainerProps
+  } = containerProps
+
   return (
     <Portal>
       <Transition
@@ -133,7 +139,7 @@ const CornerDialog = memo(function CornerDialog(props) {
             backgroundColor="white"
             elevation={4}
             width={width}
-            css={animationStyles}
+            className={cx(css(animationStyles).toString(), containerClassName)}
             data-state={state}
             padding={32}
             position="fixed"
@@ -142,7 +148,7 @@ const CornerDialog = memo(function CornerDialog(props) {
                 ? position
                 : positions.BOTTOM_RIGHT
             ]}
-            {...containerProps}
+            {...remainingContainerProps}
           >
             <Pane display="flex" alignItems="center" marginBottom={12}>
               <Heading is="h4" size={600} flex="1">

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -1,4 +1,5 @@
 import React, { memo } from 'react'
+import cx from 'classnames'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
@@ -184,6 +185,11 @@ const Dialog = memo(function Dialog({
     )
   }
 
+  const {
+    className: containerClassName,
+    remainingContainerProps
+  } = containerProps
+
   return (
     <Overlay
       isShown={isShown}
@@ -212,9 +218,9 @@ const Dialog = memo(function Dialog({
           marginY={topOffsetWithUnit}
           display="flex"
           flexDirection="column"
-          css={animationStyles}
+          className={cx(css(animationStyles).toString(), containerClassName)}
           data-state={state}
-          {...containerProps}
+          {...remainingContainerProps}
         >
           {renderHeader(close)}
 

--- a/src/layers/src/Pane.js
+++ b/src/layers/src/Pane.js
@@ -1,6 +1,6 @@
 import React, { memo, forwardRef } from 'react'
 import cx from 'classnames'
-import { css as glamorCss } from 'glamor'
+import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { useTheme } from '../../theme'
@@ -9,8 +9,6 @@ const StringAndBoolPropType = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.bool
 ])
-
-const emptyObject = {}
 
 const Pane = memo(
   forwardRef(function Pane(props, ref) {
@@ -27,7 +25,6 @@ const Pane = memo(
       borderBottom,
       borderLeft,
 
-      css = emptyObject,
       ...restProps
     } = props
     const theme = useTheme()
@@ -111,8 +108,7 @@ const Pane = memo(
 
     const className = cx(
       props.className,
-      glamorCss({
-        ...css,
+      css({
         ...hoverElevationStyle,
         ...activeElevationStyle
       }).toString()

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -156,7 +156,7 @@ const SideSheet = memo(function SideSheet(props) {
         <Pane
           width={width}
           {...paneProps[position]}
-          css={animationStylesClass[position]}
+          className={css(animationStylesClass[position]).toString()}
           data-state={state}
         >
           <SheetClose

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -1,6 +1,4 @@
 import React, { forwardRef, memo } from 'react'
-import cx from 'classnames'
-import { css as glamorCss } from 'glamor'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import useTextStyle from '../../theme/src/hooks/useTextStyle'
@@ -9,7 +7,6 @@ const Text = memo(
   forwardRef(function Text(props, ref) {
     const {
       className,
-      css,
       size = 400,
       color = 'default',
       fontFamily = 'ui',
@@ -23,7 +20,7 @@ const Text = memo(
         is="span"
         ref={ref}
         {...textStyle}
-        className={cx(className, css ? glamorCss(css).toString() : undefined)}
+        className={className}
         {...restProps}
       />
     )


### PR DESCRIPTION
## Overview 
This gets rid of the `css` prop on `<Pane />` which exposed the opportunity to add internals too easily. Instead, it generated glamor classnames at the callsite and composes any `containerProps` classnames with them. 

Unfortunately, I'd still like to get rid of the `containerProps` pattern, but I think that might be a bit away 😬 

## Screenshots (if applicable)
N/A internal change.

## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
