### PR TITLE
Add github actions in place of our Circle config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [12]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run build
+        run: yarn run build
+      - name: Run prettier
+        run: yarn run prettier 'src/**/*.js' --check
+      - name: Run test
+        run: yarn run test
+      - name: Run size-limit
+        run: yarn run size-limit

--- a/package.json
+++ b/package.json
@@ -146,6 +146,9 @@
       "indent": [
         "off"
       ],
+      "import/extensions": [
+        "off"
+      ],
       "func-names": [
         "off"
       ],


### PR DESCRIPTION
**Overview**
This PR serves as a starting point to migrate off of our Circle Config and onto GitHub actions. It's more-or-less a 1:1 mapping between tasks following [this guide](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/migrating-from-circleci-to-github-actions)

**Screenshots (if applicable)**
N/A

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
