### PR TITLE
fix IconButton in v5/v6

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -168,7 +168,7 @@ Button.propTypes = {
 
   /**
    * Forcefully set the active state of a button.
-   * Useful in conjuction with a Popover.
+   * Useful in conjunction with a Popover.
    */
   isActive: PropTypes.bool,
 

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -11,19 +11,21 @@ import Button, {
 
 const IconButton = memo(
   forwardRef(function IconButton(props, ref) {
-    const { icon, iconSize, size = 'medium', ...restProps } = props
+    const { icon, iconSize, ...restProps } = props
+
+    // modifiers
+    const { appearance, intent, size = 'medium' } = props
 
     // Composes the exact same styles as button
     const styleProps = useStyleConfig(
       'Button',
-      { appearance: restProps.appearance, intent: restProps.intent, size },
+      { appearance, intent, size },
       pseudoSelectors,
       internalStyles
     )
 
-    const relativeIconSize = getIconSizeForButton(
-      restProps.height || styleProps.height
-    )
+    const height = restProps.height || styleProps.height
+    const relativeIconSize = getIconSizeForButton(height)
 
     return (
       <Button
@@ -31,7 +33,9 @@ const IconButton = memo(
         paddingLeft={0}
         paddingRight={0}
         flex="none"
-        size={size}
+        height={height}
+        width={height}
+        minWidth={height}
         {...restProps}
       >
         <IconWrapper

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -11,25 +11,18 @@ import Button, {
 
 const IconButton = memo(
   forwardRef(function IconButton(props, ref) {
-    const {
-      icon,
-      iconSize,
-      size = 'medium',
-      intent,
-      appearance,
-      ...restProps
-    } = props
+    const { icon, iconSize, size = 'medium', ...restProps } = props
 
     // Composes the exact same styles as button
-    const { className: themedClassName, ...boxProps } = useStyleConfig(
+    const styleProps = useStyleConfig(
       'Button',
-      { appearance, intent, size },
+      { appearance: restProps.appearance, intent: restProps.intent, size },
       pseudoSelectors,
       internalStyles
     )
 
     const relativeIconSize = getIconSizeForButton(
-      restProps.height || boxProps.height
+      restProps.height || styleProps.height
     )
 
     return (
@@ -99,7 +92,7 @@ IconButton.propTypes = {
 
   /**
    * Forcefully set the active state of a button.
-   * Useful in conjuction with a Popover.
+   * Useful in conjunction with a Popover.
    */
   isActive: PropTypes.bool,
 

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -156,7 +156,6 @@ const CornerDialog = memo(function CornerDialog(props) {
               </Heading>
               {hasClose && (
                 <IconButton
-                  height={32}
                   icon={CrossIcon}
                   appearance="minimal"
                   onClick={handleClose}

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -24,7 +24,7 @@ const DefaultTitleView = ({ close, title, headerHeight }) => (
     <IconButton
       icon={CrossIcon}
       appearance="minimal"
-      height={24}
+      size="small"
       onClick={close}
       border="none"
     />

--- a/src/table/stories/AdvancedTable.js
+++ b/src/table/stories/AdvancedTable.js
@@ -242,7 +242,7 @@ export default class AdvancedTable extends React.Component {
             content={this.renderRowMenu}
             position={Position.BOTTOM_RIGHT}
           >
-            <IconButton icon={MoreIcon} height={24} appearance="minimal" />
+            <IconButton icon={MoreIcon} size="small" appearance="minimal" />
           </Popover>
         </Table.Cell>
       </Table.Row>


### PR DESCRIPTION
## Overview
This fixes the IconButton appearance/intent for v6 and v5 theming

## Screenshots (if applicable)
<img width="1792" alt="Screen Shot 2020-09-11 at 6 28 10 PM" src="https://user-images.githubusercontent.com/710752/92980631-98720800-f45c-11ea-9efa-3b3adb87c744.png">
<img width="1792" alt="Screen Shot 2020-09-11 at 6 28 13 PM" src="https://user-images.githubusercontent.com/710752/92980632-98720800-f45c-11ea-9d1c-5c07fe8bb93c.png">


## Testing

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
