### PR TITLE
Fix type definition for SideSheet

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1622,8 +1622,7 @@ export interface SideSheetProps {
   shouldCloseOnEscapePress?: boolean
   width?: string | number
   containerProps?: PaneOwnProps & BoxProps<'div'>
-  // @ts-ignore
-  position?: Pick<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
+  position?: Extract<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
   preventBodyScrolling?: boolean
 }
 


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Corrects the type of the `position` prop for the SideSheet component to use `Extract` (which is for type unions) instead of `Pick` (which is for object properties).

Fixes #1069 

**Screenshots (if applicable)**
N/A

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
