### PR TITLE
Make classic theme the fallback theme coming from the theme context

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     {
       "path": "esm/index.js",
       "import": "{ Pane, Text, majorScale, SelectMenu, Menu, AddIcon, RemoveIcon }",
-      "limit": "62 KB",
+      "limit": "65 KB",
       "running": false
     }
   ],

--- a/src/alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/src/alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Alert /> appearance snapshot 1`] = `
 <div
-  className="css-nil ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
+  className="css-1f4h84s css-nil ub-bs_17bru36 ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_white ub-color_234361 ub-bblr_3px ub-bbrr_3px ub-btlr_3px ub-btrr_3px ub-box-szg_border-box"
   role="alert"
 >
   <div
@@ -15,7 +15,7 @@ exports[`<Alert /> appearance snapshot 1`] = `
         className="css-nil ub-mr_16px ub-ml_2px ub-dspl_flex ub-algn-itms_center ub-box-szg_border-box"
       >
         <svg
-          className="css-1ffn9ia ub-w_16px ub-h_16px ub-box-szg_border-box"
+          className="css-1qmfd78 ub-w_16px ub-h_16px ub-box-szg_border-box"
           data-icon="info-sign"
           viewBox="0 0 16 16"
         >
@@ -40,7 +40,7 @@ exports[`<Alert /> appearance snapshot 1`] = `
 
 exports[`<Alert /> basic snapshot 1`] = `
 <div
-  className="css-nil ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
+  className="css-1f4h84s css-nil ub-bs_dn7fs ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_white ub-color_234361 ub-box-szg_border-box"
   role="alert"
 >
   <div
@@ -53,7 +53,7 @@ exports[`<Alert /> basic snapshot 1`] = `
         className="css-nil ub-mr_16px ub-ml_2px ub-dspl_flex ub-algn-itms_center ub-box-szg_border-box"
       >
         <svg
-          className="css-1ffn9ia ub-w_16px ub-h_16px ub-box-szg_border-box"
+          className="css-1qmfd78 ub-w_16px ub-h_16px ub-box-szg_border-box"
           data-icon="info-sign"
           viewBox="0 0 16 16"
         >
@@ -78,7 +78,7 @@ exports[`<Alert /> basic snapshot 1`] = `
 
 exports[`<Alert /> intent snapshot 1`] = `
 <div
-  className="css-nil ub-b-top_1px-solid-D14343 ub-b-rgt_1px-solid-D14343 ub-b-btm_1px-solid-D14343 ub-b-lft_1px-solid-D14343 ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_FDF4F4 ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_A73636 ub-box-szg_border-box"
+  className="css-qomzub css-nil ub-bs_dn7fs ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_white ub-color_234361 ub-box-szg_border-box"
   role="alert"
 >
   <div
@@ -91,7 +91,7 @@ exports[`<Alert /> intent snapshot 1`] = `
         className="css-nil ub-mr_16px ub-ml_2px ub-dspl_flex ub-algn-itms_center ub-box-szg_border-box"
       >
         <svg
-          className="css-tn1wco ub-w_16px ub-h_16px ub-box-szg_border-box"
+          className="css-neu3kn ub-w_16px ub-h_16px ub-box-szg_border-box"
           data-icon="error"
           viewBox="0 0 16 16"
         >

--- a/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
+++ b/src/file-picker/__tests__/__snapshots__/FilePicker.test.js.snap
@@ -11,7 +11,7 @@ exports[`<FilePicker /> snapshot 1`] = `
   />
   <input
     aria-invalid={false}
