### PR TITLE
Fix default height for the filepicker

### DIFF
--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-1ooeapk evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_12px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-box-szg_border-box"
+    className="css-1ooeapk evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"
@@ -21,7 +21,7 @@ exports[`<FilePicker /> snapshot 1`] = `
     value=""
   />
   <button
-    className="css-51skc2 evergreen-file-picker-button ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_0px ub-bbrr_4px ub-btlr_0px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-flx-srnk_0 ub-box-szg_border-box"
+    className="css-51skc2 evergreen-file-picker-button ub-pst_relative ub-f-wght_400 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_0px ub-bbrr_4px ub-btlr_0px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_16px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-flx-srnk_0 ub-ltr-spc_0 ub-box-szg_border-box"
     onBlur={[Function]}
     onClick={[Function]}
     type="button"

--- a/src/file-picker/src/FilePicker.js
+++ b/src/file-picker/src/FilePicker.js
@@ -15,7 +15,7 @@ const FilePicker = memo(
       capture,
       className,
       disabled,
-      height,
+      height = 32,
       multiple,
       name,
       onBlur,
@@ -80,12 +80,7 @@ const FilePicker = memo(
     const rootClassNames = cx(`${CLASS_PREFIX}-root`, className)
 
     return (
-      <Box
-        display="flex"
-        className={rootClassNames}
-        ref={ref}
-        {...rest}
-      >
+      <Box display="flex" className={rootClassNames} ref={ref} {...rest}>
         <Box
           ref={fileInputRef}
           className={`${CLASS_PREFIX}-file-input`}


### PR DESCRIPTION
**Overview**
Opted to go with a sane default of `32px` for the FilePicker height as opposed to introducing a new `size` param, which is a bit more coupled to the theme. 

Could always revisit this, but think this should be fine now that we have better `height` support in the underlying components. 


**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/5349500/94141886-49e04880-fe22-11ea-996e-0d44ce54a88d.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
