### PR TITLE
Add some baseline testing to our typography components

### DIFF
--- a/lib/testing/index.js
+++ b/lib/testing/index.js
@@ -1,0 +1,1 @@
+export { default as UIBoxSerializer } from './ui-box-snapshot-serializer'

--- a/lib/testing/ui-box-snapshot-serializer.js
+++ b/lib/testing/ui-box-snapshot-serializer.js
@@ -1,0 +1,26 @@
+import prettyFormat from 'pretty-format'
+import { extractStyles, clearStyles } from 'ui-box'
+
+const { ReactTestComponent } = prettyFormat.plugins
+
+export default {
+  serialize: val => {
+    const { styles } = extractStyles()
+    const rules = styles
+      .split('}')
+      .map(style => style.split('{')[1])
+      .filter(Boolean)
+      .join('\n')
+
+    const serializedElement = prettyFormat(val, {
+      plugins: [ReactTestComponent]
+    })
+
+    clearStyles()
+
+    return ['Extracted Styles:', rules, '', '', serializedElement].join('\n')
+  },
+  test: val => {
+    return val != null
+  }
+}

--- a/lib/testing/ui-box-snapshot-serializer.js
+++ b/lib/testing/ui-box-snapshot-serializer.js
@@ -10,6 +10,7 @@ export default {
       .split('}')
       .map(style => style.split('{')[1])
       .filter(Boolean)
+      .sort()
       .join('\n')
 
     const serializedElement = prettyFormat(val, {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "@testing-library/react": "^11.2.2",
     "@types/react": "^16.9.5",
     "@types/react-transition-group": "^4.4.0",
     "arrify": "^1.0.1",
@@ -99,6 +100,7 @@
     "@storybook/addons": "^6.0.21",
     "@storybook/react": "^6.0.21",
     "@storybook/theming": "^6.0.21",
+    "@testing-library/jest-dom": "^5.11.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.1.0",
@@ -153,6 +155,9 @@
   "jest": {
     "setupFiles": [
       "./tools/test-setup"
+    ],
+    "setupFilesAfterEnv": [
+      "./tools/test-setup-after-env"
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/docs/",

--- a/src/themes/default/components/input.js
+++ b/src/themes/default/components/input.js
@@ -2,6 +2,7 @@ const baseStyle = {
   borderRadius: 'radii.1',
   fontFamily: 'fontFamilies.ui',
   lineHeight: 'lineHeights.0',
+  fontSize: 'fontSizes.1',
   border: '1px solid transparent',
   color: 'colors.default',
   paddingX: 12,

--- a/src/themes/default/tokens/typography.js
+++ b/src/themes/default/tokens/typography.js
@@ -1,17 +1,17 @@
 const fontSizes = [
-  '11px',
+  '10px',
   '12px',
   '14px',
   '16px',
+  '18px',
   '20px',
   '24px',
-  '29px',
-  '35px'
+  '32px'
 ]
 
 fontSizes.body = '14px'
 fontSizes.heading = '16px'
-fontSizes.caption = '11px'
+fontSizes.caption = '10px'
 
 const typography = {
   fontFamilies: {

--- a/src/typography/__tests__/Heading.test.js
+++ b/src/typography/__tests__/Heading.test.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import renderer from 'react-test-renderer'
+import { UIBoxSerializer } from '../../../lib/testing'
+import { ThemeProvider } from '../../theme'
+import { defaultTheme } from '../../themes'
+import Heading from '../src/Heading'
+
+expect.addSnapshotSerializer(UIBoxSerializer)
+
+test.each([
+  ['size 100', 100],
+  ['size 200', 200],
+  ['size 300', 300],
+  ['size 400', 400],
+  ['size 500', 500],
+  ['size 600', 600],
+  ['size 700', 700],
+  ['size 800', 800],
+  ['size 900', 900]
+])('<Heading /> %s renders as expected', (_, size) => {
+  const component = (
+    <ThemeProvider value={defaultTheme}>
+      <Heading size={size}>{`Heading ${size}`}</Heading>
+    </ThemeProvider>
+  )
+  const tree = renderer.create(component).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Heading lets you override the underlying DOM element', async () => {
+  render(
+    <ThemeProvider value={defaultTheme}>
+      <Heading is="h1">Testing h1</Heading>
+    </ThemeProvider>
+  )
+
+  expect(screen.getByText('Testing h1', { selector: 'h1' })).toBeTruthy()
+})

--- a/src/typography/__tests__/Text.test.js
+++ b/src/typography/__tests__/Text.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import renderer from 'react-test-renderer'
+import { UIBoxSerializer } from '../../../lib/testing'
+import { ThemeProvider } from '../../theme'
+import { defaultTheme } from '../../themes'
+import Text from '../src/Text'
+
+expect.addSnapshotSerializer(UIBoxSerializer)
+
+test.each([
+  ['size 300', 300],
+  ['size 400', 400],
+  ['size 500', 500],
+  ['size 600', 600]
+])('<Text /> %s renders as expected', (_, size) => {
+  const component = (
+    <ThemeProvider value={defaultTheme}>
+      <Text size={size}>{`Text ${size}`}</Text>
+    </ThemeProvider>
+  )
+  const tree = renderer.create(component).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+describe('Colors', () => {
+  test('<Text /> accepts arbitrary theme values for color', () => {
+    const component = (
+      <ThemeProvider value={defaultTheme}>
+        <Text color="muted">Testing</Text>{' '}
+      </ThemeProvider>
+    )
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('<Text /> does not render any color when a non-theme color is passed in ', () => {
+    const component = (
+      <ThemeProvider value={defaultTheme}>
+        <Text color="SOMETHING DOESNT EXISt">Testing</Text>{' '}
+      </ThemeProvider>
+    )
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('Sizing', () => {
+  const originalConsoleError = console.error
+  const mockFn = jest.fn()
+  beforeEach(() => {
+    console.error = mockFn
+  })
+
+  afterEach(() => {
+    console.error = originalConsoleError
+  })
+
+  test('<Text /> has undefined behavior when trying to set arbitrary sizes', () => {
+    render(<Text size={800} />)
+    expect(mockFn.mock.calls.length).toEqual(1)
+    expect(mockFn.mock.calls[0][0]).toEqual(
+      expect.stringContaining('Invalid prop `size`')
+    )
+  })
+})

--- a/src/typography/__tests__/__snapshots__/Heading.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Heading.test.js.snap
@@ -2,16 +2,16 @@
 
 exports[`<Heading /> size 100 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #696f8c;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 500;
 font-size: 11px;
-text-transform: uppercase;
-line-height: 16px;
+font-weight: 500;
 letter-spacing: 0.6px;
-box-sizing: border-box;
+line-height: 16px;
+margin-bottom: 0px;
+margin-top: 0px;
+text-transform: uppercase;
 
 
 <h2
@@ -23,15 +23,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 200 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #696f8c;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 500;
 font-size: 12px;
-line-height: 16px;
+font-weight: 500;
 letter-spacing: 0;
-box-sizing: border-box;
+line-height: 16px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -43,15 +43,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 300 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 500;
 font-size: 12px;
-line-height: 16px;
+font-weight: 500;
 letter-spacing: 0;
-box-sizing: border-box;
+line-height: 16px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -63,15 +63,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 400 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 500;
 font-size: 14px;
-line-height: 18px;
+font-weight: 500;
 letter-spacing: -0.05px;
-box-sizing: border-box;
+line-height: 18px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -83,15 +83,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 500 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 600;
 font-size: 16px;
+font-weight: 600;
 letter-spacing: -0.05px;
 line-height: 20px;
-box-sizing: border-box;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -103,15 +103,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 600 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 600;
 font-size: 20px;
-line-height: 24px;
+font-weight: 600;
 letter-spacing: -0.07px;
-box-sizing: border-box;
+line-height: 24px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -123,15 +123,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 700 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 600;
 font-size: 24px;
-line-height: 24px;
+font-weight: 600;
 letter-spacing: -0.07px;
-box-sizing: border-box;
+line-height: 24px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -143,15 +143,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 800 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 600;
 font-size: 29px;
-line-height: 32px;
+font-weight: 600;
 letter-spacing: -0.2px;
-box-sizing: border-box;
+line-height: 32px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2
@@ -163,15 +163,15 @@ box-sizing: border-box;
 
 exports[`<Heading /> size 900 renders as expected 1`] = `
 Extracted Styles:
-margin-top: 0px;
-margin-bottom: 0px;
+box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-weight: 600;
 font-size: 35px;
-line-height: 40px;
+font-weight: 600;
 letter-spacing: -0.2px;
-box-sizing: border-box;
+line-height: 40px;
+margin-bottom: 0px;
+margin-top: 0px;
 
 
 <h2

--- a/src/typography/__tests__/__snapshots__/Heading.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Heading.test.js.snap
@@ -5,7 +5,7 @@ Extracted Styles:
 box-sizing: border-box;
 color: #696f8c;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-size: 11px;
+font-size: 10px;
 font-weight: 500;
 letter-spacing: 0.6px;
 line-height: 16px;
@@ -15,7 +15,7 @@ text-transform: uppercase;
 
 
 <h2
-  className="ub-mt_0px ub-mb_0px ub-color_696f8c ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_11px ub-txt-trns_uppercase ub-ln-ht_16px ub-ltr-spc_0-6px ub-box-szg_border-box"
+  className="ub-mt_0px ub-mb_0px ub-color_696f8c ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_10px ub-txt-trns_uppercase ub-ln-ht_16px ub-ltr-spc_0-6px ub-box-szg_border-box"
 >
   Heading 100
 </h2>
@@ -106,6 +106,26 @@ Extracted Styles:
 box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-size: 18px;
+font-weight: 600;
+letter-spacing: -0.07px;
+line-height: 24px;
+margin-bottom: 0px;
+margin-top: 0px;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_18px ub-ln-ht_24px ub-ltr-spc_-0-07px ub-box-szg_border-box"
+>
+  Heading 600
+</h2>
+`;
+
+exports[`<Heading /> size 700 renders as expected 1`] = `
+Extracted Styles:
+box-sizing: border-box;
+color: #101840;
+font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 20px;
 font-weight: 600;
 letter-spacing: -0.07px;
@@ -117,26 +137,6 @@ margin-top: 0px;
 <h2
   className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_20px ub-ln-ht_24px ub-ltr-spc_-0-07px ub-box-szg_border-box"
 >
-  Heading 600
-</h2>
-`;
-
-exports[`<Heading /> size 700 renders as expected 1`] = `
-Extracted Styles:
-box-sizing: border-box;
-color: #101840;
-font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-size: 24px;
-font-weight: 600;
-letter-spacing: -0.07px;
-line-height: 24px;
-margin-bottom: 0px;
-margin-top: 0px;
-
-
-<h2
-  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_24px ub-ln-ht_24px ub-ltr-spc_-0-07px ub-box-szg_border-box"
->
   Heading 700
 </h2>
 `;
@@ -146,7 +146,7 @@ Extracted Styles:
 box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-size: 29px;
+font-size: 24px;
 font-weight: 600;
 letter-spacing: -0.2px;
 line-height: 32px;
@@ -155,7 +155,7 @@ margin-top: 0px;
 
 
 <h2
-  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_29px ub-ln-ht_32px ub-ltr-spc_-0-2px ub-box-szg_border-box"
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_24px ub-ln-ht_32px ub-ltr-spc_-0-2px ub-box-szg_border-box"
 >
   Heading 800
 </h2>
@@ -166,7 +166,7 @@ Extracted Styles:
 box-sizing: border-box;
 color: #101840;
 font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-size: 35px;
+font-size: 32px;
 font-weight: 600;
 letter-spacing: -0.2px;
 line-height: 40px;
@@ -175,7 +175,7 @@ margin-top: 0px;
 
 
 <h2
-  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_35px ub-ln-ht_40px ub-ltr-spc_-0-2px ub-box-szg_border-box"
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_32px ub-ln-ht_40px ub-ltr-spc_-0-2px ub-box-szg_border-box"
 >
   Heading 900
 </h2>

--- a/src/typography/__tests__/__snapshots__/Heading.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Heading.test.js.snap
@@ -1,0 +1,182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Heading /> size 100 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #696f8c;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 500;
+font-size: 11px;
+text-transform: uppercase;
+line-height: 16px;
+letter-spacing: 0.6px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_696f8c ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_11px ub-txt-trns_uppercase ub-ln-ht_16px ub-ltr-spc_0-6px ub-box-szg_border-box"
+>
+  Heading 100
+</h2>
+`;
+
+exports[`<Heading /> size 200 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #696f8c;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 500;
+font-size: 12px;
+line-height: 16px;
+letter-spacing: 0;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_696f8c ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_12px ub-ln-ht_16px ub-ltr-spc_0 ub-box-szg_border-box"
+>
+  Heading 200
+</h2>
+`;
+
+exports[`<Heading /> size 300 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 500;
+font-size: 12px;
+line-height: 16px;
+letter-spacing: 0;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_12px ub-ln-ht_16px ub-ltr-spc_0 ub-box-szg_border-box"
+>
+  Heading 300
+</h2>
+`;
+
+exports[`<Heading /> size 400 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 500;
+font-size: 14px;
+line-height: 18px;
+letter-spacing: -0.05px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_14px ub-ln-ht_18px ub-ltr-spc_-0-05px ub-box-szg_border-box"
+>
+  Heading 400
+</h2>
+`;
+
+exports[`<Heading /> size 500 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 600;
+font-size: 16px;
+letter-spacing: -0.05px;
+line-height: 20px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_b77syt ub-f-wght_600 ub-fnt-sze_16px ub-ltr-spc_-0-05px ub-ln-ht_20px ub-box-szg_border-box"
+>
+  Heading 500
+</h2>
+`;
+
+exports[`<Heading /> size 600 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 600;
+font-size: 20px;
+line-height: 24px;
+letter-spacing: -0.07px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_20px ub-ln-ht_24px ub-ltr-spc_-0-07px ub-box-szg_border-box"
+>
+  Heading 600
+</h2>
+`;
+
+exports[`<Heading /> size 700 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 600;
+font-size: 24px;
+line-height: 24px;
+letter-spacing: -0.07px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_24px ub-ln-ht_24px ub-ltr-spc_-0-07px ub-box-szg_border-box"
+>
+  Heading 700
+</h2>
+`;
+
+exports[`<Heading /> size 800 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 600;
+font-size: 29px;
+line-height: 32px;
+letter-spacing: -0.2px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_29px ub-ln-ht_32px ub-ltr-spc_-0-2px ub-box-szg_border-box"
+>
+  Heading 800
+</h2>
+`;
+
+exports[`<Heading /> size 900 renders as expected 1`] = `
+Extracted Styles:
+margin-top: 0px;
+margin-bottom: 0px;
+color: #101840;
+font-family: "SF UI Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-weight: 600;
+font-size: 35px;
+line-height: 40px;
+letter-spacing: -0.2px;
+box-sizing: border-box;
+
+
+<h2
+  className="ub-mt_0px ub-mb_0px ub-color_101840 ub-fnt-fam_wm9v6k ub-f-wght_600 ub-fnt-sze_35px ub-ln-ht_40px ub-ltr-spc_-0-2px ub-box-szg_border-box"
+>
+  Heading 900
+</h2>
+`;

--- a/src/typography/__tests__/__snapshots__/Text.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Text.test.js.snap
@@ -59,14 +59,14 @@ Extracted Styles:
 box-sizing: border-box;
 color: #474d66;
 font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-font-size: 20px;
+font-size: 18px;
 font-weight: 400;
 letter-spacing: -0.07px;
 line-height: 24px;
 
 
 <span
-  className="ub-fnt-sze_20px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_b77syt ub-color_474d66 ub-box-szg_border-box"
+  className="ub-fnt-sze_18px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_b77syt ub-color_474d66 ub-box-szg_border-box"
 >
   Text 600
 </span>

--- a/src/typography/__tests__/__snapshots__/Text.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Text.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`<Text /> size 300 renders as expected 1`] = `
 Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 12px;
 font-weight: 400;
-line-height: 16px;
 letter-spacing: 0;
-font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-color: #474d66;
-box-sizing: border-box;
+line-height: 16px;
 
 
 <span
@@ -20,13 +20,13 @@ box-sizing: border-box;
 
 exports[`<Text /> size 400 renders as expected 1`] = `
 Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 14px;
 font-weight: 400;
-line-height: 20px;
 letter-spacing: -0.05px;
-font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-color: #474d66;
-box-sizing: border-box;
+line-height: 20px;
 
 
 <span
@@ -38,13 +38,13 @@ box-sizing: border-box;
 
 exports[`<Text /> size 500 renders as expected 1`] = `
 Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 16px;
 font-weight: 400;
-line-height: 20px;
 letter-spacing: -0.05px;
-font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-color: #474d66;
-box-sizing: border-box;
+line-height: 20px;
 
 
 <span
@@ -56,13 +56,13 @@ box-sizing: border-box;
 
 exports[`<Text /> size 600 renders as expected 1`] = `
 Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 20px;
 font-weight: 400;
-line-height: 24px;
 letter-spacing: -0.07px;
-font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-color: #474d66;
-box-sizing: border-box;
+line-height: 24px;
 
 
 <span
@@ -74,13 +74,13 @@ box-sizing: border-box;
 
 exports[`Colors <Text /> accepts arbitrary theme values for color 1`] = `
 Extracted Styles:
+box-sizing: border-box;
+color: #696f8c;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 14px;
 font-weight: 400;
-line-height: 20px;
 letter-spacing: -0.05px;
-font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-color: #696f8c;
-box-sizing: border-box;
+line-height: 20px;
 
 
 Array [
@@ -95,13 +95,13 @@ Array [
 
 exports[`Colors <Text /> does not render any color when a non-theme color is passed in  1`] = `
 Extracted Styles:
+box-sizing: border-box;
+color: SOMETHING DOESNT EXISt;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 font-size: 14px;
 font-weight: 400;
-line-height: 20px;
 letter-spacing: -0.05px;
-font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-color: SOMETHING DOESNT EXISt;
-box-sizing: border-box;
+line-height: 20px;
 
 
 Array [

--- a/src/typography/__tests__/__snapshots__/Text.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Text.test.js.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Text /> size 300 renders as expected 1`] = `
+Extracted Styles:
+font-size: 12px;
+font-weight: 400;
+line-height: 16px;
+letter-spacing: 0;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+color: #474d66;
+box-sizing: border-box;
+
+
+<span
+  className="ub-fnt-sze_12px ub-f-wght_400 ub-ln-ht_16px ub-ltr-spc_0 ub-fnt-fam_b77syt ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 300
+</span>
+`;
+
+exports[`<Text /> size 400 renders as expected 1`] = `
+Extracted Styles:
+font-size: 14px;
+font-weight: 400;
+line-height: 20px;
+letter-spacing: -0.05px;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+color: #474d66;
+box-sizing: border-box;
+
+
+<span
+  className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_b77syt ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 400
+</span>
+`;
+
+exports[`<Text /> size 500 renders as expected 1`] = `
+Extracted Styles:
+font-size: 16px;
+font-weight: 400;
+line-height: 20px;
+letter-spacing: -0.05px;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+color: #474d66;
+box-sizing: border-box;
+
+
+<span
+  className="ub-fnt-sze_16px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_b77syt ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 500
+</span>
+`;
+
+exports[`<Text /> size 600 renders as expected 1`] = `
+Extracted Styles:
+font-size: 20px;
+font-weight: 400;
+line-height: 24px;
+letter-spacing: -0.07px;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+color: #474d66;
+box-sizing: border-box;
+
+
+<span
+  className="ub-fnt-sze_20px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_b77syt ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 600
+</span>
+`;
+
+exports[`Colors <Text /> accepts arbitrary theme values for color 1`] = `
+Extracted Styles:
+font-size: 14px;
+font-weight: 400;
+line-height: 20px;
+letter-spacing: -0.05px;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+color: #696f8c;
+box-sizing: border-box;
+
+
+Array [
+  <span
+    className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_b77syt ub-color_696f8c ub-box-szg_border-box"
+  >
+    Testing
+  </span>,
+  " ",
+]
+`;
+
+exports[`Colors <Text /> does not render any color when a non-theme color is passed in  1`] = `
+Extracted Styles:
+font-size: 14px;
+font-weight: 400;
+line-height: 20px;
+letter-spacing: -0.05px;
+font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+color: SOMETHING DOESNT EXISt;
+box-sizing: border-box;
+
+
+Array [
+  <span
+    className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_b77syt ub-color_SOMETHING-DOESNT-EXISt ub-box-szg_border-box"
+  >
+    Testing
+  </span>,
+  " ",
+]
+`;

--- a/tools/test-setup-after-env.js
+++ b/tools/test-setup-after-env.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,6 +1049,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz#ffee91da0eb4c6dae080774e94ba606368e414f4"
+  integrity sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
@@ -1061,6 +1069,13 @@
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1593,6 +1608,17 @@
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
   integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -2568,10 +2594,51 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testing-library/dom@^7.28.1":
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.28.1.tgz#dea78be6e1e6db32ddcb29a449e94d9700c79eb9"
+  integrity sha512-acv3l6kDwZkQif/YqJjstT3ks5aaI33uxGNVIQmdKzbZ2eMKgg3EV2tB84GDdc72k3Kjhl6mO8yUt6StVIdRDg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/jest-dom@^5.11.6":
+  version "5.11.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
+  integrity sha512-cVZyUNRWwUKI0++yepYpYX7uhrP398I+tGz4zOlLVlUYnZS+Svuxv4fwLeCIy7TnBYKXUaOlQr3vopxL8ZfEnA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react@^11.2.2":
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.2.tgz#099c6c195140ff069211143cb31c0f8337bdb7b7"
+  integrity sha512-jaxm0hwUjv+hzC+UFEywic7buDC9JQ1q3cDsrWVSDAPmLotfA6E6kUHlYm/zOeGCac6g48DR36tFHxl7Zb+N5A==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
@@ -2709,6 +2776,14 @@
   integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "26.0.16"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.16.tgz#b47abd50f6ed0503f589db8e126fc8eb470cf87c"
+  integrity sha512-Gp12+7tmKCgv9JjtltxUXokohCAEZfpJaEW5tn871SGRp8I+bRWBonQO7vW5NHwnAHe5dd50+Q4zyKuN35i09g==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/json-schema@^7.0.4":
   version "7.0.5"
@@ -2894,6 +2969,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.9.2"
@@ -3381,6 +3463,14 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4564,7 +4654,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -5117,6 +5207,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.3"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.0.tgz#4cdd2eca37d49cda206b66e26204818dba77884a"
+  integrity sha512-fRjhg3NeouotRoIV0L1FdchA6CK7ZD+lyINyMoz19SyV+ROpC4noS1xItWHFtwZdlqfMfVPJEyEGdfri2bD1pA==
+
 core-js-pure@^3.0.1:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
@@ -5335,6 +5430,20 @@ css-what@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -5718,6 +5827,11 @@ diff-sequences@^26.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.3.0.tgz#62a59b1b29ab7fd27cef2a33ae52abe73042d0a2"
   integrity sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -5773,6 +5887,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -8908,6 +9027,16 @@ jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-diff@^26.4.2:
   version "26.4.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.4.2.tgz#a1b7b303bcc534aabdb3bd4a7caf594ac059f5aa"
@@ -10144,6 +10273,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 magic-string@^0.25.2:
   version "0.25.6"
@@ -12044,6 +12178,16 @@ pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^26.4.2:
   version "26.4.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
@@ -12531,6 +12675,11 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -13643,6 +13792,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"


### PR DESCRIPTION
**Overview**
This PR adds a custom snapshot serializer so we can extract styles out of leaf nodes - there's probably more interesting things we can do here, i.e. rendering custom placeholders that are then referenced by styles. For a lot of our base components though that are comprised of a single `<Box />` (`<Button />` included), this gives us some safety towards making changes. 

**Screenshots (if applicable)**



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
