### PR TITLE
Clear up tooltip timeouts on mouse leave

### DIFF
--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -35,6 +35,8 @@ const Tooltip = memo(function Tooltip(props) {
 
   const hide = () => {
     setIsShown(false)
+    // Clean up any timeouts that may have been triggered from `showDelay`
+    clearTimeout(closeTimeout)
   }
 
   const handleHide = debounce(hide, hideDelay)


### PR DESCRIPTION
**Overview**
Fixes up the issue over in https://github.com/segmentio/evergreen/issues/996. Basically, when a mouse leaves the tooltip, we don't cleanup the timeout set for `showDelay`. The tooltip then mounts, but a user has to re-enter and re-leave the target. 

This PR just adds a one-line fix to cleanup any delay timeouts on hide (on mouse leave)


**Screenshots (if applicable)**
Check the loom below - when the mouse stays on the target for the duration of the `showDelay`, the tooltip shows. Otherwise, briefly hovering over the target doesn't trigger the tooltip at all. 

https://www.loom.com/share/2ddc53903c914ade9ab44469b8e4e4bc


**Documentation**

<!-- If your change impacts component behavior or usage please be sure to include appropriate documentation and types! -->

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
