### PR TITLE
feat: simplify code contributions via automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+tasks:
+  - name: Storybook
+    init: yarn install
+    command: yarn dev
+
+ports:
+  - port: 6006
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ Now you can visit `http://localhost:8000/` in your browser.
 
 Documentation code is under the `docs` directory. A big portion of these docs are written in MDX, if you've never used MDX before, check out these [docs](https://mdxjs.com/getting-started).
 
+#### Online one click setup
+
+You can also use Gitpod(a free online IDE) for contributing code. With a single click it will launch a workspace and automatically:
+
+- clone the `evergreen` repo.
+- install the dependencies.
+- run `yarn dev`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### 🏆 Step 4. Making your pull request
 
 Once you're done with making your changes, push everything to your local repository's branch.


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Hi.

I work for Gitpod(An online VS Code like IDE which is free for Open Source). This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `evergreen` repo.
- install the dependencies.
- run `yarn dev`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/evergreen


**Screenshots (if applicable)**

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/97891215-53799c00-1d50-11eb-8f10-a42cd5bcd2d5.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
