### PR TITLE
Fixup options list searchable header cell

### DIFF
--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -225,12 +225,11 @@ const OptionsList = memo(function OptionsList(props) {
       {...rest}
     >
       {hasFilter && (
-        <TableHead backgroundColor={tokens.colors.gray50}>
+        <TableHead height={32} backgroundColor={tokens.colors.gray50}>
           <SearchTableHeaderCell
             onChange={handleChange}
             ref={setSearchRef}
             borderRight={null}
-            height={32}
             placeholder={filterPlaceholder}
             icon={filterIcon}
           />


### PR DESCRIPTION
**Overview**
Tiny PR moving the fixed height to the wrapping table row for the options list, since in v6 it has a _much_ taller height. 

**Screenshots (if applicable)**

Before:
![image](https://user-images.githubusercontent.com/5349500/97237494-78946a80-17a4-11eb-8489-5478bed5f229.png)

After:
![image](https://user-images.githubusercontent.com/5349500/97237391-3d923700-17a4-11eb-91de-708656c67546.png)



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
