### PR TITLE
move InlineAlert to new theming

### DIFF
--- a/src/alert/src/InlineAlert.js
+++ b/src/alert/src/InlineAlert.js
@@ -1,36 +1,51 @@
 import React, { memo, forwardRef } from 'react'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { spacing, dimensions, position, layout } from 'ui-box'
 import { Pane } from '../../layers'
 import { Text } from '../../typography'
-import { useTheme } from '../../theme'
+import useStyleConfig from '../../hooks/use-style-config'
 import { getIconForIntent } from './getIconForIntent'
+
+const pseudoSelectors = {}
+
+const internalStyles = {
+  display: 'flex',
+  alignItems: 'center'
+}
 
 const InlineAlert = memo(
   forwardRef(function InlineAlert(props, ref) {
     const {
       children,
-      intent = 'none',
+      className,
+      intent = 'info',
       hasIcon = true,
       size = 400,
       ...restProps
     } = props
 
-    const {
-      tokens: { intents }
-    } = useTheme()
-
     const intentToken = intent === 'none' ? 'info' : intent
-    const textColor = intents[intentToken].text
+    const { className: themedClassName, ...styleProps } = useStyleConfig(
+      'InlineAlert',
+      { intent: intentToken },
+      pseudoSelectors,
+      internalStyles
+    )
 
     return (
-      <Pane ref={ref} alignItems="center" display="flex" {...restProps}>
+      <Pane
+        ref={ref}
+        className={cx(className, themedClassName)}
+        {...styleProps}
+        {...restProps}
+      >
         {hasIcon && (
           <Pane display="flex" marginRight={16}>
             {getIconForIntent(intent, { size: 16 })}
           </Pane>
         )}
-        <Text size={size} lineHeight={1} fontWeight={500} color={textColor}>
+        <Text size={size} lineHeight={1} fontWeight={500} color="inherit">
           {children}
         </Text>
       </Pane>

--- a/src/themes/classic/components/index.js
+++ b/src/themes/classic/components/index.js
@@ -2,6 +2,7 @@ import Alert from './alert'
 import Button from './button'
 import Code from './code'
 import Icon from './icon'
+import InlineAlert from './inline-alert'
 import Pane from './pane'
 import Select from './select'
 import Tooltip from './tooltip'
@@ -11,6 +12,7 @@ export default {
   Button,
   Code,
   Icon,
+  InlineAlert,
   Pane,
   Select,
   Tooltip

--- a/src/themes/classic/components/inline-alert.js
+++ b/src/themes/classic/components/inline-alert.js
@@ -1,0 +1,12 @@
+const baseStyle = {
+  color: 'colors.default'
+}
+
+const appearances = {}
+const sizes = {}
+
+export default {
+  baseStyle,
+  appearances,
+  sizes
+}

--- a/src/themes/default/components/index.js
+++ b/src/themes/default/components/index.js
@@ -2,6 +2,7 @@ import Alert from './alert'
 import Button from './button'
 import Code from './code'
 import Icon from './icon'
+import InlineAlert from './inline-alert'
 import Pane from './pane'
 import Select from './select'
 import Tooltip from './tooltip'
@@ -11,6 +12,7 @@ export default {
   Button,
   Code,
   Icon,
+  InlineAlert,
   Pane,
   Select,
   Tooltip

--- a/src/themes/default/components/inline-alert.js
+++ b/src/themes/default/components/inline-alert.js
@@ -1,0 +1,12 @@
+const baseStyle = (theme, { intent = 'info' }) => ({
+  color: theme.intents[intent].text
+})
+
+const appearances = {}
+const sizes = {}
+
+export default {
+  baseStyle,
+  appearances,
+  sizes
+}


### PR DESCRIPTION
## Overview
This PR moves `InlineAlert` to the new theming

## Screenshots (if applicable)
<img width="446" alt="Screen Shot 2020-09-11 at 2 08 07 PM" src="https://user-images.githubusercontent.com/710752/92971814-c6e4e880-f446-11ea-8071-5b81d8d2fb66.png">
<img width="443" alt="Screen Shot 2020-09-11 at 2 08 11 PM" src="https://user-images.githubusercontent.com/710752/92971816-c77d7f00-f446-11ea-8e67-76deca5283c9.png">


## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
