### PR TITLE
Remove explicit `type` set on `<Button />`

### DIFF
--- a/src/buttons/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.test.js.snap
@@ -3,13 +3,11 @@
 exports[`<Button /> % classic snapshots with the rendered output 1`] = `
 <button
   className="css-15cxcpy ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_0 ub-b-lft_0 ub-b-rgt_0 ub-b-top_0 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_3px ub-bbrr_3px ub-btlr_3px ub-btrr_3px ub-color_425A70 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-bg-img_zk1eut ub-bs_ruftdn ub-box-szg_border-box"
-  type="button"
 />
 `;
 
 exports[`<Button /> % default snapshots with the rendered output 1`] = `
 <button
   className="css-51skc2 ub-pst_relative ub-f-wght_500 ub-dspl_inline-flex ub-algn-itms_center ub-flx-wrap_nowrap ub-just-cnt_center ub-txt-deco_none ub-ver-algn_middle ub-b-btm_1px-solid-c1c4d6 ub-b-lft_1px-solid-c1c4d6 ub-b-rgt_1px-solid-c1c4d6 ub-b-top_1px-solid-c1c4d6 ub-otln_iu2jf4 ub-usr-slct_none ub-crsr_pointer ub-wht-spc_nowrap ub-fnt-fam_b77syt ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-color_474d66 ub-tstn_n1akt6 ub-h_32px ub-min-w_32px ub-fnt-sze_12px ub-ln-ht_32px ub-pl_16px ub-pr_16px ub-bg-clr_white ub-box-szg_border-box"
-  type="button"
 />
 `;

--- a/src/buttons/src/Button.js
+++ b/src/buttons/src/Button.js
@@ -104,7 +104,6 @@ const Button = memo(
       <Box
         is={is}
         ref={ref}
-        type={is === 'button' ? 'button' : undefined}
         className={cx(themedClassName, className)}
         data-active={isActive || undefined}
         {...boxProps}


### PR DESCRIPTION
**Overview**
This breaks cases where consumers can put a button inside a `form` without explicitly setting `type="submit"`


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
