### PR TITLE
Fix error caused when bringFocusInside is called outside an event han…

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -63,7 +63,7 @@ const Popover = memo(
      * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
      */
     const bringFocusInside = useCallback((e) => {
-      if(isShown) {
+      if(isShown && e) {
         e.preventDefault()
       }
       // Always delay focus manipulation to just before repaint to prevent scroll jumping


### PR DESCRIPTION

<!---

Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).

--->

**Overview**
Resolves an error caused by calling `bringFocusInside` outside an event handler


**Screenshots (if applicable)**
n/a
<!-- Please provide screenshots or gifs showing the change in action -->


**Documentation**

<!-- If your change impacts component behavior or usage please be sure to include appropriate documentation and types! -->

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
