### PR TITLE
docs: fix theming playground rendering

### DIFF
--- a/docs/src/components/ThemeLayout.js
+++ b/docs/src/components/ThemeLayout.js
@@ -22,7 +22,7 @@ const PageLayout = ({ children }) => (
               style={{ marginBottom: 160 }}
             >
               <div className="Content">
-                <DocsMDXProvider>{children}</DocsMDXProvider>
+                <DocsMDXProvider noInline>{children}</DocsMDXProvider>
               </div>
             </div>
           </section>

--- a/docs/src/pages/get-started/theming.mdx
+++ b/docs/src/pages/get-started/theming.mdx
@@ -13,7 +13,7 @@ Please note: at this moment in time, theming isn't fully supported yet! There ar
 
 ## Simple theming
 
-The `ThemeProvider` Component, you can either override the default styles(shown below) or use your own theme completely.
+Using the `ThemeProvider` Component, you can either override the default styles (shown below) or use your own theme completely.
 You can add anything you want to the theme object, as long as you have required properties.
 
 ```jsx


### PR DESCRIPTION
**Overview**
Fix https://evergreen.segment.com/get-started/theming, which needs a `noInline` property to render the MDX as written.

Currently displays:
```js
SyntaxError: Unexpected token (1:8)
1 : return (const newTheme = {
```

**Screenshots (if applicable)**

**Before**
![Screenshot before](https://user-images.githubusercontent.com/4712430/95647845-468ec300-0a98-11eb-8c6d-5ade22b89221.png)

**After**
![Screenshot after](https://user-images.githubusercontent.com/4712430/95647849-54dcdf00-0a98-11eb-9578-a2289d66a374.png)
