### PR TITLE
Move table cell appearance over to `useStyleConfig` and avoid exposing on the main API

### DIFF
--- a/src/table/src/TableCell.js
+++ b/src/table/src/TableCell.js
@@ -2,10 +2,10 @@ import React, { memo, forwardRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { toaster } from '../../toaster'
-import { useTheme } from '../../theme'
 import { Pane } from '../../layers'
 import safeInvoke from '../../lib/safe-invoke'
 import { useMergedRef } from '../../hooks'
+import useTableCellAppearance from '../../theme/src/hooks/useTableCellAppearance'
 import { TableRowConsumer } from './TableRowContext'
 import manageTableCellFocusInteraction from './manageTableCellFocusInteraction'
 
@@ -43,19 +43,9 @@ const TableCell = memo(
       arrowKeysOverrides,
       ...rest
     } = props
-    const theme = useTheme()
+
     const [cellRef, setCellRef] = useState(null)
     const handleRef = useMergedRef(setCellRef, forwardedRef)
-
-    const styles = {
-      paddingX: 12,
-      boxSizing: 'border-box',
-      flex: 1,
-      display: 'flex',
-      alignItems: 'center',
-      flexShrink: 0,
-      overflow: 'hidden'
-    }
 
     const handleKeyDown = e => {
       const { arrowKeysOverrides = {} } = props
@@ -89,7 +79,11 @@ const TableCell = memo(
       safeInvoke(onKeyDown, e)
     }
 
-    const themedClassName = theme.getTableCellClassName(appearance)
+    const { boxProps, className: themedClassName } = useTableCellAppearance({
+      appearance
+    })
+
+    console.log(boxProps, themedClassName)
 
     return (
       <TableRowConsumer>
@@ -103,7 +97,7 @@ const TableCell = memo(
               data-isselectable={isSelectable}
               onClick={onClick}
               onKeyDown={handleKeyDown}
-              {...styles}
+              {...boxProps}
               {...rest}
             >
               {children}

--- a/src/table/src/TableCell.js
+++ b/src/table/src/TableCell.js
@@ -83,8 +83,6 @@ const TableCell = memo(
       appearance
     })
 
-    console.log(boxProps, themedClassName)
-
     return (
       <TableRowConsumer>
         {height => {

--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -75,7 +75,7 @@ storiesOf('table', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <Table.Cell>Table.Cell</Table.Cell>
+      <Table.Cell isSelectable>Table.Cell</Table.Cell>
     </Box>
   ))
   .add('Table.TextCell', () => (

--- a/src/theme/src/components/table-cell.js
+++ b/src/theme/src/components/table-cell.js
@@ -1,0 +1,23 @@
+export default function getTableCellStyles(theme) {
+  const { tokens } = theme
+  return {
+    baseStyle: {
+      paddingX: 12,
+      boxSizing: 'border-box',
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      flexShrink: 0,
+      overflow: 'hidden'
+    },
+    appearances: {
+      default: {
+        _focus: {
+          outline: 'none',
+          background: tokens.colors.blue50,
+          boxShadow: `inset 0 0 0 1px ${tokens.colors.blue500}`
+        }
+      }
+    }
+  }
+}

--- a/src/theme/src/hooks/useTableCellAppearance.js
+++ b/src/theme/src/hooks/useTableCellAppearance.js
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import useStyleConfig from '../../../hooks/use-style-config'
+import getTableCellStyles from '../components/table-cell'
+import useTheme from '../useTheme'
+
+const pseudoSelectors = {
+  _focus:
+    '&[data-isselectable="true"]:focus, &[aria-expanded="true"][aria-haspopup="true"]'
+}
+
+function useTableCellAppearance(modifiers, internalStyles = {}) {
+  const theme = useTheme()
+  const tableCellStyles = useMemo(() => getTableCellStyles(theme), [theme])
+
+  return useStyleConfig(
+    tableCellStyles,
+    modifiers,
+    pseudoSelectors,
+    internalStyles
+  )
+}
+
+export default useTableCellAppearance

--- a/src/theme/src/themes/default/index.js
+++ b/src/theme/src/themes/default/index.js
@@ -36,19 +36,11 @@ import { headings, text, fontFamilies, paragraph } from './typography'
  * These ARE REQUIRED for Evergreen to work.
  */
 import {
-  getTableCellClassName,
   getRowClassName,
   getMenuItemClassName,
   buttons,
   inputs
 } from './component-specific'
-
-/**
- * Theme Helpers.
- * ---
- * These ARE REQUIRED for Evergreen to work.
- */
-import { getElevation } from './theme-helpers'
 
 export default {
   // Foundational Styles.
@@ -59,11 +51,8 @@ export default {
   scales,
   tokens,
 
-  getTableCellClassName,
   getRowClassName,
   getMenuItemClassName,
-
-  getElevation,
 
   inputs,
   buttons,

--- a/src/theme/src/themes/v5/index.js
+++ b/src/theme/src/themes/v5/index.js
@@ -36,7 +36,6 @@ import { headings, text, fontFamilies, paragraph } from './typography'
  * These ARE REQUIRED for Evergreen to work.
  */
 import {
-  getTextDropdownButtonClassName,
   getTableCellClassName,
   getRowClassName,
   getMenuItemClassName,
@@ -45,13 +44,6 @@ import {
   inputs,
   segmentedControl
 } from './component-specific'
-
-/**
- * Theme Helpers.
- * ---
- * These ARE REQUIRED for Evergreen to work.
- */
-import { getElevation } from './theme-helpers'
 
 export default {
   // Foundational Styles.
@@ -62,14 +54,9 @@ export default {
   scales,
   tokens,
 
-  getTextDropdownButtonClassName,
   getTableCellClassName,
   getRowClassName,
   getMenuItemClassName,
-
-  // Theme Helpers.
-
-  getElevation,
 
   // Component-specific
   buttons,


### PR DESCRIPTION
##  Overview
Title, and updates some of the selectable table styles, too -- we can revisit these once we see what they look like on a broader scale. 

## Screenshots (if applicable)

## Testing
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