-    className="css-12rdf6g evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_1px-solid-transparent ub-b-lft_1px-solid-transparent ub-b-rgt_1px-solid-transparent ub-b-top_1px-solid-transparent ub-otln_iu2jf4 ub-txt-deco_none ub-bblr_4px ub-bbrr_0-important ub-btlr_4px ub-btrr_0-important ub-ln-ht_16px ub-color_474d66 ub-pl_12px ub-pr_12px ub-tstn_n1akt6 ub-h_32px ub-bg-clr_white ub-b-btm-clr_d8dae5 ub-b-lft-clr_d8dae5 ub-b-rgt-clr_d8dae5 ub-b-top-clr_d8dae5 ub-flx_1 ub-txt-ovrf_ellipsis ub-fnt-sze_12px ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
+    className="css-1xbq4qr evergreen-file-picker-text-input ub-w_280px ub-fnt-fam_b77syt ub-b-btm_none ub-b-lft_none ub-b-rgt_none ub-b-top_none ub-otln_iu2jf4 ub-txt-deco_none ub-bblr_3px ub-bbrr_0-important ub-btlr_3px ub-btrr_0-important ub-ln-ht_16px ub-color_425A70 ub-fnt-sze_12px ub-pl_10px ub-pr_10px ub-h_32px ub-bg-clr_white ub-bs_13v26xr ub-flx_1 ub-txt-ovrf_ellipsis ub-f-wght_400 ub-ltr-spc_0 ub-box-szg_border-box"
     disabled={false}
     onBlur={[Function]}
     placeholder="Select a file to upload…"
