### PR TITLE
Move `<Tab />` spacing into theme

### DIFF
--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -50,15 +50,10 @@ const Tab = memo(
 
     const { className: themedClassName, ...boxProps } = useStyleConfig(
       'Tab',
-      { appearance },
+      { appearance, direction },
       pseudoSelectors,
       getInternalStyles(direction)
     )
-
-    const spacing =
-      direction === 'horizontal'
-        ? { marginRight: '8px' }
-        : { marginBottom: '8px' }
 
     const onClickRef = useLatest(props.onClick)
     const handleClick = useCallback(
@@ -115,7 +110,6 @@ const Tab = memo(
         height={height}
         ref={ref}
         tabIndex={0}
-        {...spacing}
         {...boxProps}
         {...rest}
         onClick={handleClick}

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -24,12 +24,13 @@ const getInternalStyles = direction => ({
 })
 
 const pseudoSelectors = {
-  _hover: '&:hover',
-  _current: '&[aria-current="page"], &[aria-selected="true"]',
-  _focus: '&:focus',
   _active: '&:active',
+  _after: '&:after',
   _before: '&:before',
-  _after: '&:after'
+  _current: '&[aria-current="page"], &[aria-selected="true"]',
+  _disabled: '&[aria-disabled="true"]',
+  _focus: '&:focus',
+  _hover: '&:hover'
 }
 
 const Tab = memo(

--- a/src/tabs/stories/index.stories.js
+++ b/src/tabs/stories/index.stories.js
@@ -130,7 +130,43 @@ storiesOf('tabs', module)
                 <Tablist marginX={-4} marginBottom={16}>
                   {tabs.map((tab, index) => (
                     <Tab
-                      disabled={index === 2}
+                      appearance="primary"
+                      disabled={true}
+                      key={tab}
+                      id={tab}
+                      onSelect={() => onSelect(index)}
+                      isSelected={index === selectedIndex}
+                      aria-controls={`panel-${tab}`}
+                    >
+                      {tab}
+                    </Tab>
+                  ))}
+                </Tablist>
+                <Box padding={16} backgroundColor="#eee">
+                  {tabs.map((tab, index) => (
+                    <Box
+                      key={tab}
+                      id={`panel-${tab}`}
+                      role="tabpanel"
+                      aria-labelledby={tab}
+                      aria-hidden={index !== selectedIndex}
+                      display={index === selectedIndex ? 'block' : 'none'}
+                    >
+                      <Paragraph>Panel {tab}</Paragraph>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </TabManager>
+
+          <TabManager>
+            {({ onSelect, selectedIndex }) => (
+              <Box marginTop={32}>
+                <Tablist marginX={-4} marginBottom={16}>
+                  {tabs.map((tab, index) => (
+                    <Tab
+                      disabled={true}
                       key={tab}
                       id={tab}
                       onSelect={() => onSelect(index)}

--- a/src/themes/classic/components/tab.js
+++ b/src/themes/classic/components/tab.js
@@ -22,6 +22,16 @@ const baseStyle = {
 
   _focus: {
     boxShadow: 'shadows.focusRing'
+  },
+
+  _disabled: {
+    pointerEvents: 'none',
+    cursor: 'not-allowed',
+    color: 'colors.neutralAlpha.N7A',
+
+    '&[aria-current="page"], &[aria-selected="true"]': {
+      backgroundColor: 'colors.neutralAlpha.N2A'
+    }
   }
 }
 

--- a/src/themes/classic/components/tab.js
+++ b/src/themes/classic/components/tab.js
@@ -1,10 +1,11 @@
 const baseStyle = {
   fontFamily: 'fontFamilies.ui',
   fontWeight: 500,
-  paddingX: '16px',
-  paddingY: '8px',
+  padding: '8px',
   borderRadius: 'radii.1',
   color: 'colors.default',
+  marginX: (_, props) => props.direction === 'horizontal' ? '4px' : null,
+  marginY: (_, props) => props.direction === 'vertical' ? '4px' : null,
 
   _hover: {
     backgroundColor: 'colors.neutralAlpha.N2A',

--- a/src/themes/default/components/tab.js
+++ b/src/themes/default/components/tab.js
@@ -1,6 +1,7 @@
 const baseStyle = {
   fontFamily: 'fontFamilies.ui',
-  fontWeight: 500
+  fontWeight: 500,
+  marginBottom: (_, props) => props.direction === 'vertical' ? '8px' : null,
 }
 
 const appearances = {
@@ -13,7 +14,7 @@ const appearances = {
     position: 'relative',
 
     ':not(:last-child)': {
-      marginRight: '20px'
+      marginRight: (_, props) => props.direction === 'horizontal' ? '20px' : null,
     },
     
     _before: {
@@ -56,6 +57,10 @@ const appearances = {
     paddingY: '8px',
     borderRadius: 'radii.1',
     color: 'colors.default',
+
+    ':not(:last-child)': {
+      marginRight: (_, props) => props.direction === 'horizontal' ? '8px' : null,
+    },
 
     _hover: {
       backgroundColor: 'colors.gray100',

--- a/src/themes/default/components/tab.js
+++ b/src/themes/default/components/tab.js
@@ -49,6 +49,16 @@ const appearances = {
 
     _focus: {
       color: 'colors.default'
+    },
+
+    _disabled: {
+      pointerEvents: 'none',
+      cursor: 'not-allowed',
+      color: 'colors.gray500',
+
+      '&:before': {
+        backgroundColor: 'colors.gray500'
+      }
     }
   },
 
@@ -78,6 +88,16 @@ const appearances = {
 
     _focus: {
       boxShadow: 'shadows.focusRing'
+    },
+
+    _disabled: {
+      pointerEvents: 'none',
+      cursor: 'not-allowed',
+      color: 'colors.gray500',
+
+      '&[aria-current="page"], &[aria-selected="true"]': {
+        backgroundColor: 'colors.gray100'
+      }
     }
   }
 }


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Move spacing into theme to better support classic theme

**Screenshots (if applicable)**
**Default Theme (v6)**
![image](https://user-images.githubusercontent.com/17129452/94859847-0f5e4900-03ea-11eb-9b79-82edf3b1b767.png)

**Classic theme (v5)**
![image](https://user-images.githubusercontent.com/17129452/94854988-a8896180-03e2-11eb-8052-4c03acb6e03f.png)
![image](https://user-images.githubusercontent.com/17129452/94859905-2309af80-03ea-11eb-963b-5d65adbbaa9c.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
