### PR TITLE
Add optional shouldCloseOnEscapePress for Popover

### DIFF
--- a/docs/src/pages/components/popover.mdx
+++ b/docs/src/pages/components/popover.mdx
@@ -283,4 +283,27 @@ The Popover can be positioned on the following positions using the `position` pr
 </Popover>
 ```
 
+## Disable Close on Escape Key
+
+```jsx
+<Popover
+  content={({ close }) => (
+    <Pane
+      width={320}
+      height={320}
+      paddingX={40}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      flexDirection="column"
+    >
+      <Button onClick={close}>Close</Button>
+    </Pane>
+  )}
+  shouldCloseOnEscapePress={false}
+>
+  <Button>Trigger Popover</Button>
+</Popover>
+```
+
 <PropsTable of="Popover" />

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -1,3 +1,11 @@
+import { Positioner } from '../../positioner'
+import { Tooltip } from '../../tooltip'
+import { Position } from '../../constants'
+import { useMergedRef } from '../../hooks'
+import PopoverStateless from './PopoverStateless'
+import PropTypes from 'prop-types'
+import { css as glamorCss } from 'glamor'
+import cx from 'classnames'
 import React, {
   memo,
   forwardRef,
@@ -8,14 +16,6 @@ import React, {
   useCallback,
   useMemo
 } from 'react'
-import cx from 'classnames'
-import { css as glamorCss } from 'glamor'
-import PropTypes from 'prop-types'
-import { Positioner } from '../../positioner'
-import { Tooltip } from '../../tooltip'
-import { Position } from '../../constants'
-import { useMergedRef } from '../../hooks'
-import PopoverStateless from './PopoverStateless'
 
 const noop = () => {}
 const emptyProps = {}
@@ -37,6 +37,7 @@ const Popover = memo(
       onOpenComplete = noop,
       position = Position.BOTTOM,
       shouldCloseOnExternalClick = true,
+      shouldCloseOnEscapePress = true,
       statelessProps = emptyProps,
       trigger = 'click',
       ...props
@@ -189,9 +190,11 @@ const Popover = memo(
 
     const onEsc = useCallback(
       event => {
-        return event.key === 'Escape' ? close() : undefined
+        return event.key === 'Escape' && shouldCloseOnEscapePress
+          ? close()
+          : undefined
       },
-      [close]
+      [shouldCloseOnEscapePress, close]
     )
 
     const handleBodyClick = useCallback(
@@ -437,7 +440,12 @@ Popover.propTypes = {
   /**
    * Boolean indicating if clicking outside the dialog should close the dialog.
    */
-  shouldCloseOnExternalClick: PropTypes.bool
+  shouldCloseOnExternalClick: PropTypes.bool,
+
+  /**
+   * Boolean indicating if pressing the esc key should close the dialog.
+   */
+  shouldCloseOnEscapePress: PropTypes.bool
 }
 
 export default Popover

--- a/src/popover/stories/index.stories.js
+++ b/src/popover/stories/index.stories.js
@@ -1,7 +1,3 @@
-import { storiesOf } from '@storybook/react'
-import React from 'react'
-import PropTypes from 'prop-types'
-import Box from 'ui-box'
 import { Tooltip } from '../../tooltip'
 import { TextInputField } from '../../text-input'
 import { Pane } from '../../layers'
@@ -9,6 +5,10 @@ import { Heading, Paragraph, Text } from '../../typography'
 import { Button } from '../../buttons'
 import { Position } from '../../constants'
 import { CircleArrowDownIcon } from '../../icons'
+import Box from 'ui-box'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { storiesOf } from '@storybook/react'
 import { Popover } from '..'
 
 // eslint-disable-next-line react/prop-types
@@ -150,6 +150,9 @@ storiesOf('popover', module)
       </Popover>
       <Popover content={<PopoverContent />} shouldCloseOnExternalClick={false}>
         <Button marginRight={20}>No Close on Body Click</Button>
+      </Popover>
+      <Popover content={<PopoverContent />} shouldCloseOnEscapePress={false}>
+        <Button marginRight={20}>No Close on Escape Key</Button>
       </Popover>
       <Popover
         useSmartPositioning={false}


### PR DESCRIPTION
<sup>closes #1120</sup>
**Overview**
Adds `shouldCloseOnEscapePress` optional prop to the `Popover` component to prevent closing on escape key. Default behavior is maintained, docs are updated, and story book confirms change.

It appears there's an on commit script that runs prettier on the code which is why there are so many changes in the diff. Is there a way to disable that or is it fine as is? 

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