@@ -21,7 +21,7 @@ exports[`<FilePicker /> snapshot 1`] = `
     value=""
   />
   <button
-    className="css-51skc2 evergreen-file-picker-button ub-pst_relative ub-f-wght_400 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_0px ub-bbrr_4px ub-btlr_0px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_16px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-flx-srnk_0 ub-ltr-spc_0 ub-box-szg_border-box"
+    className="css-15cxcpy evergreen-file-picker-button ub-pst_relative ub-f-wght_400 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_0 ub-b-lft_0 ub-b-rgt_0 ub-b-top_0 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_0px ub-bbrr_3px ub-btlr_0px ub-btrr_3px ub-color_425A70 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_16px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-bg-img_zk1eut ub-bs_ruftdn ub-flx-srnk_0 ub-ltr-spc_0 ub-box-szg_border-box"
     onBlur={[Function]}
     onClick={[Function]}
     type="button"

--- a/src/ssr/__tests__/__snapshots__/extractStyles.test.js.snap
+++ b/src/ssr/__tests__/__snapshots__/extractStyles.test.js.snap
@@ -65,7 +65,7 @@ Object {
       "ng405l",
       "fv6wzy",
       "11r1ktn",
-      "51skc2",
+      "15cxcpy",
     ],
     "uiBoxCache": Array [
       Array [
@@ -101,20 +101,20 @@ Object {
         "ub-ver-algn_middle",
       ],
       Array [
-        "borderBottom1px solid #c1c4d6",
-        "ub-b-btm_1px-solid-c1c4d6",
+        "borderBottom0",
+        "ub-b-btm_0",
       ],
       Array [
-        "borderLeft1px solid #c1c4d6",
-        "ub-b-lft_1px-solid-c1c4d6",
+        "borderLeft0",
+        "ub-b-lft_0",
       ],
       Array [
-        "borderRight1px solid #c1c4d6",
-        "ub-b-rgt_1px-solid-c1c4d6",
+        "borderRight0",
+        "ub-b-rgt_0",
       ],
       Array [
-        "borderTop1px solid #c1c4d6",
-        "ub-b-top_1px-solid-c1c4d6",
+        "borderTop0",
+        "ub-b-top_0",
       ],
       Array [
         "outlinenone",
@@ -137,28 +137,24 @@ Object {
         "ub-fnt-fam_b77syt",
       ],
       Array [
-        "borderBottomLeftRadius4px",
-        "ub-bblr_4px",
+        "borderBottomLeftRadius3px",
+        "ub-bblr_3px",
       ],
       Array [
-        "borderBottomRightRadius4px",
-        "ub-bbrr_4px",
+        "borderBottomRightRadius3px",
+        "ub-bbrr_3px",
       ],
       Array [
-        "borderTopLeftRadius4px",
-        "ub-btlr_4px",
+        "borderTopLeftRadius3px",
+        "ub-btlr_3px",
       ],
       Array [
-        "borderTopRightRadius4px",
-        "ub-btrr_4px",
+        "borderTopRightRadius3px",
+        "ub-btrr_3px",
       ],
       Array [
-        "color#474d66",
-        "ub-color_474d66",
-      ],
-      Array [
-        "transitionbox-shadow 80ms ease-in-out",
-        "ub-tstn_n1akt6",
+        "color#425A70",
+        "ub-color_425A70",
       ],
       Array [
         "height32",
@@ -189,12 +185,20 @@ Object {
         "ub-bg-clr_white",
       ],
       Array [
+        "backgroundImagelinear-gradient(to bottom, #FFFFFF, #F4F5F7)",
+        "ub-bg-img_zk1eut",
+      ],
+      Array [
+        "boxShadowinset 0 0 0 1px rgba(67, 90, 111, 0.14), inset 0 -1px 1px 0 rgba(67, 90, 111, 0.06)",
+        "ub-bs_ruftdn",
+      ],
+      Array [
         "boxSizingborder-box",
         "ub-box-szg_border-box",
       ],
     ],
   },
-  "css": ".ub-pst_relative {position: relative;}.ub-f-wght_500 {font-weight: 500;}.ub-dspl_inline-flex {display: inline-flex;}.ub-algn-itms_center {align-items: center; -webkit-box-align: center;}.ub-flx-wrap_nowrap {flex-wrap: nowrap; -webkit-box-lines: nowrap;}.ub-just-cnt_center {justify-content: center; -webkit-box-pack: center;}.ub-txt-deco_none {text-decoration: none;}.ub-ver-algn_middle {vertical-align: middle;}.ub-b-btm_1px-solid-c1c4d6 {border-bottom: 1px solid #c1c4d6;}.ub-b-lft_1px-solid-c1c4d6 {border-left: 1px solid #c1c4d6;}.ub-b-rgt_1px-solid-c1c4d6 {border-right: 1px solid #c1c4d6;}.ub-b-top_1px-solid-c1c4d6 {border-top: 1px solid #c1c4d6;}.ub-otln_iu2jf4 {outline: none;}.ub-usr-slct_none {-webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;}.ub-crsr_pointer {cursor: pointer;}.ub-wht-spc_nowrap {white-space: nowrap;}.ub-fnt-fam_b77syt {font-family: \\"SF UI Text\\", -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\";}.ub-bblr_4px {border-bottom-left-radius: 4px;}.ub-bbrr_4px {border-bottom-right-radius: 4px;}.ub-btlr_4px {border-top-left-radius: 4px;}.ub-btrr_4px {border-top-right-radius: 4px;}.ub-color_474d66 {color: #474d66;}.ub-tstn_n1akt6 {transition: box-shadow 80ms ease-in-out;}.ub-h_32px {height: 32px;}.ub-min-w_32px {min-width: 32px;}.ub-fnt-sze_12px {font-size: 12px;}.ub-ln-ht_32px {line-height: 32px;}.ub-pl_16px {padding-left: 16px;}.ub-pr_16px {padding-right: 16px;}.ub-bg-clr_white {background-color: white;}.ub-box-szg_border-box {box-sizing: border-box;}
+  "css": ".ub-pst_relative {position: relative;}.ub-f-wght_500 {font-weight: 500;}.ub-dspl_inline-flex {display: inline-flex;}.ub-algn-itms_center {align-items: center; -webkit-box-align: center;}.ub-flx-wrap_nowrap {flex-wrap: nowrap; -webkit-box-lines: nowrap;}.ub-just-cnt_center {justify-content: center; -webkit-box-pack: center;}.ub-txt-deco_none {text-decoration: none;}.ub-ver-algn_middle {vertical-align: middle;}.ub-b-btm_0 {border-bottom: 0;}.ub-b-lft_0 {border-left: 0;}.ub-b-rgt_0 {border-right: 0;}.ub-b-top_0 {border-top: 0;}.ub-otln_iu2jf4 {outline: none;}.ub-usr-slct_none {-webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;}.ub-crsr_pointer {cursor: pointer;}.ub-wht-spc_nowrap {white-space: nowrap;}.ub-fnt-fam_b77syt {font-family: \\"SF UI Text\\", -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\";}.ub-bblr_3px {border-bottom-left-radius: 3px;}.ub-bbrr_3px {border-bottom-right-radius: 3px;}.ub-btlr_3px {border-top-left-radius: 3px;}.ub-btrr_3px {border-top-right-radius: 3px;}.ub-color_425A70 {color: #425A70;}.ub-h_32px {height: 32px;}.ub-min-w_32px {min-width: 32px;}.ub-fnt-sze_12px {font-size: 12px;}.ub-ln-ht_32px {line-height: 32px;}.ub-pl_16px {padding-left: 16px;}.ub-pr_16px {padding-right: 16px;}.ub-bg-clr_white {background-color: white;}.ub-bg-img_zk1eut {background-image: linear-gradient(to bottom, #FFFFFF, #F4F5F7);}.ub-bs_ruftdn {box-shadow: inset 0 0 0 1px rgba(67, 90, 111, 0.14), inset 0 -1px 1px 0 rgba(67, 90, 111, 0.06);}.ub-box-szg_border-box {box-sizing: border-box;}
 @-webkit-keyframes loading_ng405l { 
   0% {transform: rotate(0); -webkit-transform: rotate(0);} 
   100% {transform: rotate(360deg); -webkit-transform: rotate(360deg);} 
@@ -219,11 +223,11 @@ Object {
 }@keyframes loading-circle_fv6wzy { 
   0% {stroke-dashoffset: 600;} 
   100% {stroke-dashoffset: 0;} 
-}.css-11r1ktn,[data-css-11r1ktn] {animation: loading_ng405l 2s linear infinite; -webkit-animation: loading_ng405l 2s linear infinite;}.css-51skc2,[data-css-51skc2] {-webkit-font-smoothing: antialiased; -webkit-appearance: none; -moz-appearance: none;}.css-51skc2::-moz-focus-inner ,[data-css-51skc2]::-moz-focus-inner {border: 0;}.css-51skc2:not([disabled]):focus,[data-css-51skc2]:not([disabled]):focus {box-shadow: 0 0 0 2px #D6E0FF;}.css-51skc2[disabled],[data-css-51skc2][disabled] {cursor: not-allowed; pointer-events: none; color: #c1c4d6; border-color: #E6E8F0;}.css-51skc2:not([disabled]):hover,[data-css-51skc2]:not([disabled]):hover {border-color: #8f95b2; background-color: #FAFBFF;}.css-51skc2:not([disabled]):active,[data-css-51skc2]:not([disabled]):active, .css-51skc2:not([disabled])[aria-expanded=\\"true\\"], [data-css-51skc2]:not([disabled])[aria-expanded=\\"true\\"], .css-51skc2:not([disabled])[data-active], [data-css-51skc2]:not([disabled])[data-active] {background-color: #F4F5F9;}",
+}.css-11r1ktn,[data-css-11r1ktn] {animation: loading_ng405l 2s linear infinite; -webkit-animation: loading_ng405l 2s linear infinite;}.css-15cxcpy,[data-css-15cxcpy] {-webkit-font-smoothing: antialiased; -webkit-appearance: none; -moz-appearance: none;}.css-15cxcpy::-moz-focus-inner ,[data-css-15cxcpy]::-moz-focus-inner {border: 0;}.css-15cxcpy[disabled],[data-css-15cxcpy][disabled] {opacity: 0.8; background-image: none; background-color: rgba(67, 90, 111, 0.06); box-shadow: none; color: rgba(67, 90, 111, 0.7); pointer-events: none;}.css-15cxcpy:not([disabled]):hover,[data-css-15cxcpy]:not([disabled]):hover {background-image: linear-gradient(to bottom, #FAFBFB, #EAECEE);}.css-15cxcpy:not([disabled]):active,[data-css-15cxcpy]:not([disabled]):active, .css-15cxcpy:not([disabled])[aria-expanded=\\"true\\"], [data-css-15cxcpy]:not([disabled])[aria-expanded=\\"true\\"], .css-15cxcpy:not([disabled])[data-active], [data-css-15cxcpy]:not([disabled])[data-active] {background-image: none; background-color: rgba(16, 112, 202, 0.09); box-shadow: inset 0 0 0 1px rgba(67, 90, 111, 0.14), inset 0 1px 1px 0 rgba(67, 90, 111, 0.06);}.css-15cxcpy:not([disabled]):focus,[data-css-15cxcpy]:not([disabled]):focus {box-shadow: 0 0 0 3px rgba(16, 112, 202, 0.14), inset 0 0 0 1px rgba(67, 90, 111, 0.3), inset 0 -1px 1px 0 rgba(67, 90, 111, 0.14);}",
   "hydrationScript": <script
     dangerouslySetInnerHTML={
       Object {
-        "__html": "{\\"uiBoxCache\\":[[\\"positionrelative\\",\\"ub-pst_relative\\"],[\\"fontWeight500\\",\\"ub-f-wght_500\\"],[\\"displayinline-flex\\",\\"ub-dspl_inline-flex\\"],[\\"alignItemscenter\\",\\"ub-algn-itms_center\\"],[\\"flexWrapnowrap\\",\\"ub-flx-wrap_nowrap\\"],[\\"justifyContentcenter\\",\\"ub-just-cnt_center\\"],[\\"textDecorationnone\\",\\"ub-txt-deco_none\\"],[\\"verticalAlignmiddle\\",\\"ub-ver-algn_middle\\"],[\\"borderBottom1px solid #c1c4d6\\",\\"ub-b-btm_1px-solid-c1c4d6\\"],[\\"borderLeft1px solid #c1c4d6\\",\\"ub-b-lft_1px-solid-c1c4d6\\"],[\\"borderRight1px solid #c1c4d6\\",\\"ub-b-rgt_1px-solid-c1c4d6\\"],[\\"borderTop1px solid #c1c4d6\\",\\"ub-b-top_1px-solid-c1c4d6\\"],[\\"outlinenone\\",\\"ub-otln_iu2jf4\\"],[\\"userSelectnone\\",\\"ub-usr-slct_none\\"],[\\"cursorpointer\\",\\"ub-crsr_pointer\\"],[\\"whiteSpacenowrap\\",\\"ub-wht-spc_nowrap\\"],[\\"fontFamily\\\\\\"SF UI Text\\\\\\", -apple-system, BlinkMacSystemFont, \\\\\\"Segoe UI\\\\\\", Roboto, Helvetica, Arial, sans-serif, \\\\\\"Apple Color Emoji\\\\\\", \\\\\\"Segoe UI Emoji\\\\\\", \\\\\\"Segoe UI Symbol\\\\\\"\\",\\"ub-fnt-fam_b77syt\\"],[\\"borderBottomLeftRadius4px\\",\\"ub-bblr_4px\\"],[\\"borderBottomRightRadius4px\\",\\"ub-bbrr_4px\\"],[\\"borderTopLeftRadius4px\\",\\"ub-btlr_4px\\"],[\\"borderTopRightRadius4px\\",\\"ub-btrr_4px\\"],[\\"color#474d66\\",\\"ub-color_474d66\\"],[\\"transitionbox-shadow 80ms ease-in-out\\",\\"ub-tstn_n1akt6\\"],[\\"height32\\",\\"ub-h_32px\\"],[\\"minWidth32\\",\\"ub-min-w_32px\\"],[\\"fontSize12px\\",\\"ub-fnt-sze_12px\\"],[\\"lineHeight32px\\",\\"ub-ln-ht_32px\\"],[\\"paddingLeft16\\",\\"ub-pl_16px\\"],[\\"paddingRight16\\",\\"ub-pr_16px\\"],[\\"backgroundColorwhite\\",\\"ub-bg-clr_white\\"],[\\"boxSizingborder-box\\",\\"ub-box-szg_border-box\\"]],\\"glamorIds\\":[\\"ng405l\\",\\"fv6wzy\\",\\"11r1ktn\\",\\"51skc2\\"]}",
+        "__html": "{\\"uiBoxCache\\":[[\\"positionrelative\\",\\"ub-pst_relative\\"],[\\"fontWeight500\\",\\"ub-f-wght_500\\"],[\\"displayinline-flex\\",\\"ub-dspl_inline-flex\\"],[\\"alignItemscenter\\",\\"ub-algn-itms_center\\"],[\\"flexWrapnowrap\\",\\"ub-flx-wrap_nowrap\\"],[\\"justifyContentcenter\\",\\"ub-just-cnt_center\\"],[\\"textDecorationnone\\",\\"ub-txt-deco_none\\"],[\\"verticalAlignmiddle\\",\\"ub-ver-algn_middle\\"],[\\"borderBottom0\\",\\"ub-b-btm_0\\"],[\\"borderLeft0\\",\\"ub-b-lft_0\\"],[\\"borderRight0\\",\\"ub-b-rgt_0\\"],[\\"borderTop0\\",\\"ub-b-top_0\\"],[\\"outlinenone\\",\\"ub-otln_iu2jf4\\"],[\\"userSelectnone\\",\\"ub-usr-slct_none\\"],[\\"cursorpointer\\",\\"ub-crsr_pointer\\"],[\\"whiteSpacenowrap\\",\\"ub-wht-spc_nowrap\\"],[\\"fontFamily\\\\\\"SF UI Text\\\\\\", -apple-system, BlinkMacSystemFont, \\\\\\"Segoe UI\\\\\\", Roboto, Helvetica, Arial, sans-serif, \\\\\\"Apple Color Emoji\\\\\\", \\\\\\"Segoe UI Emoji\\\\\\", \\\\\\"Segoe UI Symbol\\\\\\"\\",\\"ub-fnt-fam_b77syt\\"],[\\"borderBottomLeftRadius3px\\",\\"ub-bblr_3px\\"],[\\"borderBottomRightRadius3px\\",\\"ub-bbrr_3px\\"],[\\"borderTopLeftRadius3px\\",\\"ub-btlr_3px\\"],[\\"borderTopRightRadius3px\\",\\"ub-btrr_3px\\"],[\\"color#425A70\\",\\"ub-color_425A70\\"],[\\"height32\\",\\"ub-h_32px\\"],[\\"minWidth32\\",\\"ub-min-w_32px\\"],[\\"fontSize12px\\",\\"ub-fnt-sze_12px\\"],[\\"lineHeight32px\\",\\"ub-ln-ht_32px\\"],[\\"paddingLeft16\\",\\"ub-pl_16px\\"],[\\"paddingRight16\\",\\"ub-pr_16px\\"],[\\"backgroundColorwhite\\",\\"ub-bg-clr_white\\"],[\\"backgroundImagelinear-gradient(to bottom, #FFFFFF, #F4F5F7)\\",\\"ub-bg-img_zk1eut\\"],[\\"boxShadowinset 0 0 0 1px rgba(67, 90, 111, 0.14), inset 0 -1px 1px 0 rgba(67, 90, 111, 0.06)\\",\\"ub-bs_ruftdn\\"],[\\"boxSizingborder-box\\",\\"ub-box-szg_border-box\\"]],\\"glamorIds\\":[\\"ng405l\\",\\"fv6wzy\\",\\"11r1ktn\\",\\"15cxcpy\\"]}",
       }
     }
     id="evergreen-hydrate"

--- a/src/theme/src/ThemeContext.js
+++ b/src/theme/src/ThemeContext.js
@@ -1,10 +1,14 @@
 import React from 'react'
-import defaultTheme from '../../themes/default'
+import classicTheme from '../../themes/classic'
 
 /**
  * Use React 16.3+ createContext API.
  */
-const ThemeContext = React.createContext(defaultTheme)
+
+// NOTE(allen) - switch this back once we properly refactor Toasts to render
+// them in the existing DOM tree flow, instead of mounting a new root
+// outside of whatever app root an EG consumer is using.
+const ThemeContext = React.createContext(classicTheme)
 const { Consumer: ThemeConsumer, Provider: ThemeProvider } = ThemeContext
 
 export default ThemeContext


### PR DESCRIPTION
**Overview**
Left a comment in the theme context provider explaining why we're doing this for now. Once we untangle a new Toaster API + ship v6 completely, we can remove this. 


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
