### PR TITLE
Update Dialog "title" prop type in declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -766,7 +766,7 @@ export interface DialogProps {
   /**
    * Title of the Dialog. Titles should use Title Case.
    */
-  title?: string
+  title?: string | React.ReactNode
   /**
    * When true, the header with the title and close icon button is shown.
    * Defaults to true.

--- a/index.d.ts
+++ b/index.d.ts
@@ -766,7 +766,7 @@ export interface DialogProps {
   /**
    * Title of the Dialog. Titles should use Title Case.
    */
-  title?: string | React.ReactNode
+  title?: React.ReactNode
   /**
    * When true, the header with the title and close icon button is shown.
    * Defaults to true.


### PR DESCRIPTION
**Overview**
This PR introduces a 1-line change in the declaration file to match the [expected](https://github.com/segmentio/evergreen/blob/master/src/dialog/src/Dialog.js#L254) `title` prop type of the `<Dialog />` component.


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
