### PR TITLE
Migrate `<Label />` away from using `<Text />`

### DIFF
--- a/src/themes/classic/components/index.js
+++ b/src/themes/classic/components/index.js
@@ -13,6 +13,7 @@ import Heading from './heading'
 import Icon from './icon'
 import InlineAlert from './inline-alert'
 import Input from './input'
+import Label from './label'
 import Link from './link'
 import List from './list'
 import MenuItem from './menu-item'
@@ -48,6 +49,7 @@ export default {
   Icon,
   InlineAlert,
   Input,
+  Label,
   List,
   Link,
   MenuItem,

--- a/src/themes/classic/components/label.js
+++ b/src/themes/classic/components/label.js
@@ -1,0 +1,73 @@
+const baseStyle = {
+  color: 'colors.dark',
+  fontFamily: 'fontFamilies.display',
+  fontWeight: 'fontWeights.semibold'
+}
+
+const appearances = {}
+
+const sizes = {
+  900: {
+    fontSize: 'fontSizes.7',
+    lineHeight: 'lineHeights.6',
+    letterSpacing: 'letterSpacings.tightest'
+  },
+  800: {
+    fontSize: 'fontSizes.6',
+    lineHeight: 'lineHeights.5',
+    letterSpacing: 'letterSpacings.tightest'
+  },
+  700: {
+    fontSize: 'fontSizes.5',
+    lineHeight: 'lineHeights.3',
+    letterSpacing: 'letterSpacings.tighter'
+  },
+  600: {
+    fontSize: 'fontSizes.4',
+    lineHeight: 'lineHeights.3',
+    letterSpacing: 'letterSpacings.tighter'
+  },
+  500: {
+    fontFamily: 'fontFamilies.ui',
+    fontSize: 'fontSizes.3',
+    letterSpacing: 'letterSpacings.tight',
+    lineHeight: 'lineHeights.2'
+  },
+  400: {
+    fontSize: 'fontSizes.2',
+    fontWeight: 'fontWeights.bold',
+    lineHeight: 'lineHeights.1',
+    letterSpacing: 'letterSpacings.tight',
+    fontFamily: 'fontFamilies.ui'
+  },
+  300: {
+    fontSize: 'fontSizes.1',
+    fontWeight: 'fontWeights.bold',
+    lineHeight: 'lineHeights.0',
+    letterSpacing: 'letterSpacings.normal',
+    fontFamily: 'fontFamilies.ui'
+  },
+  200: {
+    fontSize: 'fontSizes.1',
+    fontWeight: 'fontWeights.bold',
+    lineHeight: 'lineHeights.0',
+    letterSpacing: 'letterSpacings.normal',
+    fontFamily: 'fontFamilies.ui',
+    color: 'colors.muted'
+  },
+  100: {
+    fontSize: 'fontSizes.0',
+    fontWeight: 'fontWeights.normal',
+    textTransform: 'uppercase',
+    lineHeight: 'lineHeights.0',
+    letterSpacing: 'letterSpacings.wide',
+    fontFamily: 'fontFamilies.ui',
+    color: 'colors.muted'
+  }
+}
+
+export default {
+  baseStyle,
+  appearances,
+  sizes
+}

--- a/src/themes/default/components/index.js
+++ b/src/themes/default/components/index.js
@@ -13,6 +13,7 @@ import Heading from './heading'
 import Icon from './icon'
 import InlineAlert from './inline-alert'
 import Input from './input'
+import Label from './label'
 import Link from './link'
 import List from './list'
 import MenuItem from './menu-item'
@@ -48,6 +49,7 @@ export default {
   Icon,
   InlineAlert,
   Input,
+  Label,
   List,
   Link,
   MenuItem,

--- a/src/themes/default/components/label.js
+++ b/src/themes/default/components/label.js
@@ -1,0 +1,74 @@
+const baseStyle = {
+  color: 'colors.dark',
+  fontFamily: 'fontFamilies.display',
+  fontWeight: 'fontWeights.semibold'
+}
+
+const appearances = {}
+
+const sizes = {
+  900: {
+    fontSize: 'fontSizes.7',
+    lineHeight: 'lineHeights.6',
+    fontWeight: 'fontWeights.bold',
+    letterSpacing: 'letterSpacings.tightest'
+  },
+  800: {
+    fontSize: 'fontSizes.6',
+    lineHeight: 'lineHeights.5',
+    fontWeight: 'fontWeights.bold',
+    letterSpacing: 'letterSpacings.tightest'
+  },
+  700: {
+    fontSize: 'fontSizes.5',
+    lineHeight: 'lineHeights.3',
+    fontWeight: 'fontWeights.bold',
+    letterSpacing: 'letterSpacings.tighter'
+  },
+  600: {
+    fontSize: 'fontSizes.4',
+    lineHeight: 'lineHeights.3',
+    fontWeight: 'fontWeights.bold',
+    letterSpacing: 'letterSpacings.tighter'
+  },
+  500: {
+    fontFamily: 'fontFamilies.ui',
+    fontSize: 'fontSizes.3',
+    fontWeight: 'fontWeights.bold',
+    letterSpacing: 'letterSpacings.tight',
+    lineHeight: 'lineHeights.2'
+  },
+  400: {
+    fontSize: 'fontSizes.2',
+    lineHeight: 'lineHeights.1',
+    letterSpacing: 'letterSpacings.tight',
+    fontFamily: 'fontFamilies.ui'
+  },
+  300: {
+    fontSize: 'fontSizes.1',
+    lineHeight: 'lineHeights.0',
+    letterSpacing: 'letterSpacings.normal',
+    fontFamily: 'fontFamilies.ui'
+  },
+  200: {
+    fontSize: 'fontSizes.1',
+    lineHeight: 'lineHeights.0',
+    letterSpacing: 'letterSpacings.normal',
+    fontFamily: 'fontFamilies.ui',
+    color: 'colors.muted'
+  },
+  100: {
+    fontSize: 'fontSizes.0',
+    textTransform: 'uppercase',
+    lineHeight: 'lineHeights.0',
+    letterSpacing: 'letterSpacings.wide',
+    fontFamily: 'fontFamilies.ui',
+    color: 'colors.muted'
+  }
+}
+
+export default {
+  baseStyle,
+  appearances,
+  sizes
+}

--- a/src/typography/src/Label.js
+++ b/src/typography/src/Label.js
@@ -16,7 +16,7 @@ const Label = memo(
     } = props
 
     const { className: themedClassName, ...boxProps } = useStyleConfig(
-      'Heading',
+      'Label',
       { size },
       pseudoSelectors,
       internalStyles
@@ -41,7 +41,7 @@ Label.propTypes = {
   ...Box.propTypes,
 
   /**
-   * The size of the label, visually based off the Heading sizes
+   * The size of the label.
    */
   size: PropTypes.oneOf([100, 200, 300, 400, 500, 600, 700, 800, 900])
 }

--- a/src/typography/src/Label.js
+++ b/src/typography/src/Label.js
@@ -1,14 +1,49 @@
 import React, { memo, forwardRef } from 'react'
-import Text from './Text'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+import { useStyleConfig } from '../../hooks'
+
+const pseudoSelectors = {}
+const internalStyles = {}
 
 const Label = memo(
   forwardRef(function Label(props, ref) {
-    return <Text is="label" fontWeight={500} {...props} ref={ref} />
+    const {
+      className,
+      size = 400,
+      ...restProps
+    } = props
+
+    const { className: themedClassName, ...boxProps } = useStyleConfig(
+      'Heading',
+      { size },
+      pseudoSelectors,
+      internalStyles
+    )
+
+    return  (
+      <Box
+        is="label"
+        ref={ref}
+        className={cx(themedClassName, className)}
+        {...boxProps}
+        {...restProps}
+      />
+    )
   })
 )
 
 Label.propTypes = {
-  ...Text.propTypes
+  /**
+   * Label composes Box as the base.
+   */
+  ...Box.propTypes,
+
+  /**
+   * The size of the label, visually based off the Heading sizes
+   */
+  size: PropTypes.oneOf([100, 200, 300, 400, 500, 600, 700, 800, 900])
 }
 
 export default Label


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Update `<Label />` to no longer compose a `<Text />` component under the hood. Also shift it to use `<Heading />` styles as those are the correct visual styles for the component.

**Screenshots (if applicable)**
**Default Theme (v6)**
![image](https://user-images.githubusercontent.com/17129452/95498328-7cc52900-0958-11eb-894c-506e4664c3e0.png)

**Classic Theme (v5)**
![image](https://user-images.githubusercontent.com/17129452/95498366-8cdd0880-0958-11eb-8a5b-49a358388345.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
