### PR TITLE
Tighten up classic theme tooltip padding

### DIFF
--- a/src/themes/classic/components/tooltip.js
+++ b/src/themes/classic/components/tooltip.js
@@ -1,6 +1,6 @@
 const baseStyle = {
-  paddingY: 8,
-  paddingX: 16,
+  paddingX: 8,
+  paddingY: 4,
   borderRadius: 'radii.1',
   maxWidth: 240,
   elevation: 'shadows.3'


### PR DESCRIPTION
**Overview**
Tiny PR that brings the classic theme tooltips more closely to spec - the original implementation had much less padding. 


**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/5349500/94743696-b11f6080-032c-11eb-899b-e5f24e0ca562.png)



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
