### PR TITLE
Fix tabs to correctly justify content

### DIFF
--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -10,6 +10,7 @@ const noop = () => {}
 
 const getInternalStyles = direction => ({
   alignItems: 'center',
+  justifyContent: 'center',
   textDecoration: 'none',
   cursor: 'pointer',
   outline: 'none',

--- a/src/tabs/stories/index.stories.js
+++ b/src/tabs/stories/index.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { Tab, Tablist, TabNavigation } from '..'
+import { majorScale } from '../../scales'
 import { Heading, Paragraph } from '../../typography'
 
 const StorySection = props => <Box marginBottom={40} {...props} />
@@ -108,6 +109,24 @@ storiesOf('tabs', module)
           <TabNavigation marginX={-4} marginBottom={16}>
             {tabs.map((tab, index) => (
               <Tab key={tab} is="a" href="#" id={tab} isSelected={index === 0}>
+                {tab}
+              </Tab>
+            ))}
+          </TabNavigation>
+        </Box>
+      </StorySection>
+      <StorySection>
+        <StoryHeader>
+          <StoryHeading>Min-width Tabs</StoryHeading>
+          <StoryDescription>
+            Tabs with a min-width set on them
+          </StoryDescription>
+        </StoryHeader>
+
+        <Box>
+          <TabNavigation marginX={-4} marginBottom={16}>
+            {tabs.map((tab, index) => (
+              <Tab key={tab} is="a" href="#" id={tab} isSelected={index === 0} minWidth={majorScale(13)}>
                 {tab}
               </Tab>
             ))}


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Fix the content justification to be center for tabs

**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/17129452/95394722-ed653a80-08b1-11eb-99ce-0e23b34428c9.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
