### PR TITLE
fixes select-menu keydown and keyup behaviour

### DIFF
--- a/docs/src/pages/components/menu.mdx
+++ b/docs/src/pages/components/menu.mdx
@@ -160,7 +160,7 @@ The `onSelect` handlers are omitted for brevity.
     <Menu>
       <Menu.Group title="Actions">
         <Menu.Item icon={PeopleIcon}>Share...</Menu.Item>
-        <Menu.Item icon={CircleArrowRight}>Move...</Menu.Item>
+        <Menu.Item icon={CircleArrowRightIcon}>Move...</Menu.Item>
         <Menu.Item icon={EditIcon} secondaryText="⌘R">
           Rename...
         </Menu.Item>

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -7,7 +7,7 @@ import { Text } from '../../typography'
 import { Pane } from '../../layers'
 import { TextInput } from '../../text-input'
 import { PeopleIcon } from '../../icons'
-import options, { optionsWithIcons } from './starwars-options'
+import options, { optionsWithIcons, disabledOptions } from './starwars-options'
 import Manager from './Manager'
 import { SelectMenu } from '..'
 
@@ -56,6 +56,20 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
             onSelect={item => setState({ selected: item.value })}
           >
             <Button>Options with icons</Button>
+          </SelectMenu>
+        )}
+      </Manager>
+    </Box>
+    <Box marginBottom={24}>
+      <Manager>
+        {({ setState, state }) => (
+          <SelectMenu
+            title="Select name"
+            options={disabledOptions}
+            selected={state.selected}
+            onSelect={item => setState({ selected: item.value })}
+          >
+            <Button>Disabled Options</Button>
           </SelectMenu>
         )}
       </Manager>

--- a/src/select-menu/stories/starwars-options.js
+++ b/src/select-menu/stories/starwars-options.js
@@ -11,3 +11,9 @@ export const optionsWithIcons = starWarsNames.all.map(name => ({
   icon:
     'https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Bananas_white_background_DS.jpg/2560px-Bananas_white_background_DS.jpg'
 }))
+
+export const disabledOptions = starWarsNames.all.map((name, index) => ({
+  label: name,
+  value: name,
+  disabled: [1,4,7].includes(index)
+}))


### PR DESCRIPTION
## Overview 

This PR fixes the following issues with Select Menu Dropdown

- Using keys, disabled items were also selectable. Now it skips the disabled items.
- Keydown events on select menu also triggers the background page scroll. Missing `e.preventDefault()`

It also fixes a bug on the website on the Menu component. An Icon was missing.

## Screenshots (if applicable)

https://www.loom.com/share/e65d0f14c0464029a5ecfb4cefddc1ff

## Testing

Local Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories

Also, I think the current behaviour of selecting menu items when as they get the focus through the keydown might not be great. For eg. if I just want to see all the options using the keydown key and not necessarily select them on the way, I can't do that.  if i want to select an item I should press spacebar or enter while the focus is on that item which is a common way how it is implemented. The current behaviour of selecting items as they get focus with keydown also introduces some issues when multi-select is on. Again, I could be wrong but let me know if a change in this behaviour could be a possibility in future.