### PR TITLE
Remove dom-helpers, add local lib/canUseDom

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/react-transition-group": "^4.4.0",
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
-    "dom-helpers": "^3.2.1",
     "downshift": "^5.2.0",
     "fuzzaldrin-plus": "^0.6.0",
     "glamor": "^2.20.40",

--- a/src/lib/canUseDom.js
+++ b/src/lib/canUseDom.js
@@ -1,0 +1,1 @@
+export default Boolean(typeof window !== 'undefined' && window.document)

--- a/src/portal/src/Portal.js
+++ b/src/portal/src/Portal.js
@@ -1,7 +1,7 @@
 import { Component } from 'react'
-import canUseDom from 'dom-helpers/util/inDOM'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
+import canUseDom from '../../lib/canUseDom'
 
 let portalContainer
 

--- a/src/ssr/src/autoHydrate.js
+++ b/src/ssr/src/autoHydrate.js
@@ -1,5 +1,6 @@
 import { hydrate as boxHydrate } from 'ui-box'
 import { rehydrate } from 'glamor'
+import canUseDom from '../../lib/canUseDom'
 
 /**
  * You shouldn't have to manually run this.
@@ -16,7 +17,7 @@ export function hydrate(hydration) {
 }
 
 export default function autoHydrate() {
-  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (canUseDom) {
     const hydration = document.querySelector('#evergreen-hydrate')
 
     if (hydration) {

--- a/src/toaster/src/Toaster.js
+++ b/src/toaster/src/Toaster.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import canUseDom from '../../lib/canUseDom'
 import ToastManager from './ToastManager'
-
-const isBrowser =
-  typeof window !== 'undefined' && typeof window.document !== 'undefined'
 
 /**
  * The Toaster manages the interactions between
@@ -11,7 +9,7 @@ const isBrowser =
  */
 export default class Toaster {
   constructor() {
-    if (!isBrowser) return
+    if (!canUseDom) return
 
     const container = document.createElement('div')
     container.setAttribute('data-evergreen-toaster-container', '')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4734,13 +4734,6 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.2.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-helpers@^5.0.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"


### PR DESCRIPTION
This eliminates a dependency on an older version of `dom-helpers` (`3.2.1`) which conflicts with that required by `react-transition-group` (`dom-helpers` `5.0.1`). This addresses an issue using evergreen with shadow-cljs which disallows multiple versions of the same package #858 (I realise it's closed currently, there's a little more detail in my comment [here](https://github.com/segmentio/evergreen/issues/858#issuecomment-698800374)).

I ran tests with `ava` successfully but did trip over some issues with `xo` but I believe they're not introduced by my changes.

There are no ui changes with this and the portal appears to work perfectly well with the updated changes.

I wasn't sure if I should update `examples/ssr-next` or not, I had a bit more difficulty running that with something like an incompatible node version. I can dig further into this if it's helpful and update the yarn.lock there too!

Thanks!