### PR TITLE
Bring default links fully in-line with specs

### DIFF
--- a/src/themes/default/components/link.js
+++ b/src/themes/default/components/link.js
@@ -1,26 +1,48 @@
-const getThemeKeyForColor = color => {
-  switch (color) {
-    case 'default':
-      return 'blue'
-    case 'neutral':
-      return 'gray'
-    default:
-      return color
-  }
-}
-
 const baseStyle = {
-  color: (_, { color }) => `colors.${getThemeKeyForColor(color)}500`,
+  borderRadius: 'radii.1',
+  transition: '120ms all ease-in-out',
+  color: (_, { color }) => {
+    switch (color) {
+      case 'neutral':
+        return 'gray700'
+      case 'default':
+      default:
+        return 'blue500'
+    }
+  },
   textDecoration: 'none',
   _hover: {
-    color: (_, { color }) => `colors.${getThemeKeyForColor(color)}400`
+    color: (theme, { color }) => {
+      switch (color) {
+        case 'neutral':
+          return theme.colors.gray800
+        case 'default':
+        default:
+          return theme.colors.blue600
+      }
+    }
   },
   _active: {
-    color: (_, { color }) => `colors.${getThemeKeyForColor(color)}600`
+    color: (theme, { color }) => {
+      switch (color) {
+        case 'neutral':
+          return theme.colors.gray900
+        case 'default':
+        default:
+          return theme.colors.blue700
+      }
+    }
   },
   _focus: {
-    boxShadow: (theme, { color }) =>
-      `0 0 0 2px ${theme.colors[getThemeKeyForColor(color)]}300`
+    boxShadow: (theme, { color }) => {
+      switch (color) {
+        case 'neutral':
+          return `0 0 0 2px ${theme.colors.gray300}`
+        case 'default':
+        default:
+          return `0 0 0 2px ${theme.colors.blue200}`
+      }
+    }
   }
 }
 

--- a/src/typography/stories/index.stories.js
+++ b/src/typography/stories/index.stories.js
@@ -40,16 +40,14 @@ storiesOf('typography', module)
   .add('Link', () => (
     <Box padding={40}>
       <Box marginBottom={24}>
-        <Link href="#">Default Link</Link>
+        <Text>
+          In order to learn more about this feature, visit{' '}
+          <Link href="#">the developer center</Link>.{' '}
+        </Text>
       </Box>
       <Box marginBottom={24}>
         <Link href="#" color="neutral">
           Neutral Link
-        </Link>
-      </Box>
-      <Box marginBottom={24}>
-        <Link href="#" color="green">
-          Green Link
         </Link>
       </Box>
     </Box>


### PR DESCRIPTION
**Overview**
Adding a light focus ring, no padding, and bringing the colors (especially for neutral links) up to spec. Tidied up storybook stories too. 


**Screenshots (if applicable)**
https://www.loom.com/share/9090ebeb07f042fc8826e0622868c4e7



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
