### PR TITLE
Fix TextInput / Textarea line height + invalid focus state

### DIFF
--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-1ooeapk evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
+    className="css-dcov57 evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"

--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-dcov57 evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
+    className="css-1xdry12 evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -9,7 +9,7 @@ import { useTheme } from '../../theme'
 const pseudoSelectors = {
   _focus: '&:focus',
   _disabled: '&:disabled',
-  _invalid: '&[aria-invalid="true"]',
+  _invalid: '&[aria-invalid="true"]:not(:focus)',
   _placeholder: '&::placeholder',
   _placeholderHover: '&:hover::placeholder',
   _placeholderFocus: '&:focus::placeholder'

--- a/src/text-input/stories/index.stories.js
+++ b/src/text-input/stories/index.stories.js
@@ -36,7 +36,7 @@ storiesOf('text-input', module)
         <Box key={appearance} padding={40} float="left">
           <Heading marginBottom={24}>Appearance: {appearance}</Heading>
           <Box marginBottom={24} width={360}>
-            <Label htmlFor="32" size={400} display="block">
+            <Label htmlFor={`${appearance}-32`} size={400} display="block">
               Height 32 (default)
             </Label>
             <Description marginBottom={8}>
@@ -45,29 +45,38 @@ storiesOf('text-input', module)
             <TextInput
               appearance={appearance}
               name="32"
-              id="32"
+              id={`${appearance}-32`}
               placeholder="With placeholder"
             />
           </Box>
           <Box marginBottom={24} width={360}>
-            <Label htmlFor="disabled" size={400} display="block">
+            <Label
+              htmlFor={`${appearance}-disabled`}
+              size={400}
+              display="block"
+            >
               Disabled
             </Label>
             <TextInput
               appearance={appearance}
               value="This is disabled"
               name="disabled"
+              id={`${appearance}-disabled`}
               disabled
             />
           </Box>
           <Box marginBottom={24} width={360}>
-            <Label htmlFor="isInvalid" size={400} display="block">
+            <Label
+              htmlFor={`${appearance}-disabled`}
+              size={400}
+              display="block"
+            >
               Is Invalid
             </Label>
             <TextInput
               appearance={appearance}
               name="isInvalid"
-              id="isInvalid"
+              id={`${appearance}-isInvalid`}
               isInvalid
             />
           </Box>
@@ -84,14 +93,19 @@ storiesOf('text-input', module)
             <TextInput appearance={appearance} name="medium" />
           </Box>
           <Box marginBottom={24}>
-            <Label htmlFor="large" size={400} display="block" marginBottom={4}>
+            <Label
+              htmlFor={`${appearance}-large`}
+              size={400}
+              display="block"
+              marginBottom={4}
+            >
               Large
             </Label>
             <TextInput
               appearance={appearance}
               size="large"
               name="large"
-              id="large"
+              id={`${appearance}-large`}
             />
           </Box>
         </Box>

--- a/src/text-input/stories/index.stories.js
+++ b/src/text-input/stories/index.stories.js
@@ -57,7 +57,6 @@ storiesOf('text-input', module)
               appearance={appearance}
               value="This is disabled"
               name="disabled"
-              id="disabled"
               disabled
             />
           </Box>
@@ -76,18 +75,13 @@ storiesOf('text-input', module)
             <Label htmlFor="small" size={300} display="block" marginBottom={4}>
               Small
             </Label>
-            <TextInput
-              appearance={appearance}
-              size="small"
-              name="small"
-              id="small"
-            />
+            <TextInput appearance={appearance} size="small" name="small" />
           </Box>
           <Box marginBottom={24}>
             <Label htmlFor="medium" size={300} display="block" marginBottom={4}>
               Medium
             </Label>
-            <TextInput appearance={appearance} name="medium" id="medium" />
+            <TextInput appearance={appearance} name="medium" />
           </Box>
           <Box marginBottom={24}>
             <Label htmlFor="large" size={400} display="block" marginBottom={4}>

--- a/src/textarea/src/Textarea.js
+++ b/src/textarea/src/Textarea.js
@@ -8,7 +8,7 @@ import { useTheme } from '../../theme'
 const pseudoSelectors = {
   _focus: '&:focus',
   _disabled: '&:disabled',
-  _invalid: '&[aria-invalid="true"]',
+  _invalid: '&[aria-invalid="true"]:not(:focus)',
   _placeholder: '&::placeholder',
   _placeholderHover: '&:hover::placeholder',
   _placeholderFocus: '&:focus::placeholder'

--- a/src/themes/classic/components/input.js
+++ b/src/themes/classic/components/input.js
@@ -1,6 +1,6 @@
 const baseStyle = {
   borderRadius: 'radii.1',
-  lineHeight: '12px',
+  lineHeight: 'lineHeights.1',
   color: 'colors.default',
 
   _placeholder: {
@@ -65,7 +65,7 @@ const sizes = {
   },
   large: {
     height: 40,
-    lineHeight: '14px'
+    lineHeight: 'lineHeights.2'
   }
 }
 

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -1,7 +1,7 @@
 const baseStyle = {
   borderRadius: 'radii.1',
   fontFamily: 'fontFamilies.ui',
-  lineHeight: '12px',
+  lineHeight: 'lineHeights.0',
   border: '1px solid transparent',
   color: 'colors.default',
   transition: 'box-shadow 80ms ease-in-out',
@@ -55,7 +55,8 @@ const sizes = {
     height: 32
   },
   large: {
-    height: 40
+    height: 40,
+    lineHeight: 'lineHeights.1'
   }
 }
 

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -14,11 +14,6 @@ const baseStyle = {
     cursor: 'not-allowed',
     backgroundColor: 'colors.gray100',
     color: 'colors.muted'
-  },
-
-  _focus: {
-    zIndex: 'zIndices.focused',
-    boxShadow: 'shadows.focusRing'
   }
 }
 
@@ -27,15 +22,14 @@ const appearances = {
     backgroundColor: 'white',
     borderColor: 'colors.gray400',
 
-    _invalid: {
-      borderColor: 'colors.red500'
+    _focus: {
+      zIndex: 'zIndices.focused',
+      boxShadow: 'shadows.focusRing',
+      borderColor: 'colors.blue200'
     },
 
-    _focus: {
-      transition: 'box-shadow 80ms ease-in-out',
-      zIndex: 'zIndices.focused',
-      borderColor: 'colors.blue200',
-      boxShadow: 'shadows.focusRing'
+    _invalid: {
+      borderColor: 'colors.red500'
     },
 
     _placeholderHover: {

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -10,6 +10,12 @@ const baseStyle = {
     color: 'colors.gray600'
   },
 
+  _focus: {
+    zIndex: 'zIndices.focused',
+    boxShadow: 'shadows.focusRing',
+    borderColor: 'colors.blue200'
+  },
+
   _disabled: {
     cursor: 'not-allowed',
     backgroundColor: 'colors.gray100',
@@ -21,12 +27,6 @@ const appearances = {
   default: {
     backgroundColor: 'white',
     borderColor: 'colors.gray400',
-
-    _focus: {
-      zIndex: 'zIndices.focused',
-      boxShadow: 'shadows.focusRing',
-      borderColor: 'colors.blue200'
-    },
 
     _invalid: {
       borderColor: 'colors.red500'


### PR DESCRIPTION
**Overview**
This PR: 

- Fixes line heights to be 16px for smaller textinputs + 18px for larger ones. This also helps stuff look much better in Textarea.
- Fixes some CSS specificity weirdness that was happening when focusing on an invalid text input.
- Makes ids unique in the `<TextInput />` Storybook stories. (Chrome will say something otherwise)

**Screenshots (if applicable)**
https://www.loom.com/share/e6395b2a88bc4ed280f0a1a0cf594af2


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
