### PR TITLE
Update Text, Paragraph to be aware of `fontFamily` and `color`

### DIFF
--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -4,20 +4,20 @@ import { ThemeConsumer, Pane, Heading, Text, Paragraph } from 'evergreen-ui'
 
 ## Text components
 
-- [**Heading**](#heading_heading_component): used for headings. A `h2` element by default.
-- [**Text**](#heading_text_component): used for single line text. A `span` element by default.
-- [**Paragraph**](#heading_paragraph_component): used for multiline text. A `p` element by default.
-- [**Link**](#heading_link_component): used for links. A `a` element by default.
-- [**Strong**](#heading_strong_component): used to make text strong. A `strong` element by default.
-- [**Small**](#heading_small_component): used for inline small text. A `small` element by default.
-- [**Pre**](#heading_pre_component): used for preformatted content. A `pre` element by default.
-- [**Code**](#heading_code_component): used for inline code. A `code` element by default.
+* [**Heading**](#heading_heading_component): used for headings. A `h2` element by default.
+* [**Text**](#heading_text_component): used for single line text. A `span` element by default.
+* [**Paragraph**](#heading_paragraph_component): used for multiline text. A `p` element by default.
+* [**Link**](#heading_link_component): used for links. A `a` element by default.
+* [**Strong**](#heading_strong_component): used to make text strong. A `strong` element by default.
+* [**Small**](#heading_small_component): used for inline small text. A `small` element by default.
+* [**Pre**](#heading_pre_component): used for preformatted content. A `pre` element by default.
+* [**Code**](#heading_code_component): used for inline code. A `code` element by default.
 
 ## List components
 
-- [**OrderedList**](#heading_orderedlist_component): used for ordered lists. A `ol` element.
-- [**UnorderedList**](#heading_unorderedlist_component): used for unordered lists. A `ul` element.
-- [**ListItem**](#heading_listitem_component): used as the list item in either an unordered list, or ordered list. A `li` element.
+* [**OrderedList**](#heading_orderedlist_component): used for ordered lists. A `ol` element.
+* [**UnorderedList**](#heading_unorderedlist_component): used for unordered lists. A `ul` element.
+* [**ListItem**](#heading_listitem_component): used as the list item in either an unordered list, or ordered list. A `li` element.
 
 ## Font families
 
@@ -25,14 +25,15 @@ Evergreen uses three font family stacks, `ui`, `display` and `mono`.
 Text components will set the font family accordingly to their use case.
 There is not need for you to override this on a component level.
 
+
 <ThemeConsumer>
-  {(theme) => (
+  {theme => (
     <div>
       <Pane marginTop={48}>
         <h2 className="heading h2">Heading Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {Object.keys(theme.typography.headings).map((size) => {
+        {Object.keys(theme.typography.headings).map(size => {
           return (
             <TextStylePreview
               key={size}
@@ -50,7 +51,7 @@ There is not need for you to override this on a component level.
         <h2 className="heading h2">Text Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {Object.keys(theme.typography.text).map((size) => {
+        {Object.keys(theme.typography.text).map(size => {
           return (
             <TextStylePreview
               key={size}
@@ -69,7 +70,7 @@ There is not need for you to override this on a component level.
         <h2 className="heading h2">Paragraph Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {[300, 400, 500].map((size) => {
+        {[300, 400, 500].map(size => {
           return (
             <TextStylePreview
               key={size}
@@ -78,8 +79,8 @@ There is not need for you to override this on a component level.
                 return (
                   <Paragraph size={size}>
                     Paragraph {size}. Lorem ipsum dolor sit amet, consectetur
-                    adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                    et dolore magna aliqua.
+                    adipiscing elit, sed do eiusmod tempor incididunt ut
+                    labore et dolore magna aliqua.
                   </Paragraph>
                 )
               }}
@@ -102,15 +103,15 @@ The size options are: `100`, `200`, `300`, `400`, `500` (default), `600`, `700`,
 
 ```jsx
 <Pane>
-  <Heading size={100}>100: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={200}>200: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={300}>300: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={400}>400: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={500}>500: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={600}>600: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={700}>700: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={800}>800: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={900}>900: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={100} marginTop="default">100: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={200} marginTop="default">200: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={300} marginTop="default">300: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={400} marginTop="default">400: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={500} marginTop="default">500: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={600} marginTop="default">600: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={700} marginTop="default">700: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={800} marginTop="default">800: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={900} marginTop="default">900: The quick brown fox jumps over the lazy dog</Heading>
 </Pane>
 ```
 
@@ -125,13 +126,14 @@ It’s important to realize that the style of a heading is independent from the 
 
 <PropsTable of="Heading" />
 
+
 # Text component
 
 The `Text` component is used for single line text.
 The component renders a `span` element by default.
 If you need a multiline paragraph use the `Paragraph` component.
 
-The size options are: `300`, `400` (default), `500`
+The size options are:  `300`, `400` (default), `500`
 
 ```jsx
 <div>
@@ -153,41 +155,24 @@ The size options are: `300`, `400` (default), `500`
 <Text color="muted">The quick brown fox jumps over the lazy dog</Text>
 ```
 
+
 # Paragraph component
 
 The `Paragraph` component is used for multiline text.
 This renders a `p` element by default.
 
-The size options are: `300`, `400` (default), `500`
+The size options are:  `300`, `400` (default), `500`
 
 ```jsx
 <div>
   <Paragraph size={300} marginTop="default">
-    Size 300. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-    est laborum.
+    Size 300. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </Paragraph>
   <Paragraph size={400} marginTop="default">
-    Size 400. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-    est laborum.
+    Size 400. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </Paragraph>
   <Paragraph marginTop="default">
-    Size 500. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-    est laborum.
+    Size 500. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </Paragraph>
 </div>
 ```
@@ -196,38 +181,26 @@ The size options are: `300`, `400` (default), `500`
 
 ```jsx
 <Paragraph color="muted">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
-  eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-  in culpa qui officia deserunt mollit anim id est laborum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </Paragraph>
 ```
 
 <PropsTable of="Paragraph" />
+
 
 # Link component
 
 The `Link` component is used for anchor links.
 This component renders a `a` element by default.
 
-The size options are: `300`, `400` (default), `500`
+The size options are:  `300`, `400` (default), `500`
 
 ```jsx
 <div>
-  <Link href="#" marginRight={12}>
-    Default
-  </Link>
-  <Link href="#" marginRight={12} color="green">
-    Green
-  </Link>
-  <Link href="#" marginRight={12} color="blue">
-    Blue
-  </Link>
-  <Link href="#" marginRight={12} color="neutral">
-    Neutral
-  </Link>
+  <Link href="#" marginRight={12}>Default</Link>
+  <Link href="#" marginRight={12} color="green">Green</Link>
+  <Link href="#" marginRight={12} color="blue">Blue</Link>
+  <Link href="#" marginRight={12} color="neutral">Neutral</Link>
 </div>
 ```
 
@@ -254,6 +227,7 @@ Make sure to set the `size` property if you are using this within a other text c
 ```
 
 <PropsTable of="Strong" />
+
 
 # Small component
 
@@ -283,19 +257,13 @@ The `Code` component is based on the `Text` component but renders a `code` eleme
     <Code size={500}>The quick brown fox jumps over the lazy dog</Code>
   </div>
   <div>
-    <Code size={300} appearance="minimal">
-      The quick brown fox jumps over the lazy dog
-    </Code>
+    <Code size={300} appearance="minimal">The quick brown fox jumps over the lazy dog</Code>
   </div>
   <div>
-    <Code size={400} appearance="minimal">
-      The quick brown fox jumps over the lazy dog
-    </Code>
+    <Code size={400} appearance="minimal">The quick brown fox jumps over the lazy dog</Code>
   </div>
   <div>
-    <Code size={500} appearance="minimal">
-      The quick brown fox jumps over the lazy dog
-    </Code>
+    <Code size={500} appearance="minimal">The quick brown fox jumps over the lazy dog</Code>
   </div>
 </div>
 ```
@@ -307,8 +275,11 @@ The `Code` component is based on the `Text` component but renders a `code` eleme
 The `Pre` component renders a chunk of preformatted text.
 This component renders a `pre` element by default.
 
+
 ```jsx
-<Pre>Preformatted text.</Pre>
+<Pre>
+  Preformatted text.
+</Pre>
 ```
 
 <PropsTable of="Pre" />
@@ -336,6 +307,7 @@ This component renders a `pre` element by default.
 </UnorderedList>
 ```
 
+
 ## Adding icons to a list
 
 The icon property has access to all available icons.
@@ -343,7 +315,10 @@ The icon property has access to all available icons.
 ### Set icons for all list items on the list
 
 ```jsx
-<UnorderedList icon={TickIcon} iconColor="success">
+<UnorderedList
+  icon={TickIcon}
+  iconColor="success"
+>
   <ListItem>Lorem ipsum dolar set amet</ListItem>
   <ListItem>Lorem ipsum dolar set amet</ListItem>
   <ListItem>Lorem ipsum dolar set amet</ListItem>
@@ -396,6 +371,7 @@ The icon property has access to all available icons.
 ```
 
 <PropsTable of="OrderedList" />
+
 
 # ListItem component
 

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -4,20 +4,20 @@ import { ThemeConsumer, Pane, Heading, Text, Paragraph } from 'evergreen-ui'
 
 ## Text components
 
-* [**Heading**](#heading_heading_component): used for headings. A `h2` element by default.
-* [**Text**](#heading_text_component): used for single line text. A `span` element by default.
-* [**Paragraph**](#heading_paragraph_component): used for multiline text. A `p` element by default.
-* [**Link**](#heading_link_component): used for links. A `a` element by default.
-* [**Strong**](#heading_strong_component): used to make text strong. A `strong` element by default.
-* [**Small**](#heading_small_component): used for inline small text. A `small` element by default.
-* [**Pre**](#heading_pre_component): used for preformatted content. A `pre` element by default.
-* [**Code**](#heading_code_component): used for inline code. A `code` element by default.
+- [**Heading**](#heading_heading_component): used for headings. A `h2` element by default.
+- [**Text**](#heading_text_component): used for single line text. A `span` element by default.
+- [**Paragraph**](#heading_paragraph_component): used for multiline text. A `p` element by default.
+- [**Link**](#heading_link_component): used for links. A `a` element by default.
+- [**Strong**](#heading_strong_component): used to make text strong. A `strong` element by default.
+- [**Small**](#heading_small_component): used for inline small text. A `small` element by default.
+- [**Pre**](#heading_pre_component): used for preformatted content. A `pre` element by default.
+- [**Code**](#heading_code_component): used for inline code. A `code` element by default.
 
 ## List components
 
-* [**OrderedList**](#heading_orderedlist_component): used for ordered lists. A `ol` element.
-* [**UnorderedList**](#heading_unorderedlist_component): used for unordered lists. A `ul` element.
-* [**ListItem**](#heading_listitem_component): used as the list item in either an unordered list, or ordered list. A `li` element.
+- [**OrderedList**](#heading_orderedlist_component): used for ordered lists. A `ol` element.
+- [**UnorderedList**](#heading_unorderedlist_component): used for unordered lists. A `ul` element.
+- [**ListItem**](#heading_listitem_component): used as the list item in either an unordered list, or ordered list. A `li` element.
 
 ## Font families
 
@@ -25,15 +25,14 @@ Evergreen uses three font family stacks, `ui`, `display` and `mono`.
 Text components will set the font family accordingly to their use case.
 There is not need for you to override this on a component level.
 
-
 <ThemeConsumer>
-  {theme => (
+  {(theme) => (
     <div>
       <Pane marginTop={48}>
         <h2 className="heading h2">Heading Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {Object.keys(theme.typography.headings).map(size => {
+        {Object.keys(theme.typography.headings).map((size) => {
           return (
             <TextStylePreview
               key={size}
@@ -51,7 +50,7 @@ There is not need for you to override this on a component level.
         <h2 className="heading h2">Text Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {Object.keys(theme.typography.text).map(size => {
+        {Object.keys(theme.typography.text).map((size) => {
           return (
             <TextStylePreview
               key={size}
@@ -70,7 +69,7 @@ There is not need for you to override this on a component level.
         <h2 className="heading h2">Paragraph Styles</h2>
       </Pane>
       <Pane borderBottom paddingBottom={24}>
-        {[300, 400, 500].map(size => {
+        {[300, 400, 500].map((size) => {
           return (
             <TextStylePreview
               key={size}
@@ -79,8 +78,8 @@ There is not need for you to override this on a component level.
                 return (
                   <Paragraph size={size}>
                     Paragraph {size}. Lorem ipsum dolor sit amet, consectetur
-                    adipiscing elit, sed do eiusmod tempor incididunt ut
-                    labore et dolore magna aliqua.
+                    adipiscing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua.
                   </Paragraph>
                 )
               }}
@@ -103,15 +102,15 @@ The size options are: `100`, `200`, `300`, `400`, `500` (default), `600`, `700`,
 
 ```jsx
 <Pane>
-  <Heading size={100} marginTop="default">100: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={200} marginTop="default">200: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={300} marginTop="default">300: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={400} marginTop="default">400: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={500} marginTop="default">500: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={600} marginTop="default">600: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={700} marginTop="default">700: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={800} marginTop="default">800: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={900} marginTop="default">900: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={100}>100: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={200}>200: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={300}>300: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={400}>400: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={500}>500: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={600}>600: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={700}>700: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={800}>800: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={900}>900: The quick brown fox jumps over the lazy dog</Heading>
 </Pane>
 ```
 
@@ -126,14 +125,13 @@ It’s important to realize that the style of a heading is independent from the 
 
 <PropsTable of="Heading" />
 
-
 # Text component
 
 The `Text` component is used for single line text.
 The component renders a `span` element by default.
 If you need a multiline paragraph use the `Paragraph` component.
 
-The size options are:  `300`, `400` (default), `500`
+The size options are: `300`, `400` (default), `500`
 
 ```jsx
 <div>
@@ -155,24 +153,41 @@ The size options are:  `300`, `400` (default), `500`
 <Text color="muted">The quick brown fox jumps over the lazy dog</Text>
 ```
 
-
 # Paragraph component
 
 The `Paragraph` component is used for multiline text.
 This renders a `p` element by default.
 
-The size options are:  `300`, `400` (default), `500`
+The size options are: `300`, `400` (default), `500`
 
 ```jsx
 <div>
   <Paragraph size={300} marginTop="default">
-    Size 300. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Size 300. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+    est laborum.
   </Paragraph>
   <Paragraph size={400} marginTop="default">
-    Size 400. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Size 400. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+    est laborum.
   </Paragraph>
   <Paragraph marginTop="default">
-    Size 500. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Size 500. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+    est laborum.
   </Paragraph>
 </div>
 ```
@@ -181,26 +196,38 @@ The size options are:  `300`, `400` (default), `500`
 
 ```jsx
 <Paragraph color="muted">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+  nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+  eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+  in culpa qui officia deserunt mollit anim id est laborum.
 </Paragraph>
 ```
 
 <PropsTable of="Paragraph" />
-
 
 # Link component
 
 The `Link` component is used for anchor links.
 This component renders a `a` element by default.
 
-The size options are:  `300`, `400` (default), `500`
+The size options are: `300`, `400` (default), `500`
 
 ```jsx
 <div>
-  <Link href="#" marginRight={12}>Default</Link>
-  <Link href="#" marginRight={12} color="green">Green</Link>
-  <Link href="#" marginRight={12} color="blue">Blue</Link>
-  <Link href="#" marginRight={12} color="neutral">Neutral</Link>
+  <Link href="#" marginRight={12}>
+    Default
+  </Link>
+  <Link href="#" marginRight={12} color="green">
+    Green
+  </Link>
+  <Link href="#" marginRight={12} color="blue">
+    Blue
+  </Link>
+  <Link href="#" marginRight={12} color="neutral">
+    Neutral
+  </Link>
 </div>
 ```
 
@@ -227,7 +254,6 @@ Make sure to set the `size` property if you are using this within a other text c
 ```
 
 <PropsTable of="Strong" />
-
 
 # Small component
 
@@ -257,13 +283,19 @@ The `Code` component is based on the `Text` component but renders a `code` eleme
     <Code size={500}>The quick brown fox jumps over the lazy dog</Code>
   </div>
   <div>
-    <Code size={300} appearance="minimal">The quick brown fox jumps over the lazy dog</Code>
+    <Code size={300} appearance="minimal">
+      The quick brown fox jumps over the lazy dog
+    </Code>
   </div>
   <div>
-    <Code size={400} appearance="minimal">The quick brown fox jumps over the lazy dog</Code>
+    <Code size={400} appearance="minimal">
+      The quick brown fox jumps over the lazy dog
+    </Code>
   </div>
   <div>
-    <Code size={500} appearance="minimal">The quick brown fox jumps over the lazy dog</Code>
+    <Code size={500} appearance="minimal">
+      The quick brown fox jumps over the lazy dog
+    </Code>
   </div>
 </div>
 ```
@@ -275,11 +307,8 @@ The `Code` component is based on the `Text` component but renders a `code` eleme
 The `Pre` component renders a chunk of preformatted text.
 This component renders a `pre` element by default.
 
-
 ```jsx
-<Pre>
-  Preformatted text.
-</Pre>
+<Pre>Preformatted text.</Pre>
 ```
 
 <PropsTable of="Pre" />
@@ -307,7 +336,6 @@ This component renders a `pre` element by default.
 </UnorderedList>
 ```
 
-
 ## Adding icons to a list
 
 The icon property has access to all available icons.
@@ -315,10 +343,7 @@ The icon property has access to all available icons.
 ### Set icons for all list items on the list
 
 ```jsx
-<UnorderedList
-  icon={TickIcon}
-  iconColor="success"
->
+<UnorderedList icon={TickIcon} iconColor="success">
   <ListItem>Lorem ipsum dolar set amet</ListItem>
   <ListItem>Lorem ipsum dolar set amet</ListItem>
   <ListItem>Lorem ipsum dolar set amet</ListItem>
@@ -371,7 +396,6 @@ The icon property has access to all available icons.
 ```
 
 <PropsTable of="OrderedList" />
-
 
 # ListItem component
 

--- a/docs/src/pages/get-started/v6-migration-guide.mdx
+++ b/docs/src/pages/get-started/v6-migration-guide.mdx
@@ -82,12 +82,10 @@ If you consume `<BackButton />` in your own application, please feel free to re-
 
 #### No more `marginTop="default"` on `<Paragraph />` or `<Heading />` {#no-more-default-margin-top}
 
-The default theme (and even classic themes) exported by Evergreen no longer support `marginTop="default"` as a computed property. In order to be able to add this
-to your theme, you can extend the existing Evergreen themes as such:
+The default theme (and even classic themes) exported by Evergreen no longer support `marginTop="default"` as a "special" property. We recommend defining your own
+margin and applying that as standard in your codebase.
 
 ```diff static
-+ // copy over Evergreen's default theme
-+ const theme = { ...defaultTheme }
-+ // add a special case for `marginTop` for the theme
-+ theme.components.Paragraph.baseStyle.marginTop = (_, { marginTop }) => marginTop === 'default' ? 24 /* or some other value */ : marginTop
+- <Heading marginTop="default"> ... </Heading>
++ <Heading marginTop={majorScale(3)}> ... </Heading>
 ```

--- a/src/colors/stories/ColorExamples.js
+++ b/src/colors/stories/ColorExamples.js
@@ -27,7 +27,7 @@ const ColorExamples = props => {
             })}
           </Pane>
           <Pane clearfix>
-            <Heading size={800} marginTop="default">
+            <Heading size={800} marginTop={24}>
               Functional Colors
             </Heading>
             {Object.keys(theme.colors).map(key => {
@@ -42,7 +42,7 @@ const ColorExamples = props => {
             })}
           </Pane>
           <Pane clearfix>
-            <Heading size={800} marginTop="default">
+            <Heading size={800} marginTop={24}>
               Scales
             </Heading>
             {Object.keys(theme.scales).map(key => {

--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-1ooeapk evergreen-file-picker-text-input ub-w_280px ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-fnt-fam_b77syt ub-ln-ht_12px ub-color_474d66 ub-tstn_n1akt6 ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-box-szg_border-box"
+    className="css-1ooeapk evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_12px ub-color_474d66 ub-tstn_n1akt6 ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"

--- a/src/icons/stories/index.stories.js
+++ b/src/icons/stories/index.stories.js
@@ -9,7 +9,7 @@ storiesOf('icons', module)
     <div>
       <Box paddingLeft={40}>
         <Heading size={800}>icons</Heading>
-        <Paragraph marginTop="default">
+        <Paragraph marginTop={24}>
           Evergreen uses the amazing{' '}
           <Link href="https://blueprintjs.com/docs/#icons">
             @blueprintjs/icons

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import Box, { spacing, dimensions, position, layout } from 'ui-box'
 import useStyleConfig from '../../hooks/use-style-config'
+import { useTheme } from '../../theme'
 
 const pseudoSelectors = {
   _focus: '&:focus',
@@ -29,6 +30,7 @@ const TextInput = memo(
       appearance = 'default',
       className,
       disabled = false,
+      fontFamily = 'ui',
       isInvalid = false,
       placeholder,
       required,
@@ -38,6 +40,9 @@ const TextInput = memo(
       ...restProps
     } = props
 
+    const theme = useTheme()
+    const { fontFamilies } = theme
+    const themedFontFamily = fontFamilies[fontFamily] || fontFamily
     const { className: themedClassName, ...boxProps } = useStyleConfig(
       'Input',
       { appearance, size },
@@ -57,6 +62,7 @@ const TextInput = memo(
         spellCheck={spellCheck}
         aria-invalid={isInvalid}
         ref={ref}
+        fontFamily={themedFontFamily}
         {...boxProps}
         {...restProps}
       />

--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import Box, { spacing, dimensions, position, layout } from 'ui-box'
 import useStyleConfig from '../../hooks/use-style-config'
+import { useTheme } from '../../theme'
 
 const pseudoSelectors = {
   _focus: '&:focus',
@@ -31,6 +32,7 @@ const Textarea = memo(
     const {
       className,
       disabled = false,
+      fontFamily = 'ui',
       grammarly = false,
       height,
       isInvalid = false,
@@ -40,6 +42,10 @@ const Textarea = memo(
       width = '100%',
       ...restProps
     } = props
+
+    const theme = useTheme()
+    const { fontFamilies } = theme
+    const themedFontFamily = fontFamilies[fontFamily] || fontFamily
 
     const { className: themedClassName, ...boxProps } = useStyleConfig(
       'Input',
@@ -61,6 +67,7 @@ const Textarea = memo(
         spellCheck={spellCheck}
         aria-invalid={isInvalid}
         data-gramm_editor={grammarly}
+        fontFamily={themedFontFamily}
         {...boxProps}
         {...restProps}
       />

--- a/src/themes/classic/components/input.js
+++ b/src/themes/classic/components/input.js
@@ -1,6 +1,5 @@
 const baseStyle = {
   borderRadius: 'radii.1',
-  fontFamily: 'fontFamilies.ui',
   lineHeight: '12px',
   color: 'colors.default',
 

--- a/src/themes/classic/components/paragraph.js
+++ b/src/themes/classic/components/paragraph.js
@@ -1,8 +1,4 @@
 const baseStyle = {
-  fontFamily: (theme, { fontFamily = 'ui' }) =>
-    theme.fontFamilies[fontFamily] ? `fontFamilies.${fontFamily}` : fontFamily,
-  color: (theme, { color = 'default' }) =>
-    theme.colors[color] ? `colors.${color}` : color,
   marginTop: 0,
   marginBottom: 0
 }

--- a/src/themes/classic/components/text.js
+++ b/src/themes/classic/components/text.js
@@ -1,8 +1,4 @@
-const baseStyle = {
-  fontFamily: (theme, { fontFamily = 'ui' }) =>
-    theme.fontFamilies[fontFamily] ? `fontFamilies.${fontFamily}` : fontFamily,
-  color: (theme, { color }) => (theme.colors[color] ? `colors.${color}` : color)
-}
+const baseStyle = {}
 
 const appearances = {}
 

--- a/src/themes/default/components/text.js
+++ b/src/themes/default/components/text.js
@@ -1,8 +1,4 @@
-const baseStyle = {
-  fontFamily: (theme, { fontFamily = 'ui' }) =>
-    theme.fontFamilies[fontFamily] ? `fontFamilies.${fontFamily}` : fontFamily,
-  color: (theme, { color }) => (theme.colors[color] ? `colors.${color}` : color)
-}
+const baseStyle = {}
 
 const appearances = {}
 

--- a/src/typography/src/Paragraph.js
+++ b/src/typography/src/Paragraph.js
@@ -2,12 +2,25 @@ import React, { forwardRef, memo } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import useStyleConfig from '../../hooks/use-style-config'
+import { useTheme } from '../../theme'
 
 const emptyObject = {}
 
 const Paragraph = memo(
   forwardRef(function Paragraph(props, ref) {
-    const { marginTop, size = 400, ...restProps } = props
+    const {
+      color = 'default',
+      fontFamily = 'ui',
+      size = 400,
+      ...restProps
+    } = props
+
+    const theme = useTheme()
+
+    const { colors, fontFamilies } = theme
+
+    const themedFontFamily = fontFamilies[fontFamily] || fontFamily
+    const themedColor = colors[color] || color
 
     const textStyle = useStyleConfig(
       'Paragraph',
@@ -16,7 +29,16 @@ const Paragraph = memo(
       emptyObject
     )
 
-    return <Box is="p" ref={ref} {...textStyle} {...restProps} />
+    return (
+      <Box
+        is="p"
+        ref={ref}
+        {...textStyle}
+        fontFamily={themedFontFamily}
+        color={themedColor}
+        {...restProps}
+      />
+    )
   })
 )
 

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -2,12 +2,25 @@ import React, { forwardRef, memo } from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import useStyleConfig from '../../hooks/use-style-config'
+import { useTheme } from '../../theme'
 
 const emptyObject = {}
 
 const Text = memo(
   forwardRef(function Text(props, ref) {
-    const { className, size = 400, ...restProps } = props
+    const {
+      className,
+      color = 'default',
+      fontFamily = 'ui',
+      size = 400,
+      ...restProps
+    } = props
+
+    const theme = useTheme()
+    const { colors, fontFamilies } = theme
+
+    const themedFontFamily = fontFamilies[fontFamily] || fontFamily
+    const themedColor = colors[color] || color
 
     const textStyle = useStyleConfig('Text', { size }, emptyObject, emptyObject)
 
@@ -16,6 +29,8 @@ const Text = memo(
         is="span"
         ref={ref}
         {...textStyle}
+        fontFamily={themedFontFamily}
+        color={themedColor}
         className={className}
         {...restProps}
       />

--- a/src/typography/stories/index.stories.js
+++ b/src/typography/stories/index.stories.js
@@ -55,14 +55,10 @@ storiesOf('typography', module)
     </Box>
   ))
   .add('Paragraph', () => (
-    <div>
-      {previewTextComponent(Paragraph, TextSizes, { marginTop: 'default' })}
-    </div>
+    <div>{previewTextComponent(Paragraph, TextSizes, { marginTop: 24 })}</div>
   ))
   .add('Heading', () => (
-    <div>
-      {previewTextComponent(Heading, HeadingSizes, { marginTop: 'default' })}
-    </div>
+    <div>{previewTextComponent(Heading, HeadingSizes, { marginTop: 24 })}</div>
   ))
   .add('Code', () => <div>{previewTextComponent(Code)}</div>)
   .add('Pre', () => <div>{previewTextComponent(Pre)}</div>)
@@ -80,10 +76,10 @@ storiesOf('typography', module)
     <Box padding={40}>
       {[300, 400, 500].map(size => (
         <Box key={size}>
-          <Heading size={700} marginTop="default">
+          <Heading size={700} marginTop={24}>
             Size {size}
           </Heading>
-          <Paragraph size={size} marginTop="default">
+          <Paragraph size={size} marginTop={24}>
             A paragraph before a list. You have to manually set the margins on a
             list.
           </Paragraph>
@@ -94,7 +90,7 @@ storiesOf('typography', module)
             <ListItem>Lorem ipsum dolar set amet</ListItem>
             <ListItem>Lorem ipsum dolar set amet</ListItem>
           </OrderedList>
-          <Paragraph size={size} marginTop="default">
+          <Paragraph size={size} marginTop={24}>
             A paragraph after a list.
           </Paragraph>
         </Box>
@@ -105,10 +101,10 @@ storiesOf('typography', module)
     <Box padding={40}>
       {[300, 400, 500].map(size => (
         <Box key={size}>
-          <Heading size={700} marginTop="default">
+          <Heading size={700} marginTop={24}>
             Size {size}
           </Heading>
-          <Paragraph size={size} marginTop="default">
+          <Paragraph size={size} marginTop={24}>
             You can add icons to list items individually.
           </Paragraph>
           <UnorderedList size={size} marginY={16}>
@@ -147,10 +143,10 @@ storiesOf('typography', module)
     <Box padding={40}>
       {[300, 400, 500].map(size => (
         <Box key={size}>
-          <Heading size={700} marginTop="default">
+          <Heading size={700} marginTop={24}>
             Size {size}
           </Heading>
-          <Paragraph size={size} marginTop="default">
+          <Paragraph size={size} marginTop={24}>
             A paragraph before a list. You have to manually set the margins on a
             list.
           </Paragraph>
@@ -161,7 +157,7 @@ storiesOf('typography', module)
             <ListItem>Lorem ipsum dolar set amet</ListItem>
             <ListItem>Lorem ipsum dolar set amet</ListItem>
           </UnorderedList>
-          <Paragraph size={size} marginTop="default">
+          <Paragraph size={size} marginTop={24}>
             A paragraph after a list.
           </Paragraph>
         </Box>


### PR DESCRIPTION
**Overview**
The themes are aware of `size` as a prop, but not the other props on the theme. We could probably pass those in, but this should roughly accomplish the same thing, as we compose `<Text />` quite heavily throughout the codebase internally. 

Still need to clean up all of the `marginTop="default"` throughout the codebase. 


**Screenshots (if applicable)**
N/A


**Documentation**

<!-- If your change impacts component behavior or usage please be sure to include appropriate documentation and types! -->

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
