### PR TITLE
Custom item width combobox

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,37 @@
 /* tslint:disable:interface-name max-classes-per-file no-empty-interface */
 
 import * as React from 'react'
-import { extractStyles as boxExtractStyles, BoxProps, BoxComponent, PolymorphicBoxProps } from 'ui-box'
+import {
+  extractStyles as boxExtractStyles,
+  BoxProps,
+  BoxComponent,
+  PolymorphicBoxProps
+} from 'ui-box'
 import { StyleAttribute, CSSProperties } from 'glamor'
 import { DownshiftProps } from 'downshift'
-import { TransitionProps, TransitionStatus } from 'react-transition-group/Transition'
+import {
+  TransitionProps,
+  TransitionStatus
+} from 'react-transition-group/Transition'
 
-export { configureSafeHref, BoxProps, BoxOwnProps, BoxComponent, PolymorphicBoxProps, EnhancerProps } from 'ui-box'
+export {
+  configureSafeHref,
+  BoxProps,
+  BoxOwnProps,
+  BoxComponent,
+  PolymorphicBoxProps,
+  EnhancerProps
+} from 'ui-box'
 
-export type PositionTypes = 'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'
+export type PositionTypes =
+  | 'top'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'left'
+  | 'right'
 export type IntentTypes = 'none' | 'success' | 'warning' | 'danger'
 export type DefaultAppearance = 'default'
 export type AlertAppearance = DefaultAppearance | 'card'
@@ -415,7 +438,9 @@ export enum Position {
   RIGHT = 'right'
 }
 
