### PR TITLE
Quick fix for vertical tabs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2641,9 +2641,7 @@ export interface IconProps extends BoxProps<'svg'> {
 }
 
 /* Start generated icons */
-type IconComponent = React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>
->
+type IconComponent = React.ForwardRefExoticComponent<React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>>
 export declare const AddIcon: IconComponent
 export declare const AddColumnLeftIcon: IconComponent
 export declare const AddColumnRightIcon: IconComponent

--- a/src/tabs/src/Tab.js
+++ b/src/tabs/src/Tab.js
@@ -10,7 +10,7 @@ const noop = () => {}
 
 const getInternalStyles = direction => ({
   alignItems: 'center',
-  justifyContent: 'center',
+  justifyContent: direction === 'horizontal' ? 'center' : 'flex-start',
   textDecoration: 'none',
   cursor: 'pointer',
   outline: 'none',


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Fix an issue introduced in 6.0.0-20 for vertical tabs where text was being centered instead of left aligned. Min-width horizontal tabs should still align center 

**Screenshots (if applicable)**
**Before**
![image](https://user-images.githubusercontent.com/17129452/95399808-e3e1cf80-08bd-11eb-8c93-98c0efc589a2.png)


**After**
![image](https://user-images.githubusercontent.com/17129452/95399827-ef34fb00-08bd-11eb-9819-3bb313f787de.png)
![image](https://user-images.githubusercontent.com/17129452/95399847-fcea8080-08bd-11eb-8473-b4f2ab48e43a.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
