### PR TITLE
[Default theme] Fix input focus rings to just be for default appearance 3ef0c83

### DIFF
--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-ylec85 evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-pl_12px ub-pr_12px ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
+    className="css-12rdf6g evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-pl_12px ub-pr_12px ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -11,12 +11,6 @@ const baseStyle = {
     color: 'colors.gray600'
   },
 
-  _focus: {
-    zIndex: 'zIndices.focused',
-    boxShadow: 'shadows.focusRing',
-    borderColor: 'colors.blue200'
-  },
-
   _disabled: {
     cursor: 'not-allowed',
     backgroundColor: 'colors.gray100',
@@ -28,6 +22,12 @@ const appearances = {
   default: {
     backgroundColor: 'white',
     borderColor: 'colors.gray400',
+
+    _focus: {
+      zIndex: 'zIndices.focused',
+      boxShadow: 'shadows.focusRing',
+      borderColor: 'colors.blue200'
+    },
 
     _invalid: {
       borderColor: 'colors.red500'


### PR DESCRIPTION
**Overview**
Fixing this - input appearance of `none` shouldn't have a focus ring. 


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
