### PR TITLE
Fixup paragraph line height and table row selected color in classic theme

### DIFF
--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Component from '@reactions/component'
 import { storiesOf } from '@storybook/react'
 import faker from 'faker'
 import Box from 'ui-box'
@@ -136,15 +137,26 @@ storiesOf('table', module)
         document.body.style.margin = '0'
         document.body.style.height = '100vh'
       })()}
-      <Table.Body>
-        {range(10).map(item => {
-          return (
-            <Table.Row key={item} isSelectable onSelect={() => alert('selected!')} onDeselect={() => alert('deselected!')}>
-              <Table.TextCell>{item}</Table.TextCell>
-            </Table.Row>
-          )
-        })}
-      </Table.Body>
+
+      <Component initialState={{ selectedItem: null }}>
+        {({ setState, state }) => (
+          <Table.Body>
+            {range(10).map(item => {
+              return (
+                <Table.Row
+                  key={item}
+                  isSelectable
+                  isSelected={state.selectedItem === item}
+                  onSelect={() => setState({ selectedItem: item })}
+                  onDeselect={() => setState({ selectedItem: null })}
+                >
+                  <Table.TextCell>{item}</Table.TextCell>
+                </Table.Row>
+              )
+            })}
+          </Table.Body>
+        )}
+      </Component>
     </Box>
   ))
   .add('Table.HeaderCell', () => (

--- a/src/themes/classic/components/paragraph.js
+++ b/src/themes/classic/components/paragraph.js
@@ -9,17 +9,17 @@ const paragraphSizes = {
   300: {
     fontSize: 'fontSizes.1',
     fontWeight: 'fontWeights.normal',
-    lineHeight: 'lineHeights.1',
+    lineHeight: 'lineHeights.0',
     letterSpacing: 'letterSpacings.normal'
   },
   400: {
     fontSize: 'fontSizes.2',
     fontWeight: 'fontWeights.normal',
-    lineHeight: 'lineHeights.3',
+    lineHeight: 'lineHeights.2',
     letterSpacing: 'letterSpacings.tight'
   },
   500: {
-    fontSize: 'fontSizes.3',
+    fontSize: 'fontSizes.2',
     fontWeight: 'fontWeights.normal',
     lineHeight: 'lineHeights.3',
     letterSpacing: 'letterSpacings.tight'
@@ -27,7 +27,7 @@ const paragraphSizes = {
   600: {
     fontSize: 'fontSizes.4',
     fontWeight: 'fontWeights.normal',
-    lineHeight: 'lineHeights.4',
+    lineHeight: 'lineHeights.3',
     letterSpacing: 'letterSpacings.tighter'
   }
 }

--- a/src/themes/classic/components/table-row.js
+++ b/src/themes/classic/components/table-row.js
@@ -3,8 +3,8 @@ const colorMap = {
     base: 'white',
     hover: 'colors.neutral.lightest',
     focus: 'colors.neutral.lightest',
-    active: 'colors.blue.light',
-    current: 'colors.blue.light'
+    active: 'colors.blue.lightest',
+    current: 'colors.blue.lightest'
   },
 
   danger: {
@@ -12,7 +12,7 @@ const colorMap = {
     hover: 'colors.red.lightest',
     focus: 'colors.red.light',
     active: 'colors.red.light',
-    current: 'colors.red.light',
+    current: 'colors.red.light'
   },
 
   warning: {
@@ -20,7 +20,7 @@ const colorMap = {
     hover: 'colors.yellow.lightest',
     focus: 'colors.yellow.light',
     active: 'colors.yellow.light',
-    current: 'colors.yellow.light',
+    current: 'colors.yellow.light'
   },
 
   success: {
@@ -28,11 +28,12 @@ const colorMap = {
     hover: 'colors.green.lightest',
     focus: 'colors.green.light',
     active: 'colors.green.light',
-    current: 'colors.green.light',
+    current: 'colors.green.light'
   }
 }
 
-const getBackgroundForIntentAndState = (intent, state) => colorMap[intent][state]
+const getBackgroundForIntentAndState = (intent, state) =>
+  colorMap[intent][state]
 
 const baseStyle = {
   outline: 'none',
@@ -46,27 +47,32 @@ const baseStyle = {
 
 const appearances = {
   default: {
-    backgroundColor: (_, props) => getBackgroundForIntentAndState(props.intent, 'base'),
+    backgroundColor: (_, props) =>
+      getBackgroundForIntentAndState(props.intent, 'base'),
 
     _hover: {
-      backgroundColor: (_, props) => getBackgroundForIntentAndState(props.intent, 'hover')
+      backgroundColor: (_, props) =>
+        getBackgroundForIntentAndState(props.intent, 'hover')
     },
 
     _focus: {
-      backgroundColor: (_, props) => getBackgroundForIntentAndState(props.intent, 'focus')
+      backgroundColor: (_, props) =>
+        getBackgroundForIntentAndState(props.intent, 'focus')
     },
 
     _active: {
-      backgroundColor: (_, props) => getBackgroundForIntentAndState(props.intent, 'active')
+      backgroundColor: (_, props) =>
+        getBackgroundForIntentAndState(props.intent, 'active')
     },
 
     _current: {
-      backgroundColor: (_, props) => getBackgroundForIntentAndState(props.intent, 'current')
-    },
+      backgroundColor: (_, props) =>
+        getBackgroundForIntentAndState(props.intent, 'current')
+    }
   }
 }
 
 export default {
   baseStyle,
-  appearances,
+  appearances
 }


### PR DESCRIPTION
**Overview**
This PR makes the selected table row a bit closer to the original v5 theme, and makes the paragraph line heights a bit more accurate too (400 / 500 paragraph sizes should both be 14px, with some slight adjustments in line height (20px -> 24px)


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
