### PR TITLE
Fix `github` link on the select docs page

### DIFF
--- a/docs/src/IA.js
+++ b/docs/src/IA.js
@@ -177,7 +177,7 @@ export default {
       {
         title: 'Selects & Dropdown Menus',
         items: [
-          { id: 'select', name: 'Select', image: Select },
+          { id: 'select', name: 'Select', image: Select, github: githubLink('select') },
           {
             id: 'combobox',
             github: githubLink('combobox'),


### PR DESCRIPTION
**Overview**
This fixes up a broken github link on the docs page that takes users to the github page for the `<Select />` component. This fixes up that broken link.


**Screenshots (if applicable)**
N/A


**Documentation**

<!-- If your change impacts component behavior or usage please be sure to include appropriate documentation and types! -->

- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
