### PR TITLE
tweak input styles

### DIFF
--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-kkuc82 evergreen-file-picker-text-input ub-w_280px ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-fnt-fam_b77syt ub-ln-ht_12px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-box-szg_border-box"
+    className="css-1ooeapk evergreen-file-picker-text-input ub-w_280px ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-fnt-fam_b77syt ub-ln-ht_12px ub-color_474d66 ub-tstn_n1akt6 ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"

--- a/src/themes/classic/components/input.js
+++ b/src/themes/classic/components/input.js
@@ -1,7 +1,17 @@
 const baseStyle = {
   borderRadius: 'radii.1',
   fontFamily: 'fontFamilies.ui',
-  lineHeight: '12px'
+  lineHeight: '12px',
+  color: 'colors.default',
+
+  _placeholder: {
+    color: 'colors.neutralAlpha.N6A'
+  },
+
+  _disabled: {
+    cursor: 'not-allowed',
+    backgroundColor: 'colors.neutralAlpha.N2'
+  }
 }
 
 const appearances = {
@@ -14,18 +24,12 @@ const appearances = {
       boxShadow: theme =>
         `inset 0 0 0 1px ${theme.palette.red.base}, inset 0 1px 2px ${theme.scales.neutral.N4A}`
     },
-    _placeholder: {
-      color: 'scales.neutral.N6A'
-    },
     _focus: {
-      outline: 'none',
       boxShadow: theme =>
         `inset 0 0 2px ${theme.scales.neutral.N4A}, inset 0 0 0 1px ${theme.scales.blue.B7}, ${theme.shadows.focusRing}`
     },
     _disabled: {
-      cursor: 'not-allowed',
-      boxShadow: theme => `inset 0 0 0 1px ${theme.scales.neutral.N4A}`,
-      backgroundColor: 'scales.neutral.N2'
+      boxShadow: theme => `inset 0 0 0 1px ${theme.scales.neutral.N4A}`
     }
   },
   neutral: {
@@ -33,33 +37,16 @@ const appearances = {
     _invalid: {
       boxShadow: theme => `inset 0 0 0 1px ${theme.palette.red.base}`
     },
-    _placeholder: {
-      color: 'scales.neutral.N6A'
-    },
     _focus: {
-      outline: 'none',
       backgroundColor: 'white',
       boxShadow: theme => `0 0 0 2px ${theme.scales.blue.B6A}`
     },
     _disabled: {
-      cursor: 'not-allowed',
-      boxShadow: theme => `inset 0 0 0 1px ${theme.scales.neutral.N4A}`,
-      backgroundColor: 'scales.neutral.N2'
+      boxShadow: theme => `inset 0 0 0 1px ${theme.scales.neutral.N4A}`
     }
   },
   none: {
-    backgroundColor: 'white',
-    _invalid: {},
-    _placeholder: {
-      color: 'scales.neutral.N6A'
-    },
-    _focus: {
-      outline: 'none'
-    },
-    _disabled: {
-      cursor: 'not-allowed',
-      backgroundColor: 'scales.neutral.N2'
-    }
+    backgroundColor: 'white'
   }
 }
 

--- a/src/themes/classic/components/input.js
+++ b/src/themes/classic/components/input.js
@@ -11,6 +11,10 @@ const baseStyle = {
   _disabled: {
     cursor: 'not-allowed',
     backgroundColor: 'colors.neutralAlpha.N2'
+  },
+
+  _focus: {
+    zIndex: 'zIndices.focused'
   }
 }
 
