### PR TITLE
Bring default theme headings + font weights closer to spec 

### DIFF
--- a/src/themes/default/components/heading.js
+++ b/src/themes/default/components/heading.js
@@ -40,21 +40,18 @@ const sizes = {
   },
   400: {
     fontSize: 'fontSizes.2',
-    fontWeight: 'fontWeights.bold',
     lineHeight: 'lineHeights.1',
     letterSpacing: 'letterSpacings.tight',
     fontFamily: 'fontFamilies.ui'
   },
   300: {
     fontSize: 'fontSizes.1',
-    fontWeight: 'fontWeights.bold',
     lineHeight: 'lineHeights.0',
     letterSpacing: 'letterSpacings.normal',
     fontFamily: 'fontFamilies.ui'
   },
   200: {
     fontSize: 'fontSizes.1',
-    fontWeight: 'fontWeights.bold',
     lineHeight: 'lineHeights.0',
     letterSpacing: 'letterSpacings.normal',
     fontFamily: 'fontFamilies.ui',
@@ -62,7 +59,6 @@ const sizes = {
   },
   100: {
     fontSize: 'fontSizes.0',
-    fontWeight: 'fontWeights.normal',
     textTransform: 'uppercase',
     lineHeight: 'lineHeights.0',
     letterSpacing: 'letterSpacings.wide',

--- a/src/themes/default/components/heading.js
+++ b/src/themes/default/components/heading.js
@@ -10,26 +10,31 @@ const sizes = {
   900: {
     fontSize: 'fontSizes.7',
     lineHeight: 'lineHeights.6',
+    fontWeight: 'fontWeights.bold',
     letterSpacing: 'letterSpacings.tightest'
   },
   800: {
     fontSize: 'fontSizes.6',
     lineHeight: 'lineHeights.5',
+    fontWeight: 'fontWeights.bold',
     letterSpacing: 'letterSpacings.tightest'
   },
   700: {
     fontSize: 'fontSizes.5',
     lineHeight: 'lineHeights.3',
+    fontWeight: 'fontWeights.bold',
     letterSpacing: 'letterSpacings.tighter'
   },
   600: {
     fontSize: 'fontSizes.4',
     lineHeight: 'lineHeights.3',
+    fontWeight: 'fontWeights.bold',
     letterSpacing: 'letterSpacings.tighter'
   },
   500: {
     fontFamily: 'fontFamilies.ui',
     fontSize: 'fontSizes.3',
+    fontWeight: 'fontWeights.bold',
     letterSpacing: 'letterSpacings.tight',
     lineHeight: 'lineHeights.2'
   },


### PR DESCRIPTION
**Overview**
Any heading 500 >= should have `600` as the font weight -- anything other than that, should just be set to the semibold font weight (500)


**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/5349500/95142892-9d5b6c00-0729-11eb-970e-181faec2be86.png)



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
