### PR TITLE
Fixup classic button / text input styles + make button default theme backwards-compat

### DIFF
--- a/src/buttons/__tests__/Button.test.js
+++ b/src/buttons/__tests__/Button.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import render from 'react-test-renderer'
+import { ThemeProvider } from '../../theme'
+import { classicTheme, defaultTheme } from '../../themes'
+import Button from '../src/Button'
+
+describe.each([
+  [defaultTheme, 'default'],
+  [classicTheme, 'classic']
+])('<Button /> %% %s', theme => {
+  it('snapshots with the rendered output', () => {
+    const component = (
+      <ThemeProvider value={theme}>
+        <Button />
+      </ThemeProvider>
+    )
+    const tree = render.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/buttons/__tests__/Button.test.js
+++ b/src/buttons/__tests__/Button.test.js
@@ -5,9 +5,9 @@ import { classicTheme, defaultTheme } from '../../themes'
 import Button from '../src/Button'
 
 describe.each([
-  [defaultTheme, 'default'],
-  [classicTheme, 'classic']
-])('<Button /> %% %s', theme => {
+  ['default', defaultTheme],
+  ['classic', classicTheme]
+])('<Button /> % %s', (_, theme) => {
   it('snapshots with the rendered output', () => {
     const component = (
       <ThemeProvider value={theme}>

--- a/src/buttons/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.test.js.snap
@@ -1,43 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Button /> % {
-  palette: [Object],
-  scales: [Object],
-  tokens: [Object],
-  colors: [Object],
-  fills: [Object],
-  intents: [Object],
-  radii: [Array],
-  shadows: [Array],
-  fontFamilies: [Object],
-  fontSizes: [Array],
-  fontWeights: [Object],
-  letterSpacings: [Object],
-  lineHeights: [Array],
-  zIndices: [Object],
-  components: [Object]
-} snapshots with the rendered output 1`] = `
+exports[`<Button /> % classic snapshots with the rendered output 1`] = `
 <button
   className="css-15cxcpy ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_0px ub-b-lft_0px ub-b-rgt_0px ub-b-top_0px ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_3px ub-bbrr_3px ub-btlr_3px ub-btrr_3px ub-color_425A70 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-bg-img_zk1eut ub-bs_ruftdn ub-box-szg_border-box"
   type="button"
 />
 `;
 
-exports[`<Button /> % {
-  tokens: [Object],
-  colors: [Object],
-  fills: [Object],
-  intents: [Object],
-  radii: [Array],
-  shadows: [Array],
-  fontFamilies: [Object],
-  fontSizes: [Array],
-  fontWeights: [Object],
-  letterSpacings: [Object],
-  lineHeights: [Array],
-  zIndices: [Object],
-  components: [Object]
-} snapshots with the rendered output 1`] = `
+exports[`<Button /> % default snapshots with the rendered output 1`] = `
 <button
   className="css-51skc2 ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-box-szg_border-box"
   type="button"

--- a/src/buttons/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Button /> % {
+  palette: [Object],
+  scales: [Object],
+  tokens: [Object],
+  colors: [Object],
+  fills: [Object],
+  intents: [Object],
+  radii: [Array],
+  shadows: [Array],
+  fontFamilies: [Object],
+  fontSizes: [Array],
+  fontWeights: [Object],
+  letterSpacings: [Object],
+  lineHeights: [Array],
+  zIndices: [Object],
+  components: [Object]
+} snapshots with the rendered output 1`] = `
+<button
+  className="css-15cxcpy ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_0px ub-b-lft_0px ub-b-rgt_0px ub-b-top_0px ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_3px ub-bbrr_3px ub-btlr_3px ub-btrr_3px ub-color_425A70 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-bg-img_zk1eut ub-bs_ruftdn ub-box-szg_border-box"
+  type="button"
+/>
+`;
+
+exports[`<Button /> % {
+  tokens: [Object],
+  colors: [Object],
+  fills: [Object],
+  intents: [Object],
+  radii: [Array],
+  shadows: [Array],
+  fontFamilies: [Object],
+  fontSizes: [Array],
+  fontWeights: [Object],
+  letterSpacings: [Object],
+  lineHeights: [Array],
+  zIndices: [Object],
+  components: [Object]
+} snapshots with the rendered output 1`] = `
+<button
+  className="css-51skc2 ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-box-szg_border-box"
+  type="button"
+/>
+`;

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -77,7 +77,7 @@ const Button = memo(
       disabled,
       iconAfter,
       iconBefore,
-      intent, // Unused for now... tbd
+      intent,
       is = 'button',
       isActive = false,
       isLoading,

--- a/src/themes/classic/components/button.js
+++ b/src/themes/classic/components/button.js
@@ -8,7 +8,10 @@ const baseStyle = {
   fontFamily: 'fontFamilies.ui',
   borderRadius: 'radii.1',
   border: 0,
-  color: (theme, { color }) => theme.colors[color] || color || 'colors.default'
+  color: (theme, { color }) => theme.colors[color] || color || 'colors.default',
+  _disabled: {
+    ...defaultControlStyles.disabled
+  }
 }
 
 const appearances = {

--- a/src/themes/classic/components/input.js
+++ b/src/themes/classic/components/input.js
@@ -8,8 +8,7 @@ const baseStyle = {
   },
 
   _disabled: {
-    cursor: 'not-allowed',
-    backgroundColor: 'colors.neutralAlpha.N2'
+    cursor: 'not-allowed'
   },
 
   _focus: {
@@ -32,7 +31,8 @@ const appearances = {
         `inset 0 0 2px ${theme.colors.neutralAlpha.N4A}, inset 0 0 0 1px ${theme.colors.blue.B7}, ${theme.shadows.focusRing}`
     },
     _disabled: {
-      boxShadow: theme => `inset 0 0 0 1px ${theme.colors.neutralAlpha.N4A}`
+      boxShadow: theme => `inset 0 0 0 1px ${theme.colors.neutralAlpha.N4A}`,
+      backgroundColor: 'colors.neutralAlpha.N2A'
     }
   },
   neutral: {
@@ -49,7 +49,10 @@ const appearances = {
     }
   },
   none: {
-    backgroundColor: 'white'
+    backgroundColor: 'white',
+    _disabled: {
+      backgroundColor: 'colors.neutral.N2'
+    }
   }
 }
 

--- a/src/themes/default/components/button.js
+++ b/src/themes/default/components/button.js
@@ -15,11 +15,33 @@ const baseStyle = {
   }
 }
 
-const colorKeyForAppearance = appearance =>
-  appearance === 'destructive' ? 'red' : 'blue'
+const colorKeyForAppearanceOrIntent = (appearance, intent) => {
+  if (appearance === 'destructive') {
+    return 'red'
+  }
 
-const getPrimaryButtonAppearance = appearance => {
-  const color = colorKeyForAppearance(appearance)
+  switch (intent) {
+    case 'success':
+      return 'green'
+    case 'danger':
+      return 'red'
+    default:
+      return 'blue'
+  }
+}
+
+const colorKeyForIntent = (intent, isBorder) => {
+  if (intent === 'danger') {
+    return `red${isBorder ? 300 : 500}`
+  } else if (intent === 'success') {
+    return `green${isBorder ? 300 : 500}`
+  } else {
+    return `gray${isBorder ? 500 : 800}`
+  }
+}
+
+const getPrimaryButtonAppearance = (appearance, intent) => {
+  const color = colorKeyForAppearanceOrIntent(appearance, intent)
   return {
     backgroundColor: `colors.${color}500`,
     borderColor: `colors.${color}500`,
@@ -45,11 +67,13 @@ const getPrimaryButtonAppearance = appearance => {
 }
 
 const appearances = {
-  primary: getPrimaryButtonAppearance(),
+  primary: (_, { appearance, intent }) =>
+    getPrimaryButtonAppearance(appearance, intent),
   default: {
     backgroundColor: 'white',
-    border: theme => `1px solid ${theme.colors.gray500}`,
-    color: 'colors.gray800',
+    border: (theme, props) =>
+      `1px solid ${theme.colors[colorKeyForIntent(props.intent, true)]}`,
+    color: (theme, props) => theme.colors[colorKeyForIntent(props.intent)],
 
     _disabled: {
       color: 'colors.gray500',
@@ -67,7 +91,7 @@ const appearances = {
   },
   minimal: {
     backgroundColor: 'transparent',
-    color: 'colors.gray800',
+    color: (theme, props) => theme.colors[colorKeyForIntent(props.intent)],
 
     _disabled: {
       color: 'colors.gray500',

--- a/src/themes/default/tokens/colors.js
+++ b/src/themes/default/tokens/colors.js
@@ -30,6 +30,7 @@ const colorScales = {
   red700: '#7D2828',
   red600: '#A73636',
   red500: '#D14343',
+  red300: '#EE9191',
   red100: '#F9DADA',
   red25: '#FDF4F4',
 


### PR DESCRIPTION
**Overview**
Title of the PR. Decided to wing some of the default / outlined button style, we can always revisit if we so choose.


**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/5349500/93831431-9b70b380-fc27-11ea-991f-a5f99749ee21.png)




**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
