### PR TITLE
fix(button): merge props value

### DIFF
--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -1,5 +1,6 @@
 import React, { memo, forwardRef } from 'react'
 import cx from 'classnames'
+import merge from 'lodash.merge'
 import PropTypes from 'prop-types'
 import Box, { spacing, dimensions, position, layout } from 'ui-box'
 import { useStyleConfig } from '../../hooks'
@@ -92,6 +93,9 @@ const Button = memo(
       internalStyles
     )
 
+    // Merge boxProps and restProps. Initialize the undefined value in `restProps` according to `boxProps`
+    const otherProps = merge({}, boxProps, restProps)
+
     const height = restProps.height || boxProps.height
     // Keep backwards compat font sizing if an explicit height was passed in.
     const textProps =
@@ -107,8 +111,7 @@ const Button = memo(
         type={is === 'button' ? 'button' : undefined}
         className={cx(themedClassName, className)}
         data-active={isActive || undefined}
-        {...boxProps}
-        {...restProps}
+        {...otherProps}
         {...textProps}
         disabled={disabled || isLoading}
       >

--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -21,7 +21,7 @@ exports[`<FilePicker /> snapshot 1`] = `
     value=""
   />
   <button
-    className="css-51skc2 evergreen-file-picker-button ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_0px ub-bbrr_4px ub-btlr_0px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-flx-srnk_0 ub-box-szg_border-box"
+    className="css-51skc2 evergreen-file-picker-button ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_0px ub-bbrr_4px ub-btlr_0px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-flx-srnk_0 ub-box-szg_border-box"
     onBlur={[Function]}
     onClick={[Function]}
     type="button"


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

https://codesandbox.io/s/evergreen-ui-button-yhwd8?file=/src/App.js

Merge props value (boxProps and restProps).
Initialize the undefined value in `restProps` according to `boxProps`.

more:
I suspect that all components that use `resetProps` after `boxProps` have problems🤔

**Screenshots (if applicable)**
![Screen Shot 2020-09-24 at 2 34 38 PM](https://user-images.githubusercontent.com/28584349/94117802-44651b80-fe7f-11ea-92ab-2ef61bc5c521.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
