### PR TITLE
Fix `marginTop="default"` codemod to be better-aware of default sizing

### DIFF
--- a/codemods/5.0.0-6.0.0/replace-margin-top-default.js
+++ b/codemods/5.0.0-6.0.0/replace-margin-top-default.js
@@ -57,11 +57,9 @@ export default function transformer(file, api) {
       const sizeAttribute = attributes.find((attr) => attr.name.name === "size");
       const marginTopAttribute = attributes.find((attr) => attr.name.name === "marginTop");
 
-      if (marginTopAttribute.value.value === "default") {
-        const componentSize = (sizeAttribute && sizeAttribute.value && sizeAttribute.value.value) || SIZE_TO_MARGIN_TOP_MAPPING[elementName].defaultSize;
-        marginTopAttribute.value = j.jsxExpressionContainer(
-          j.literal(SIZE_TO_MARGIN_TOP_MAPPING[elementName].sizes[sizeAttribute.value.expression.value])
-        );
+      if (marginTopAttribute && marginTopAttribute.value && marginTopAttribute.value.value === "default") {
+        const componentSize = (sizeAttribute && sizeAttribute.value && sizeAttribute.value.expression && sizeAttribute.value.expression.value) || SIZE_TO_MARGIN_TOP_MAPPING[elementName].defaultSize;
+        marginTopAttribute.value = j.jsxExpressionContainer(j.literal(SIZE_TO_MARGIN_TOP_MAPPING[elementName].sizes[componentSize]));
       }
     });
   });

--- a/docs/src/components/TextStylePreview.js
+++ b/docs/src/components/TextStylePreview.js
@@ -9,7 +9,6 @@ export default class TextStylePreview extends React.Component {
     fontWeight: PropTypes.string,
     lineHeight: PropTypes.string,
     letterSpacing: PropTypes.string,
-    marginTop: PropTypes.number,
     fontFamilies: PropTypes.object,
     fontFamily: PropTypes.string,
     color: PropTypes.string
@@ -44,16 +43,6 @@ export default class TextStylePreview extends React.Component {
             {this.props.color && (
               <React.Fragment>
                 color: <strong>{this.props.color}</strong>
-                <br />
-              </React.Fragment>
-            )}
-            {this.props.marginTop && (
-              <React.Fragment>
-                Default margin top:{' '}
-                <strong>
-                  {this.props.marginTop}
-                  px
-                </strong>
                 <br />
               </React.Fragment>
             )}

--- a/docs/src/pages/components/button.mdx
+++ b/docs/src/pages/components/button.mdx
@@ -41,7 +41,7 @@ It contains a label and optional icons before or after the label.
         value={state.value}
         onChange={value => setState({ value })}
       />
-      <Heading marginTop="default">Default Appearance</Heading>
+      <Heading marginTop={24}>Default Appearance</Heading>
       <Pane marginTop={12}>
         <Button size={state.value} marginRight={16}>
           Default
@@ -62,7 +62,7 @@ It contains a label and optional icons before or after the label.
           Icon After
         </Button>
       </Pane>
-      <Heading marginTop="default">Primary Appearance</Heading>
+      <Heading marginTop={24}>Primary Appearance</Heading>
       <Pane marginTop={12}>
         <Button size={state.value} appearance="primary" marginRight={16}>
           Default
@@ -93,7 +93,7 @@ It contains a label and optional icons before or after the label.
           Icon After
         </Button>
       </Pane>
-      <Heading marginTop="default">Minimal Appearance</Heading>
+      <Heading marginTop={24}>Minimal Appearance</Heading>
       <Pane marginTop={12}>
         <Button size={state.value} appearance="minimal" marginRight={16}>
           Default

--- a/docs/src/pages/components/typography.mdx
+++ b/docs/src/pages/components/typography.mdx
@@ -103,15 +103,15 @@ The size options are: `100`, `200`, `300`, `400`, `500` (default), `600`, `700`,
 
 ```jsx
 <Pane>
-  <Heading size={100} marginTop="default">100: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={200} marginTop="default">200: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={300} marginTop="default">300: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={400} marginTop="default">400: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={500} marginTop="default">500: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={600} marginTop="default">600: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={700} marginTop="default">700: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={800} marginTop="default">800: The quick brown fox jumps over the lazy dog</Heading>
-  <Heading size={900} marginTop="default">900: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={100} marginTop={16}>100: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={200} marginTop={16}>200: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={300} marginTop={16}>300: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={400} marginTop={16}>400: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={500} marginTop={24}>500: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={600} marginTop={28}>600: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={700} marginTop={40}>700: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={800} marginTop={40}>800: The quick brown fox jumps over the lazy dog</Heading>
+  <Heading size={900} marginTop={52}>900: The quick brown fox jumps over the lazy dog</Heading>
 </Pane>
 ```
 
@@ -165,13 +165,13 @@ The size options are:  `300`, `400` (default), `500`
 
 ```jsx
 <div>
-  <Paragraph size={300} marginTop="default">
+  <Paragraph size={300} marginTop={12}>
     Size 300. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </Paragraph>
-  <Paragraph size={400} marginTop="default">
+  <Paragraph size={400} marginTop={12}>
     Size 400. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </Paragraph>
-  <Paragraph marginTop="default">
+  <Paragraph marginTop={16}>
     Size 500. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </Paragraph>
 </div>


### PR DESCRIPTION
**Overview**
Just ran this across a larger codebase, and decided to fix up a small bug that was preventing a cleaner upgrade.

Also removed all references of `marginTop="default"` throughout the codebase. 


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