-type ForwardRefComponent<P = {}, T = any> = React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>
+type ForwardRefComponent<P = {}, T = any> = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<P> & React.RefAttributes<T>
+>
 
 export interface AlertOwnProps extends Omit<PaneOwnProps, 'title'> {
   intent?: IntentTypes
@@ -432,7 +457,11 @@ export interface AlertOwnProps extends Omit<PaneOwnProps, 'title'> {
   /**
    * Function called when the remove button is clicked.
    */
-  onRemove?: (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => void
+  onRemove?: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.TouchEvent<HTMLButtonElement>
+  ) => void
   /**
    * The appearance of the alert.
    */
@@ -456,31 +485,33 @@ export interface AutocompleteItemProps extends OptionProps {
 export declare const AutocompleteItem: ForwardRefComponent<AutocompleteItemProps>
 
 // https://github.com/downshift-js/downshift
-export interface AutocompleteProps extends Omit<DownshiftProps<any>, 'children'> {
+export interface AutocompleteProps
+  extends Omit<DownshiftProps<any>, 'children'> {
   title?: React.ReactNode
   items: any[]
   renderItem?: (i: AutocompleteItemProps) => JSX.Element | null
   itemsFilter?: (items: string[], input: string) => string[]
   children: (props: {
-                toggle: () => void,
-                getRef: React.Ref<any>,
-                isShown: NonNullable<PopoverProps['isShown']>,
-                getInputProps: <T>(options?: T) => T & {
-                  onChange: (event: React.ChangeEvent) => void,
-                  onKeyDown: (event: React.KeyboardEvent) => void,
-                  onBlur: (event: React.FocusEvent) => void,
-                  id: string,
-                  value: string,
-                  'aria-autocomplete': 'list',
-                  'aria-activedescendant'?: string,
-                  'aria-controls'?: string,
-                  'aria-labelledby': string,
-                  autoComplete: 'off'
-                },
-                openMenu: () => any,
-                inputValue: string,
-              }
-  ) => React.ReactNode
+    toggle: () => void
+    getRef: React.Ref<any>
+    isShown: NonNullable<PopoverProps['isShown']>
+    getInputProps: <T>(
+      options?: T
+    ) => T & {
+      onChange: (event: React.ChangeEvent) => void
+      onKeyDown: (event: React.KeyboardEvent) => void
+      onBlur: (event: React.FocusEvent) => void
+      id: string
+      value: string
+      'aria-autocomplete': 'list'
+      'aria-activedescendant'?: string
+      'aria-controls'?: string
+      'aria-labelledby': string
+      autoComplete: 'off'
+    }
+    openMenu: () => any
+    inputValue: string
+  }) => React.ReactNode
   itemSize?: number
   position?: PositionTypes
   isFilterDisabled?: boolean
@@ -520,7 +551,16 @@ export interface BadgeOwnProps extends StrongOwnProps {
   /**
    * The color used for the badge. When the value is `automatic`, use the hash function to determine the color.
    */
-  color?: 'automatic' | 'neutral' | 'blue' | 'red' | 'orange' | 'yellow' | 'green' | 'teal' | 'purple'
+  color?:
+    | 'automatic'
+    | 'neutral'
+    | 'blue'
+    | 'red'
+    | 'orange'
+    | 'yellow'
+    | 'green'
+    | 'teal'
+    | 'purple'
   /**
    * Whether or not to apply hover/focus/active styles.
    */
@@ -639,7 +679,7 @@ export interface ComboboxOwnProps {
   /**
    * Properties forwarded to the autocomplete component. Use with caution.
    */
-  autocompleteProps?: AutocompleteProps
+  autocompleteProps?: Partial<AutocompleteProps>
   /**
    * When true, open the autocomplete on focus.
    */
@@ -950,19 +990,21 @@ export interface FormFieldOwnProps {
 export type FormFieldProps = PolymorphicBoxProps<'div', FormFieldOwnProps>
 export declare const FormField: BoxComponent<FormFieldOwnProps>
 
-export interface FormFieldDescriptionOwnProps extends ParagraphOwnProps {
-}
+export interface FormFieldDescriptionOwnProps extends ParagraphOwnProps {}
 
-export type FormFieldDescriptionProps = PolymorphicBoxProps<'p', FormFieldDescriptionOwnProps>
-export declare const FormFieldDescription: BoxComponent<FormFieldDescriptionOwnProps, 'p'>
+export type FormFieldDescriptionProps = PolymorphicBoxProps<
+  'p',
+  FormFieldDescriptionOwnProps
+>
+export declare const FormFieldDescription: BoxComponent<
+  FormFieldDescriptionOwnProps,
+  'p'
+>
 
-
-export interface FormFieldHintOwnProps extends ParagraphOwnProps {
-}
+export interface FormFieldHintOwnProps extends ParagraphOwnProps {}
 
 export type FormFieldHintProps = PolymorphicBoxProps<'p', FormFieldHintOwnProps>
 export declare const FormFieldHint: BoxComponent<FormFieldHintOwnProps, 'p'>
-
 
 export interface FormFieldLabelOwnProps extends LabelOwnProps {
   /**
@@ -971,12 +1013,24 @@ export interface FormFieldLabelOwnProps extends LabelOwnProps {
   isAstrixShown?: boolean
 }
 
-export type FormFieldLabelProps = PolymorphicBoxProps<'label', FormFieldLabelOwnProps>
-export declare const FormFieldLabel: BoxComponent<FormFieldLabelOwnProps, 'label'>
+export type FormFieldLabelProps = PolymorphicBoxProps<
+  'label',
+  FormFieldLabelOwnProps
+>
+export declare const FormFieldLabel: BoxComponent<
+  FormFieldLabelOwnProps,
+  'label'
+>
 
 export interface FormFieldValidationMessageOwnProps extends PaneOwnProps {}
-export type FormFieldValidationMessageProps = PolymorphicBoxProps<'div', FormFieldValidationMessageOwnProps>
-export declare const FormFieldValidationMessage: BoxComponent<FormFieldValidationMessageOwnProps, 'div'>
+export type FormFieldValidationMessageProps = PolymorphicBoxProps<
+  'div',
+  FormFieldValidationMessageOwnProps
+>
+export declare const FormFieldValidationMessage: BoxComponent<
+  FormFieldValidationMessageOwnProps,
+  'div'
+>
 
 export interface HeadingOwnProps {
   size?: keyof Typography['headings']
@@ -1131,7 +1185,7 @@ export interface MenuOptionsGroupProps<T> {
   title?: React.ReactNode
   selected?: T
   onChange?: (value: T) => void
-  options: Array<{ value: T, label: string }>
+  options: Array<{ value: T; label: string }>
 }
 
 declare const MenuItem: BoxComponent<MenuItemOwnProps, 'div'>
@@ -1173,9 +1227,15 @@ export interface PopoverProps {
   position?: PositionTypes
   isShown?: boolean
   trigger?: 'click' | 'hover'
-  content: React.ReactNode | ((object: { close: () => void }) => React.ReactNode)
+  content:
+    | React.ReactNode
+    | ((object: { close: () => void }) => React.ReactNode)
   children:
-    ((props: { toggle: () => void, getRef: (ref: React.RefObject<HTMLElement>) => void, isShown: NonNullable<PopoverProps['isShown']> }) => React.ReactNode)
+    | ((props: {
+        toggle: () => void
+        getRef: (ref: React.RefObject<HTMLElement>) => void
+        isShown: NonNullable<PopoverProps['isShown']>
+      }) => React.ReactNode)
     | React.ReactNode
   display?: string
   minWidth?: number | string
@@ -1207,23 +1267,26 @@ export interface PositionerProps {
   position?: PositionTypes
   isShown?: boolean
   children: (params: {
-    top: number,
-    left: number,
-    zIndex: NonNullable<StackProps['value']>,
-    css: StyleAttribute | CSSProperties,
+    top: number
+    left: number
+    zIndex: NonNullable<StackProps['value']>
+    css: StyleAttribute | CSSProperties
     style: {
-      transformOrigin: string,
-      left: number,
-      top: number,
-      zIndex: NonNullable<StackProps['value']>,
-    },
-    getRef: (ref: React.RefObject<HTMLElement>) => void,
-    animationDuration: PositionerProps['animationDuration'],
+      transformOrigin: string
+      left: number
+      top: number
+      zIndex: NonNullable<StackProps['value']>
+    }
+    getRef: (ref: React.RefObject<HTMLElement>) => void
+    animationDuration: PositionerProps['animationDuration']
     state: PositionState
   }) => React.ReactNode
   bodyOffset?: number
   targetOffset?: number
-  target: (params: { getRef: () => React.RefObject<HTMLElement>, isShown: boolean }) => React.ReactNode
+  target: (params: {
+    getRef: () => React.RefObject<HTMLElement>
+    isShown: boolean
+  }) => React.ReactNode
   initialScale?: number
   animationDuration?: number
   onCloseComplete?: () => void
@@ -1349,8 +1412,8 @@ export interface OptionsListProps extends PaneOwnProps {
   renderItem?: (props: {
     key: Option['value']
     label: Option['label']
-    style: object,
-    height: NonNullable<OptionsListProps['optionSize']>,
+    style: object
+    height: NonNullable<OptionsListProps['optionSize']>
     onSelect: () => void
     onDeselect: () => void
     isSelectable: boolean
@@ -1366,8 +1429,9 @@ export interface OptionsListProps extends PaneOwnProps {
   defaultSearchValue?: string
 }
 
-export class OptionsList extends React.PureComponent<OptionsListProps & BoxProps<'div'>> {
-}
+export class OptionsList extends React.PureComponent<
+  OptionsListProps & BoxProps<'div'>
+> {}
 
 export interface SearchInputOwnProps extends TextInputOwnProps {
   height?: number
@@ -1403,25 +1467,34 @@ export interface SearchTableHeaderCellOwnProps extends TableHeaderCellOwnProps {
   icon?: React.ElementType | JSX.Element | null | false
 }
 
-export type SearchTableHeaderCellProps = PolymorphicBoxProps<'div', SearchTableHeaderCellOwnProps>
-export declare const SearchTableHeaderCell: BoxComponent<SearchTableHeaderCellOwnProps, 'div'>
+export type SearchTableHeaderCellProps = PolymorphicBoxProps<
+  'div',
+  SearchTableHeaderCellOwnProps
+>
+export declare const SearchTableHeaderCell: BoxComponent<
+  SearchTableHeaderCellOwnProps,
+  'div'
+>
 
 export interface SegmentedControlOwnProps {
   /**
    * The options (elements) displayed by the segmented control
    */
-  options: Array<{ label: string, value: NonNullable<SegmentedControlOwnProps['value']> }>
-  
+  options: Array<{
+    label: string
+    value: NonNullable<SegmentedControlOwnProps['value']>
+  }>
+
   /**
    * The value of the segmented control
    */
   value?: number | string | boolean
-  
+
   /**
    * The initial value of an uncontrolled segmented control
    */
   defaultValue?: number | string | boolean
-  
+
   /**
    * Function called when value changes.
    */
@@ -1443,8 +1516,14 @@ export interface SegmentedControlOwnProps {
   disabled?: boolean
 }
 
-export type SegmentedControlProps = PolymorphicBoxProps<'div', SegmentedControlOwnProps>
-export declare const SegmentedControl: BoxComponent<SegmentedControlOwnProps, 'div'>
+export type SegmentedControlProps = PolymorphicBoxProps<
+  'div',
+  SegmentedControlOwnProps
+>
+export declare const SegmentedControl: BoxComponent<
+  SegmentedControlOwnProps,
+  'div'
+>
 
 export interface SelectOwnProps {
   /**
@@ -1510,11 +1589,13 @@ export interface SelectMenuContentProps {
   filterIcon?: OptionsListProps['filterIcon']
   listProps?: OptionsListProps
   isMultiSelect?: boolean
-  titleView?: React.ReactNode | ((props: {
-    close: NonNullable<SelectMenuContentProps['close']>,
-    title: SelectMenuContentProps['title'],
-    headerHeight: NonNullable<SelectMenuContentProps['headerHeight']>,
-  }) => React.ReactNode)
+  titleView?:
+    | React.ReactNode
+    | ((props: {
+        close: NonNullable<SelectMenuContentProps['close']>
+        title: SelectMenuContentProps['title']
+        headerHeight: NonNullable<SelectMenuContentProps['headerHeight']>
+      }) => React.ReactNode)
   detailView?: React.ReactNode
   emptyView?: React.ReactNode
 }
@@ -1528,9 +1609,12 @@ export interface SelectMenuItem {
   disabled?: boolean
 }
 
-export type SelectMenuPropsViewCallback = (args: { close(): void }) => React.ReactNode
+export type SelectMenuPropsViewCallback = (args: {
+  close(): void
+}) => React.ReactNode
 
-export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'content'> {
+export interface SelectMenuProps
+  extends Omit<PopoverProps, 'position' | 'content'> {
   /**
    * The title of the Select Menu.
    */
@@ -1605,8 +1689,8 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
    */
   filterIcon?: React.ElementType | JSX.Element
   /*
-    * When true, menu closes on option selection.
-    */
+   * When true, menu closes on option selection.
+   */
   closeOnSelect?: boolean
 }
 
@@ -1723,8 +1807,7 @@ export interface SwitchOwnProps {
 export type SwitchProps = PolymorphicBoxProps<'label', SwitchOwnProps>
 export declare const Switch: BoxComponent<SwitchOwnProps, 'label'>
 
-export interface TableBodyOwnProps extends PaneOwnProps {
-}
+export interface TableBodyOwnProps extends PaneOwnProps {}
 
 export type TableBodyProps = PolymorphicBoxProps<'div', TableBodyOwnProps>
 export declare const TableBody: BoxComponent<TableBodyOwnProps, 'div'>
@@ -1763,7 +1846,8 @@ export interface TableCellOwnProps extends PaneOwnProps {
 export type TableCellProps = PolymorphicBoxProps<'div', TableCellOwnProps>
 export declare const TableCell: BoxComponent<TableCellOwnProps, 'div'>
 
-interface TableEditableCellProps extends Omit<TextTableCellOwnProps, 'placeholder' | 'onChange'> {
+interface TableEditableCellProps
+  extends Omit<TextTableCellOwnProps, 'placeholder' | 'onChange'> {
   autoFocus?: boolean
   /**
    * Makes the TableCell focusable.
@@ -1792,11 +1876,16 @@ interface TableEditableCellProps extends Omit<TextTableCellOwnProps, 'placeholde
   onChange?(value: string): void
 }
 
-export interface TableHeaderCellOwnProps extends TableCellOwnProps {
-}
+export interface TableHeaderCellOwnProps extends TableCellOwnProps {}
 
-export type TableHeaderCellProps = PolymorphicBoxProps<'div', TableHeaderCellOwnProps>
-export declare const TableHeaderCell: BoxComponent<TableHeaderCellOwnProps, 'div'>
+export type TableHeaderCellProps = PolymorphicBoxProps<
+  'div',
+  TableHeaderCellOwnProps
+>
+export declare const TableHeaderCell: BoxComponent<
+  TableHeaderCellOwnProps,
+  'div'
+>
 
 export interface TableHeadOwnProps extends PaneOwnProps {
   height?: number | string
@@ -1853,7 +1942,8 @@ export interface TableRowOwnProps extends PaneOwnProps {
 export type TableRowProps = PolymorphicBoxProps<'div', TableRowOwnProps>
 export declare const TableRow: BoxComponent<TableRowOwnProps, 'div'>
 
-export interface TableSelectMenuCellProps extends Omit<TextTableCellOwnProps, 'placeholder'> {
+export interface TableSelectMenuCellProps
+  extends Omit<TextTableCellOwnProps, 'placeholder'> {
   /**
    * Makes the TableCell focusable.
    * Will add tabIndex={-1 || this.props.tabIndex}.
@@ -1917,8 +2007,7 @@ interface TableVirtualBodyProps extends PaneOwnProps {
   scrollToAlignment?: 'start' | 'center' | 'end' | 'auto'
 }
 
-export interface TableOwnProps extends PaneOwnProps {
-}
+export interface TableOwnProps extends PaneOwnProps {}
 
 export type TableProps = PolymorphicBoxProps<'div', TableOwnProps>
 
@@ -1961,7 +2050,10 @@ export type TablistProps = PolymorphicBoxProps<'div', TablistOwnProps>
 export declare const Tablist: BoxComponent<TablistOwnProps>
 
 export interface TabNavigationOwnProps {}
-export type TabNavigationProps = PolymorphicBoxProps<'nav', TabNavigationOwnProps>
+export type TabNavigationProps = PolymorphicBoxProps<
+  'nav',
+  TabNavigationOwnProps
+>
 export declare const TabNavigation: BoxComponent<TabNavigationOwnProps, 'nav'>
 
 export interface TagInputOwnProps {
@@ -1978,7 +2070,7 @@ export interface TagInputOwnProps {
   onInputChange?: (event: React.ChangeEvent) => void
   onRemove?: (value: string | React.ReactNode, index: number) => void
   separator?: string
-  tagSubmitKey?: "enter" | "space"
+  tagSubmitKey?: 'enter' | 'space'
   tagProps?: any
   values?: string[]
 }
@@ -2038,8 +2130,14 @@ export interface TextareaFieldOwnProps extends TextareaOwnProps {
   inputWidth?: number | string
 }
 
-export type TextareaFieldProps = PolymorphicBoxProps<'textarea', TextareaFieldOwnProps>
-export declare const TextareaField: BoxComponent<TextareaFieldOwnProps, 'textarea'>
+export type TextareaFieldProps = PolymorphicBoxProps<
+  'textarea',
+  TextareaFieldOwnProps
+>
+export declare const TextareaField: BoxComponent<
+  TextareaFieldOwnProps,
+  'textarea'
+>
 
 export interface TextDropdownButtonOwnProps extends TextOwnProps {
   /**
@@ -2062,8 +2160,14 @@ export interface TextDropdownButtonOwnProps extends TextOwnProps {
   className?: string
 }
 
-export type TextDropdownButtonProps = PolymorphicBoxProps<'button', TextDropdownButtonOwnProps>
-export declare const TextDropdownButton: BoxComponent<TextDropdownButtonOwnProps, 'button'>
+export type TextDropdownButtonProps = PolymorphicBoxProps<
+  'button',
+  TextDropdownButtonOwnProps
+>
+export declare const TextDropdownButton: BoxComponent<
+  TextDropdownButtonOwnProps,
+  'button'
+>
 
 export interface TextTableCellOwnProps extends TableCellOwnProps {
   /**
@@ -2076,15 +2180,24 @@ export interface TextTableCellOwnProps extends TableCellOwnProps {
   textProps?: PolymorphicBoxProps<'span', TextOwnProps>
 }
 
-export type TextTableCellProps = PolymorphicBoxProps<'div', TextTableCellOwnProps>
+export type TextTableCellProps = PolymorphicBoxProps<
+  'div',
+  TextTableCellOwnProps
+>
 export declare const TextTableCell: BoxComponent<TextTableCellOwnProps, 'div'>
 
 export type TextTableHeaderCellOwnProps = TableCellOwnProps & {
   textProps?: PolymorphicBoxProps<'span', TextOwnProps>
 }
 
-export type TextTableHeaderCellProps = PolymorphicBoxProps<'div', TextTableHeaderCellOwnProps>
-export declare const TextTableHeaderCell: BoxComponent<TextTableHeaderCellOwnProps, 'div'>
+export type TextTableHeaderCellProps = PolymorphicBoxProps<
+  'div',
+  TextTableHeaderCellOwnProps
+>
+export declare const TextTableHeaderCell: BoxComponent<
+  TextTableHeaderCellOwnProps,
+  'div'
+>
 
 export type TextOwnProps = {
   size?: keyof Typography['text']
@@ -2173,8 +2286,14 @@ export interface TextInputFieldOwnProps extends FormFieldOwnProps {
   inputWidth?: number | string
 }
 
-export type TextInputFieldProps = PolymorphicBoxProps<'input', TextInputFieldOwnProps>
-export declare const TextInputField: BoxComponent<TextInputFieldOwnProps, 'input'>
+export type TextInputFieldProps = PolymorphicBoxProps<
+  'input',
+  TextInputFieldOwnProps
+>
+export declare const TextInputField: BoxComponent<
+  TextInputFieldOwnProps,
+  'input'
+>
 
 export interface TooltipStatelessProps extends PaneOwnProps {
   /**
@@ -2243,7 +2362,10 @@ export interface UnorderedListOwnProps {
   iconColor?: string
 }
 
-export type UnorderedListProps = PolymorphicBoxProps<'ul', UnorderedListOwnProps>
+export type UnorderedListProps = PolymorphicBoxProps<
+  'ul',
+  UnorderedListOwnProps
+>
 export declare const UnorderedList: BoxComponent<UnorderedListOwnProps, 'ul'>
 export declare const Ul: typeof UnorderedList
 
@@ -2251,11 +2373,13 @@ export function majorScale(x: number): number
 
 export function minorScale(x: number): number
 
-export function extractStyles(options?: { nonce?: React.ScriptHTMLAttributes<'script'>['nonce'] }): {
+export function extractStyles(options?: {
+  nonce?: React.ScriptHTMLAttributes<'script'>['nonce']
+}): {
   css: string
   cache: {
-    uiBoxCache: ReturnType<typeof boxExtractStyles>['cache'],
-    glamorIds: string[],
+    uiBoxCache: ReturnType<typeof boxExtractStyles>['cache']
+    glamorIds: string[]
   }
   hydrationScript: JSX.Element
 }
@@ -2346,20 +2470,22 @@ export const toaster: {
 }
 
 export interface OverlayProps {
-  children: React.ReactNode | ((props: { state: TransitionStatus, close: () => void }) => JSX.Element);
+  children:
+    | React.ReactNode
+    | ((props: { state: TransitionStatus; close: () => void }) => JSX.Element)
 
-  isShown?: boolean;
-  containerProps?: BoxProps<'div'>;
-  preventBodyScrolling?: boolean;
-  shouldCloseOnClick?: boolean;
-  shouldCloseOnEscapePress?: boolean;
-  onBeforeClose?: () => void;
-  onExit?: TransitionProps['onExit'];
-  onExiting?: TransitionProps['onExiting'];
-  onExited?: TransitionProps['onExited'];
-  onEnter?: TransitionProps['onEnter'];
-  onEntering?: TransitionProps['onEntering'];
-  onEntered?: TransitionProps['onEntered'];
+  isShown?: boolean
+  containerProps?: BoxProps<'div'>
+  preventBodyScrolling?: boolean
+  shouldCloseOnClick?: boolean
+  shouldCloseOnEscapePress?: boolean
+  onBeforeClose?: () => void
+  onExit?: TransitionProps['onExit']
+  onExiting?: TransitionProps['onExiting']
+  onExited?: TransitionProps['onExited']
+  onEnter?: TransitionProps['onEnter']
+  onEntering?: TransitionProps['onEntering']
+  onEntered?: TransitionProps['onEntered']
 }
 
 export declare const Overlay: React.FC<OverlayProps>
@@ -2393,9 +2519,10 @@ export interface IconProps extends BoxProps<'svg'> {
   style?: React.CSSProperties
 }
 
-
 /* Start generated icons */
-type IconComponent = React.ForwardRefExoticComponent<React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>>
+type IconComponent = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>
+>
 export declare const AddIcon: IconComponent
 export declare const AddColumnLeftIcon: IconComponent
 export declare const AddColumnRightIcon: IconComponent

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -13,6 +13,7 @@ const Combobox = memo(function Combobox(props) {
     initialSelectedItem,
     itemToString,
     width = 240,
+    popoverMinWidth = 240,
     height,
     onChange,
     placeholder,
@@ -53,6 +54,7 @@ const Combobox = memo(function Combobox(props) {
       isFilterDisabled={isOpenedByButton}
       {...autocompleteProps}
       onStateChange={handleStateChange}
+      popoverMinWidth={popoverMinWidth}
     >
       {({
         getRef,

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -40,20 +40,18 @@ storiesOf('combobox', module).add('Combobox', () => {
         <Heading>Default usage</Heading>
         <Combobox items={items} onChange={handleChange} />
       </Box>
-      <Box>
-        <Box marginBottom={16}>
-          <Heading>Custom width</Heading>
-          <Combobox width={120} items={items} onChange={handleChange} />
-        </Box>
-        <Box marginBottom={16}>
-          <Heading>Custom width Popover</Heading>
-          <Combobox
-            width={120}
-            items={items}
-            onChange={handleChange}
-            popoverMinWidth={120}
-          />
-        </Box>
+      <Box marginBottom={16}>
+        <Heading>Custom width</Heading>
+        <Combobox width={120} items={items} onChange={handleChange} />
+      </Box>
+      <Box marginBottom={16}>
+        <Heading>Custom width Popover</Heading>
+        <Combobox
+          width={120}
+          items={items}
+          onChange={handleChange}
+          popoverMinWidth={120}
+        />
       </Box>
       <Box marginBottom={16} marginLeft={400}>
         <Heading>Custom width + offset</Heading>

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -40,14 +40,26 @@ storiesOf('combobox', module).add('Combobox', () => {
         <Heading>Default usage</Heading>
         <Combobox items={items} onChange={handleChange} />
       </Box>
-      <Box marginBottom={16}>
-        <Heading>Custom width</Heading>
-        <Combobox width={120} items={items} onChange={handleChange} />
+      <Box>
+        <Box marginBottom={16}>
+          <Heading>Custom width</Heading>
+          <Combobox width={120} items={items} onChange={handleChange} />
+        </Box>
+        <Box marginBottom={16}>
+          <Heading>Custom width Popover</Heading>
+          <Combobox
+            width={120}
+            items={items}
+            onChange={handleChange}
+            popoverMinWidth={120}
+          />
+        </Box>
       </Box>
       <Box marginBottom={16} marginLeft={400}>
         <Heading>Custom width + offset</Heading>
         <Combobox width={120} items={items} onChange={handleChange} />
       </Box>
+
       <Box marginBottom={16}>
         <Heading>Open on focus</Heading>
         <Combobox openOnFocus items={items} onChange={handleChange} />

--- a/src/combobox/stories/index.stories.js
+++ b/src/combobox/stories/index.stories.js
@@ -45,7 +45,7 @@ storiesOf('combobox', module).add('Combobox', () => {
         <Combobox width={120} items={items} onChange={handleChange} />
       </Box>
       <Box marginBottom={16}>
-        <Heading>Custom width Popover</Heading>
+        <Heading>Custom minimum width Popover</Heading>
         <Combobox
           width={120}
           items={items}
@@ -57,7 +57,6 @@ storiesOf('combobox', module).add('Combobox', () => {
         <Heading>Custom width + offset</Heading>
         <Combobox width={120} items={items} onChange={handleChange} />
       </Box>
-
       <Box marginBottom={16}>
         <Heading>Open on focus</Heading>
         <Combobox openOnFocus items={items} onChange={handleChange} />


### PR DESCRIPTION
**Disclaimer**
I couldn't find a way to do this without modifying the Combobox component, but if there's already a way to do this please let me know! Also, this is my first PR so I'm sorry if I did something wrong.

**Overview**
Added `popoverMinWidth` to Combobox component so the 240 default size can be changed to fit smaller items.

**Screenshots (if applicable)**
Before: Popover had fixed width of 240
![Screenshot from 2021-01-22 22-32-10](https://user-images.githubusercontent.com/32800546/105564700-1646f980-5d02-11eb-8900-bac2d178a748.png)

After: Popover with custom min width to fit combobox size
![Screenshot from 2021-01-22 22-32-18](https://user-images.githubusercontent.com/32800546/105564717-25c64280-5d02-11eb-91a4-a4d020ba1e3a.png)

Comboboxes with smaller texts (like just numbers) don't have much leftover space
![Screenshot from 2021-01-22 22-34-44](https://user-images.githubusercontent.com/32800546/105564730-337bc800-5d02-11eb-848c-4d61f7836f45.png)


**Documentation**
- [X] Added `popoverMinWidth` prop to Combobox component
- [X] Added Custom Minimum Width Popover to Storybook stories
