### PR TITLE
Fix TextArea issue from migrating to Box from Text

### DIFF
--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -1,7 +1,7 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import Box from 'ui-box'
+import Box, { spacing, dimensions, position, layout } from 'ui-box'
 import { minorScale } from '../../scales'
 import useInputAppearance from '../../theme/src/hooks/useInputAppearance'
 
@@ -53,9 +53,24 @@ const Textarea = memo(
 
 Textarea.propTypes = {
   /**
-   * Composes the Text component as the base.
+   * Composes the dimensions spec from the Box primitive.
    */
-  ...Text.propTypes,
+  ...dimensions.propTypes,
+
+  /**
+   * Composes the spacing spec from the Box primitive.
+   */
+  ...spacing.propTypes,
+
+  /**
+   * Composes the position spec from the Box primitive.
+   */
+  ...position.propTypes,
+
+  /**
+   * Composes the layout spec from the Box primitive.
+   */
+  ...layout.propTypes,
 
   /**
    * Makes the textarea element required.


### PR DESCRIPTION
<!--
# 🎉 Thanks for taking the time to contribute to 🌲Evergreen! 🎉

It is highly appreciated that you take the time to help improve Evergreen.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.
-->

## Overview
Fix an issue where we are still referencing the `Text` component in `Textarea` and not using `Box` types

## Screenshots (if applicable)
n/a

## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