@@ -18,31 +22,31 @@ const appearances = {
   default: {
     backgroundColor: 'white',
     boxShadow: theme =>
-      `inset 0 0 0 1px ${theme.scales.neutral.N5A}, inset 0 1px 2px ${theme.scales.neutral.N4A}`,
+      `inset 0 0 0 1px ${theme.colors.neutralAlpha.N5A}, inset 0 1px 2px ${theme.colors.neutralAlpha.N4A}`,
 
     _invalid: {
       boxShadow: theme =>
-        `inset 0 0 0 1px ${theme.palette.red.base}, inset 0 1px 2px ${theme.scales.neutral.N4A}`
+        `inset 0 0 0 1px ${theme.colors.red.base}, inset 0 1px 2px ${theme.colors.neutralAlpha.N4A}`
     },
     _focus: {
       boxShadow: theme =>
-        `inset 0 0 2px ${theme.scales.neutral.N4A}, inset 0 0 0 1px ${theme.scales.blue.B7}, ${theme.shadows.focusRing}`
+        `inset 0 0 2px ${theme.colors.neutralAlpha.N4A}, inset 0 0 0 1px ${theme.colors.blue.B7}, ${theme.shadows.focusRing}`
     },
     _disabled: {
-      boxShadow: theme => `inset 0 0 0 1px ${theme.scales.neutral.N4A}`
+      boxShadow: theme => `inset 0 0 0 1px ${theme.colors.neutralAlpha.N4A}`
     }
   },
   neutral: {
-    backgroundColor: 'scales.neutral.N2A',
+    backgroundColor: 'colors.neutralAlpha.N2A',
     _invalid: {
-      boxShadow: theme => `inset 0 0 0 1px ${theme.palette.red.base}`
+      boxShadow: theme => `inset 0 0 0 1px ${theme.colors.red.base}`
     },
     _focus: {
       backgroundColor: 'white',
-      boxShadow: theme => `0 0 0 2px ${theme.scales.blue.B6A}`
+      boxShadow: theme => `0 0 0 2px ${theme.colors.blueAlpha.B6A}`
     },
     _disabled: {
-      boxShadow: theme => `inset 0 0 0 1px ${theme.scales.neutral.N4A}`
+      boxShadow: theme => `inset 0 0 0 1px ${theme.colors.neutralAlpha.N4A}`
     }
   },
   none: {

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -2,7 +2,24 @@ const baseStyle = {
   borderRadius: 'radii.1',
   fontFamily: 'fontFamilies.ui',
   lineHeight: '12px',
-  border: '1px solid transparent'
+  border: '1px solid transparent',
+  color: 'colors.default',
+  transition: 'box-shadow 80ms ease-in-out',
+
+  _placeholder: {
+    color: 'colors.gray600'
+  },
+
+  _disabled: {
+    cursor: 'not-allowed',
+    backgroundColor: 'colors.gray100',
+    color: 'colors.muted'
+  },
+
+  _focus: {
+    zIndex: 'zIndices.focused',
+    boxShadow: 'shadows.focusRing'
+  }
 }
 
 const appearances = {
@@ -15,21 +32,10 @@ const appearances = {
     },
 
     _focus: {
-      outline: 'none',
       transition: 'box-shadow 80ms ease-in-out',
       zIndex: 'zIndices.focused',
       borderColor: 'colors.blue200',
       boxShadow: 'shadows.focusRing'
-    },
-
-    _disabled: {
-      cursor: 'not-allowed',
-      backgroundColor: 'colors.gray100',
-      color: 'colors.muted'
-    },
-
-    _placeholder: {
-      color: 'colors.gray600'
     },
 
     _placeholderHover: {
@@ -37,19 +43,7 @@ const appearances = {
     }
   },
   none: {
-    backgroundColor: 'transparent',
-    _invalid: {},
-    _placeholder: {
-      color: 'colors.gray600'
-    },
-    _focus: {
-      outline: 'none'
-    },
-    _disabled: {
-      cursor: 'not-allowed',
-      backgroundColor: 'colors.gray100',
-      color: 'colors.muted'
-    }
+    backgroundColor: 'transparent'
   }
 }
 


### PR DESCRIPTION
<!---

Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).

--->

**Overview**
While looking at Autocomplete I noticed some of the font styles were off across all inputs. Fixed!
<!-- A clear description of the what and *why* of this code change. -->


**Screenshots (if applicable)**
<img width="366" alt="Screen Shot 2020-09-14 at 2 15 08 PM" src="https://user-images.githubusercontent.com/710752/93128219-c5a8fb00-f694-11ea-9241-9d10beb8d442.png">
<img width="335" alt="Screen Shot 2020-09-14 at 2 15 21 PM" src="https://user-images.githubusercontent.com/710752/93128221-c5a8fb00-f694-11ea-8daf-c4f3f28640a1.png">


<!-- Please provide screenshots or gifs showing the change in action -->


**Documentation**

<!-- If your change impacts component behavior or usage please be sure to include appropriate documentation and types! -->

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
