### PR TITLE
Break apart theme styles for Dialog into header, body, and footer props

### DIFF
--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Button, IconButton } from '../../buttons'
+import { useStyleConfig } from '../../hooks'
 import { CrossIcon } from '../../icons'
 import { Pane } from '../../layers'
 import { Overlay } from '../../overlay'
@@ -109,6 +110,25 @@ const Dialog = memo(function Dialog({
     return node
   }
 
+  const themedHeaderProps = useStyleConfig(
+    'DialogHeader',
+    emptyProps,
+    emptyProps,
+    emptyProps
+  )
+  const themedBodyProps = useStyleConfig(
+    'DialogBody',
+    emptyProps,
+    emptyProps,
+    emptyProps
+  )
+  const themedFooterProps = useStyleConfig(
+    'DialogFooter',
+    emptyProps,
+    emptyProps,
+    emptyProps
+  )
+
   const renderHeader = close => {
     if (!header && !hasHeader) {
       return undefined
@@ -116,12 +136,10 @@ const Dialog = memo(function Dialog({
 
     return (
       <Pane
-        paddingX={32}
-        paddingTop={32}
-        paddingBottom={24}
         flexShrink={0}
         display="flex"
         alignItems="center"
+        {...themedHeaderProps}
       >
         {header ? (
           renderNode(header, close)
@@ -149,8 +167,8 @@ const Dialog = memo(function Dialog({
     }
 
     return (
-      <Pane display="flex" justifyContent="flex-end">
-        <Pane paddingX={32} paddingBottom={32} paddingTop={24}>
+      <Pane display="flex" justifyContent="flex-end" {...themedFooterProps}>
+        <Pane>
           {footer ? (
             renderNode(footer, close)
           ) : (
@@ -223,10 +241,9 @@ const Dialog = memo(function Dialog({
             data-state={state}
             display="flex"
             overflow="auto"
-            paddingY={8}
-            paddingX={32}
             flexDirection="column"
             minHeight={minHeightContent}
+            {...themedBodyProps}
             {...contentContainerProps}
           >
             <Pane>{renderChildren(close)}</Pane>

--- a/src/themes/classic/components/dialog-body.js
+++ b/src/themes/classic/components/dialog-body.js
@@ -1,0 +1,7 @@
+const baseStyle = {
+  padding: '16px'
+}
+
+export default {
+  baseStyle
+}

--- a/src/themes/classic/components/dialog-footer.js
+++ b/src/themes/classic/components/dialog-footer.js
@@ -1,0 +1,8 @@
+const baseStyle = {
+  padding: '16px',
+  borderTop: 'muted'
+}
+
+export default {
+  baseStyle
+}

--- a/src/themes/classic/components/dialog-header.js
+++ b/src/themes/classic/components/dialog-header.js
@@ -1,0 +1,8 @@
+const baseStyle = {
+  padding: '16px',
+  borderBottom: 'muted'
+}
+
+export default {
+  baseStyle
+}

--- a/src/themes/classic/components/index.js
+++ b/src/themes/classic/components/index.js
@@ -5,6 +5,9 @@ import Button from './button'
 import Card from './card'
 import Checkbox from './checkbox'
 import Code from './code'
+import DialogBody from './dialog-body'
+import DialogFooter from './dialog-footer'
+import DialogHeader from './dialog-header'
 import Group from './group'
 import Heading from './heading'
 import Icon from './icon'
@@ -44,6 +47,9 @@ export default {
   List,
   Link,
   MenuItem,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
   Pane,
   Paragraph,
   Radio,

--- a/src/themes/default/components/dialog-body.js
+++ b/src/themes/default/components/dialog-body.js
@@ -1,0 +1,8 @@
+const baseStyle = {
+  paddingY: 8,
+  paddingX: 32
+}
+
+export default {
+  baseStyle
+}

--- a/src/themes/default/components/dialog-footer.js
+++ b/src/themes/default/components/dialog-footer.js
@@ -1,0 +1,9 @@
+const baseStyle = {
+  paddingX: 32,
+  paddingBottom: 32,
+  paddingTop: 24
+}
+
+export default {
+  baseStyle
+}

--- a/src/themes/default/components/dialog-header.js
+++ b/src/themes/default/components/dialog-header.js
@@ -1,0 +1,9 @@
+const baseStyle = {
+  paddingX: 32,
+  paddingTop: 32,
+  paddingBottom: 24
+}
+
+export default {
+  baseStyle
+}

--- a/src/themes/default/components/index.js
+++ b/src/themes/default/components/index.js
@@ -5,6 +5,9 @@ import Button from './button'
 import Card from './card'
 import Checkbox from './checkbox'
 import Code from './code'
+import DialogBody from './dialog-body'
+import DialogFooter from './dialog-footer'
+import DialogHeader from './dialog-header'
 import Group from './group'
 import Heading from './heading'
 import Icon from './icon'
@@ -36,6 +39,9 @@ export default {
   Card,
   Checkbox,
   Code,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
   Group,
   Heading,
   Icon,


### PR DESCRIPTION
**Overview**
This PR splits apart some of the visual styles for the v5 and v6 themes into header, footer, and body styles. We could likely push more of the styles into the theme, but this should be a good holdover for now. 


**Screenshots (if applicable)**
https://www.loom.com/share/cd3e1fb01a354de293c9ef15495a5849


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
