### PR TITLE
Fix infinite render loop in Positioner

### DIFF
--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -74,7 +74,7 @@ const Positioner = memo(function Positioner(props) {
         cancelAnimationFrame(latestAnimationFrame.current)
       }
     }
-  }, [dimensions])
+  }, [dimensions.height, dimensions.width, dimensions.left, dimensions.top, dimensions.transformOrigin])
 
   const handleEnter = () => {
     transitionState.current = 'entered'


### PR DESCRIPTION
**Overview**
Positioner seems to be in an infinite rendering loop, caused by a `useEffect` hook with an object in the dependency array:

https://github.com/segmentio/evergreen/blob/e1050a724413b344f3d1412199a277bdc2243821/src/positioner/src/Positioner.js#L77

I noticed it causing performance issues in my app, then was able to replicate it in both the Docs and the Storybook

This PR spreads the `dimensions` object into the dependency array.

Usually this would raise an error in React, but I think because the update is wrapped in `requestAnimationFrame` React doesn't know it's looping.

