### PR TITLE
Initial pass bringing the `classicTheme` implementation closer to what it should be

### DIFF
--- a/src/alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/src/alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -31,6 +31,9 @@ exports[`<Alert /> appearance snapshot 1`] = `
         Test title
       </h4>
     </div>
+    <div
+      className="css-nil ub-pl_34px ub-box-szg_border-box"
+    />
   </div>
 </div>
 `;
@@ -66,6 +69,9 @@ exports[`<Alert /> basic snapshot 1`] = `
         A simple general message
       </h4>
     </div>
+    <div
+      className="css-nil ub-pl_34px ub-box-szg_border-box"
+    />
   </div>
 </div>
 `;
@@ -101,6 +107,9 @@ exports[`<Alert /> intent snapshot 1`] = `
         Test title
       </h4>
     </div>
+    <div
+      className="css-nil ub-pl_34px ub-box-szg_border-box"
+    />
   </div>
 </div>
 `;

--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -85,7 +85,7 @@ const Alert = memo(
               {children}
             </Paragraph>
           ) : (
-            children
+            <Pane paddingLeft={hasIcon ? 34 : 0}>{children}</Pane>
           )}
         </Pane>
         {isRemoveable && (

--- a/src/alert/stories/index.stories.js
+++ b/src/alert/stories/index.stories.js
@@ -1,8 +1,21 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import Box from 'ui-box'
-import { InlineAlert, Alert } from '..'
+import { InlineAlert, Alert, Button, majorScale, Paragraph } from '../..'
 import { Heading } from '../../typography'
+
+/* eslint-disable react/prop-types */
+const ErrorMessage = ({ cta, messaging, title }) => (
+  <Alert appearance="card" intent="danger" title={title}>
+    <Paragraph>{messaging}</Paragraph>
+    {cta && (
+      <Button appearance="primary" marginTop={majorScale(1)} onClick={() => {}}>
+        {cta}
+      </Button>
+    )}
+  </Alert>
+)
+/* eslint-enable react/prop-types */
 
 storiesOf('alert', module)
   .add('Alert', () => (
@@ -37,6 +50,11 @@ storiesOf('alert', module)
               marginBottom={32}
               intent="danger"
               title="We weren’t able to save your changes."
+            />
+            <ErrorMessage
+              title="This is broken"
+              messaging="You need to fix this"
+              cta="Try again"
             />
           </Box>
         ))}

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -78,7 +78,7 @@ const Button = memo(
       disabled,
       iconAfter,
       iconBefore,
-      intent,
+      intent = 'none',
       is = 'button',
       isActive = false,
       isLoading,

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -14,7 +14,7 @@ const IconButton = memo(
     const { icon, iconSize, ...restProps } = props
 
     // modifiers
-    const { appearance, intent, size = 'medium' } = props
+    const { appearance, intent = 'none', size = 'medium' } = props
 
     // Composes the exact same styles as button
     const styleProps = useStyleConfig(
@@ -40,7 +40,7 @@ const IconButton = memo(
       >
         <IconWrapper
           icon={icon}
-          color="currentColor"
+          color={intent === 'none' ? 'default' : 'currentColor'}
           size={iconSize || relativeIconSize}
         />
       </Button>

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -148,12 +148,6 @@ const Dialog = memo(function Dialog({
       return undefined
     }
 
-    let appearance = 'primary'
-
-    if (intent === 'danger') {
-      appearance = 'destructive'
-    }
-
     return (
       <Pane display="flex" justifyContent="flex-end">
         <Pane paddingX={32} paddingBottom={32} paddingTop={24}>
@@ -171,7 +165,8 @@ const Dialog = memo(function Dialog({
               <Button
                 tabIndex={0}
                 marginLeft={8}
-                appearance={appearance}
+                appearance="primary"
+                intent={intent}
                 isLoading={isConfirmLoading}
                 disabled={isConfirmDisabled}
                 onClick={() => onConfirm(close)}

--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-1xdry12 evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-pl_12px ub-pr_12px ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
+    className="css-ylec85 evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-pl_12px ub-pr_12px ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"

--- a/src/hooks/use-clickable.js
+++ b/src/hooks/use-clickable.js
@@ -7,7 +7,7 @@ import { useLatest } from './use-latest'
  * When the component has focus, Enter and space activate it
  */
 export function useClickable({
-  disabled,
+  disabled = false,
   onKeyDown: onKeyDownHandler,
   tabIndex = 0
 }) {

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -60,6 +60,7 @@ const MenuItem = memo(
     )
 
     const iconColor = intent === 'none' ? 'default' : intent
+    const textColor = disabled ? 'muted' : iconColor
 
     return (
       <Pane
@@ -84,7 +85,7 @@ const MenuItem = memo(
           size={16}
           flexShrink={0}
         />
-        <Text color={intent} marginLeft={16} marginRight={16} flex={1}>
+        <Text color={textColor} marginLeft={16} marginRight={16} flex={1}>
           {children}
         </Text>
         {secondaryText && (

--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -42,7 +42,7 @@ const SearchInput = memo(
           alignItems="center"
         >
           <SearchIcon
-            color="gray600"
+            color="default"
             zIndex={StackingOrder.FOCUSED + 1}
             size={iconSize}
           />

--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -149,7 +149,12 @@ const Switch = memo(
             data-checked={checked}
             className={iconContainerStyleClass}
           >
-            {hasCheckIcon && <CheckIcon size={height / 2 - 3} />}
+            {hasCheckIcon && (
+              <CheckIcon
+                display={checked ? 'block' : undefined}
+                size={height / 2 - 3}
+              />
+            )}
           </Box>
           <Box
             width={height * 2}

--- a/src/switch/stories/index.stories.js
+++ b/src/switch/stories/index.stories.js
@@ -19,6 +19,7 @@ storiesOf('switch', module).add('Switch', () => {
         <Switch
           marginBottom={24}
           checked={testOneChecked}
+          hasCheckIcon
           onChange={event => setTestOneChecked(event.target.checked)}
         />
         <Switch marginBottom={24} disabled />

--- a/src/text-input/src/TextInput.js
+++ b/src/text-input/src/TextInput.js
@@ -21,8 +21,7 @@ const internalStyles = {
   outline: 'none',
   textDecoration: 'none',
   WebkitAppearance: 'none',
-  WebkitFontSmoothing: 'antialiased',
-  paddingX: 12
+  WebkitFontSmoothing: 'antialiased'
 }
 
 const TextInput = memo(

--- a/src/themes/classic/components/button.js
+++ b/src/themes/classic/components/button.js
@@ -7,6 +7,7 @@ import { defaultControlStyles } from '../deprecated/shared'
 const baseStyle = {
   fontFamily: 'fontFamilies.ui',
   borderRadius: 'radii.1',
+  fontWeight: 500,
   border: '0',
   color: (theme, { color }) => theme.colors[color] || color || 'colors.default',
   _disabled: {
@@ -52,7 +53,8 @@ const appearances = {
     _disabled: defaultControlStyles.disabled
   },
   minimal: {
-    color: (_, props) => getTextColorForIntent(props.intent),
+    color: (theme, props) =>
+      getTextColorForIntent(props.intent, theme.colors.blue.base),
     background: 'transparent',
     _hover: {
       background: 'scales.neutral.N2A'

--- a/src/themes/classic/components/input.js
+++ b/src/themes/classic/components/input.js
@@ -2,6 +2,8 @@ const baseStyle = {
   borderRadius: 'radii.1',
   lineHeight: 'lineHeights.1',
   color: 'colors.default',
+  fontSize: 'fontSizes.1',
+  paddingX: 10,
 
   _placeholder: {
     color: 'colors.neutralAlpha.N6A'

--- a/src/themes/classic/components/tooltip.js
+++ b/src/themes/classic/components/tooltip.js
@@ -2,6 +2,7 @@ const baseStyle = {
   paddingY: 8,
   paddingX: 16,
   borderRadius: 'radii.1',
+  maxWidth: 240,
   elevation: 'shadows.3'
 }
 

--- a/src/themes/classic/tokens/colors.js
+++ b/src/themes/classic/tokens/colors.js
@@ -140,6 +140,12 @@ const colors = {
     muted: neutral.N3
   },
 
+  text: {
+    success: palette.green.dark,
+    info: palette.blue.dark,
+    danger: palette.red.dark
+  },
+
   icon: {
     default: palette.neutral.N8,
     muted: palette.neutral.N7,

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -4,6 +4,7 @@ const baseStyle = {
   lineHeight: 'lineHeights.0',
   border: '1px solid transparent',
   color: 'colors.default',
+  paddingX: 12,
   transition: 'box-shadow 80ms ease-in-out',
 
   _placeholder: {
@@ -30,10 +31,6 @@ const appearances = {
 
     _invalid: {
       borderColor: 'colors.red500'
-    },
-
-    _placeholderHover: {
-      color: 'colors.gray700'
     }
   },
   none: {

--- a/src/themes/default/components/menu-item.js
+++ b/src/themes/default/components/menu-item.js
@@ -3,6 +3,7 @@ const baseStyle = {
   textDecoration: 'none',
   display: 'flex',
   position: 'relative',
+  paddingX: 12,
 
   _isSelectable: {
     cursor: 'pointer'
@@ -45,7 +46,7 @@ const appearances = {
 
       '&:before': {
         transform: 'scaleX(1)'
-      },
+      }
     },
 
     _current: {
@@ -53,12 +54,12 @@ const appearances = {
 
       '&:before': {
         transform: 'scaleX(1)'
-      },
-    },
+      }
+    }
   }
 }
 
 export default {
   baseStyle,
-  appearances,
+  appearances
 }

--- a/src/themes/default/tokens/colors.js
+++ b/src/themes/default/tokens/colors.js
@@ -95,6 +95,12 @@ const colors = {
     muted: colorScales.gray600,
     disabled: colorScales.gray400,
     selected: colorScales.blue500
+  },
+
+  text: {
+    danger: colorScales.red500,
+    success: colorScales.green500,
+    info: colorScales.blue500
   }
 }
 

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -10,7 +10,7 @@ const Text = memo(
   forwardRef(function Text(props, ref) {
     const {
       className,
-      color = 'default',
+      color: colorProp = 'default',
       fontFamily = 'ui',
       size = 400,
       ...restProps
@@ -19,8 +19,12 @@ const Text = memo(
     const theme = useTheme()
     const { colors, fontFamilies } = theme
 
+    const color =
+      colorProp === 'none' || colorProp === 'default' ? 'default' : colorProp
+
     const themedFontFamily = fontFamilies[fontFamily] || fontFamily
-    const themedColor = colors[color] || color
+    const themedColor =
+      colors[color] || (colors.text && colors.text[color]) || color
 
     const textStyle = useStyleConfig('Text', { size }, emptyObject, emptyObject)
 


### PR DESCRIPTION
**Overview**
This PR goes through an initial round of reconciliation to get the default theme closer to the real thing. 

Summary of changes: 
- Tooltips get back their max width of 240px 
- Input padding is 2px shorter on both sides (10px instead of 12px -- 12px is still preserved for the default theme)
- Menu row items preserve intent (and properly render the right text colors)
- Alerts with icons + children now get padding applied to the children (like they should've before) 
- Modals with intent properly render the button in all cases
- Search input icon is fixed (gray600 is only a color on the default theme)
- Removed the placeholder hover effect on inputs for the default theme


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
