### PR TITLE
Fix color of headings in default theme

### DIFF
--- a/src/themes/default/components/heading.js
+++ b/src/themes/default/components/heading.js
@@ -1,5 +1,5 @@
 const baseStyle = {
-  color: 'colors.default',
+  color: 'colors.dark',
   fontFamily: 'fontFamilies.display',
   fontWeight: 'fontWeights.semibold'
 }

--- a/src/themes/default/components/link.js
+++ b/src/themes/default/components/link.js
@@ -11,6 +11,7 @@ const getThemeKeyForColor = color => {
 
 const baseStyle = {
   color: (_, { color }) => `colors.${getThemeKeyForColor(color)}500`,
+  textDecoration: 'none',
   _hover: {
     color: (_, { color }) => `colors.${getThemeKeyForColor(color)}400`
   },


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Update `<Heading />` Theme colors to match figma spec

`colors.default` -> `colors.dark`

**Screenshots (if applicable)**
n/a

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
