### PR TITLE
Fixup `<Select />` styles in v6

### DIFF
--- a/src/select/src/Select.js
+++ b/src/select/src/Select.js
@@ -91,6 +91,8 @@ const Select = memo(
           autoFocus={autoFocus}
           disabled={disabled}
           aria-invalid={String(isInvalid)}
+          paddingLeft={Math.round(height / 3.2)}
+          paddingRight={iconMargin * 2 + iconSize}
           {...boxProps}
         >
           {children}

--- a/src/themes/classic/components/select.js
+++ b/src/themes/classic/components/select.js
@@ -8,6 +8,7 @@ const baseStyle = {
 
 const appearances = {
   default: {
+    color: 'colors.neutralAlpha.N8A',
     ...defaultControlStyles.base,
     _disabled: defaultControlStyles.disabled,
     _hover: defaultControlStyles.hover,

--- a/src/themes/classic/components/select.js
+++ b/src/themes/classic/components/select.js
@@ -20,23 +20,17 @@ const sizes = {
   small: {
     height: 24,
     minWidth: 24,
-    lineHeight: '24px',
-    paddingLeft: 12,
-    paddingRight: 12
+    lineHeight: '24px'
   },
   medium: {
     height: 32,
     minWidth: 32,
-    lineHeight: '32px',
-    paddingLeft: 16,
-    paddingRight: 16
+    lineHeight: '32px'
   },
   large: {
     height: 40,
     minWidth: 40,
-    lineHeight: '40px',
-    paddingLeft: 20,
-    paddingRight: 20
+    lineHeight: '40px'
   }
 }
 

--- a/src/themes/default/components/select.js
+++ b/src/themes/default/components/select.js
@@ -34,21 +34,15 @@ const appearances = {
 const sizes = {
   small: {
     height: 24,
-    lineHeight: '24px',
-    paddingLeft: 12,
-    paddingRight: 12
+    lineHeight: '24px'
   },
   medium: {
     height: 32,
-    lineHeight: '32px',
-    paddingLeft: 16,
-    paddingRight: 16
+    lineHeight: '32px'
   },
   large: {
     height: 40,
-    lineHeight: '40px',
-    paddingLeft: 20,
-    paddingRight: 20
+    lineHeight: '40px'
   }
 }
 


### PR DESCRIPTION
**Overview**
This fixes up v5 + v6 selects by directly computing the padding applied based on height (aka how it was before)


**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/5349500/93162189-09b5f300-f6c9-11ea-8a78-812d55157e2e.png)

![image](https://user-images.githubusercontent.com/5349500/93162306-57caf680-f6c9-11ea-8f13-9a3961743b0b.png)


**Documentation**

<!-- If your change impacts component behavior or usage please be sure to include appropriate documentation and types! -->

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
