### PR TITLE
Remove references to deprecated `tokens` for `<Code />` in the default theme

### DIFF
--- a/src/themes/default/components/code.js
+++ b/src/themes/default/components/code.js
@@ -1,13 +1,15 @@
 const baseStyle = {}
 
+const codeBackgroundColor = 'rgba(16, 112, 202, 0.06)'
+const codeBorderColor = 'rgba(16, 112, 202, 0.14)'
+
 const appearances = {
   default: {
-    backgroundColor: 'tokens.codeBackgroundColor',
-    boxShadow: (theme, _props) =>
-      `inset 0 0 0 1px ${theme.tokens.codeBorderColor}`,
+    backgroundColor: codeBackgroundColor,
+    boxShadow: `inset 0 0 0 1px ${codeBorderColor}`,
     paddingX: 6,
     paddingY: 3,
-    borderRadius: 'tokens.borderRadius'
+    borderRadius: 'radii.1'
   }
 }
 


### PR DESCRIPTION
**Overview**
Tiny, cleanup PR that helps unblock fully removing the `tokens` key in the default theme. 


**Screenshots (if applicable)**
N/A - no visual changes. 

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
