### PR TITLE
remove unused getElevation from theme helpers

### DIFF
--- a/src/theme/src/themes/default/index.js
+++ b/src/theme/src/themes/default/index.js
@@ -43,13 +43,6 @@ import {
   inputs
 } from './component-specific'
 
-/**
- * Theme Helpers.
- * ---
- * These ARE REQUIRED for Evergreen to work.
- */
-import { getElevation } from './theme-helpers'
-
 export default {
   // Foundational Styles.
   colors,
@@ -62,8 +55,6 @@ export default {
   getTableCellClassName,
   getRowClassName,
   getMenuItemClassName,
-
-  getElevation,
 
   inputs,
   buttons,

--- a/src/theme/src/themes/default/theme-helpers/index.js
+++ b/src/theme/src/themes/default/theme-helpers/index.js
@@ -1,5 +1,5 @@
 import themedProperty from '../utils/themedProperty'
-import { colors, elevations } from '../foundational-styles'
+import { colors } from '../foundational-styles'
 import { fontFamilies, headings, paragraph, text } from '../typography'
 
 /**
@@ -69,18 +69,6 @@ const getBackground = background => {
    * Return one of theme presets or the original value.
    */
   return themedProperty(colors.background, background)
-}
-
-/**
- * Get box-shadow (elevation).
- * @param {string} level — level of elevation.
- * @return {string} elevation box-shadow.
- */
-const getElevation = level => {
-  /**
-   * There is no fallback, undefined will be returned.
-   */
-  return elevations[level]
 }
 
 /**
@@ -161,7 +149,6 @@ export {
   getIconSizeForSelect,
   getIconSizeForIconButton,
   getBackground,
-  getElevation,
   getIconColor,
   getHeadingStyle,
   getTextStyle,

--- a/src/theme/src/themes/v5/index.js
+++ b/src/theme/src/themes/v5/index.js
@@ -46,13 +46,6 @@ import {
   segmentedControl
 } from './component-specific'
 
-/**
- * Theme Helpers.
- * ---
- * These ARE REQUIRED for Evergreen to work.
- */
-import { getElevation } from './theme-helpers'
-
 export default {
   // Foundational Styles.
   colors,
@@ -66,10 +59,6 @@ export default {
   getTableCellClassName,
   getRowClassName,
   getMenuItemClassName,
-
-  // Theme Helpers.
-
-  getElevation,
 
   // Component-specific
   buttons,

--- a/src/theme/src/themes/v5/theme-helpers/index.js
+++ b/src/theme/src/themes/v5/theme-helpers/index.js
@@ -1,5 +1,5 @@
 import themedProperty from '../utils/themedProperty'
-import { colors, elevations } from '../foundational-styles'
+import { colors } from '../foundational-styles'
 import { fontFamilies, headings, paragraph, text } from '../typography'
 
 /**
@@ -69,18 +69,6 @@ const getBackground = background => {
    * Return one of theme presets or the original value.
    */
   return themedProperty(colors.background, background)
-}
-
-/**
- * Get box-shadow (elevation).
- * @param {string} level — level of elevation.
- * @return {string} elevation box-shadow.
- */
-const getElevation = level => {
-  /**
-   * There is no fallback, undefined will be returned.
-   */
-  return elevations[level]
 }
 
 /**
@@ -161,7 +149,6 @@ export {
   getIconSizeForSelect,
   getIconSizeForIconButton,
   getBackground,
-  getElevation,
   getIconColor,
   getHeadingStyle,
   getTextStyle,


### PR DESCRIPTION
## Overview
This PR removes `getElevation` which is no longer used by the theme.

## Screenshots (if applicable)
NA

## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
