### PR TITLE
Fix button prop type errors for classic theme 

### DIFF
--- a/src/buttons/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> % classic snapshots with the rendered output 1`] = `
 <button
-  className="css-15cxcpy ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_0px ub-b-lft_0px ub-b-rgt_0px ub-b-top_0px ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_3px ub-bbrr_3px ub-btlr_3px ub-btrr_3px ub-color_425A70 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-bg-img_zk1eut ub-bs_ruftdn ub-box-szg_border-box"
+  className="css-15cxcpy ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_0 ub-b-lft_0 ub-b-rgt_0 ub-b-top_0 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_3px ub-bbrr_3px ub-btlr_3px ub-btrr_3px ub-color_425A70 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-bg-img_zk1eut ub-bs_ruftdn ub-box-szg_border-box"
   type="button"
 />
 `;

--- a/src/themes/classic/components/button.js
+++ b/src/themes/classic/components/button.js
@@ -7,7 +7,7 @@ import { defaultControlStyles } from '../deprecated/shared'
 const baseStyle = {
   fontFamily: 'fontFamilies.ui',
   borderRadius: 'radii.1',
-  border: 0,
+  border: '0',
   color: (theme, { color }) => theme.colors[color] || color || 'colors.default',
   _disabled: {
     ...defaultControlStyles.disabled


### PR DESCRIPTION
**Overview**
We were getting a bunch of prop type errors in the console for buttons - this should be fixed in `ui-box`, but this is a workaround for now. 


**Screenshots (if applicable)**
Before: 
![image](https://user-images.githubusercontent.com/5349500/94146003-32a45980-fe28-11ea-8342-ebd7a5985455.png)

After: 
![image](https://user-images.githubusercontent.com/5349500/94146044-3cc65800-fe28-11ea-811f-2b9b9040d6cd.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
