### PR TITLE
[v6] allow free entry autocomplete

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -568,6 +568,7 @@ export interface AutocompleteProps
   extends Omit<DownshiftProps<any>, 'children'> {
   title?: React.ReactNode
   items: any[]
+  allowOtherValues?: boolean
   renderItem?: (i: AutocompleteItemProps) => JSX.Element | null
   itemsFilter?: (items: string[], input: string) => string[]
   children: (props: {

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -117,6 +117,7 @@ const Autocomplete = memo(
       itemToString = i => (i ? String(i) : ''),
       popoverMaxHeight = 240,
       popoverMinWidth = 240,
+      allowOtherValues,
       ...restProps
     } = props
 
@@ -131,7 +132,7 @@ const Autocomplete = memo(
 
     const stateReducer = useCallback(
       (state, changes) => {
-        const { items } = props
+        const { allowOtherValues, items } = props
 
         if (
           Object.prototype.hasOwnProperty.call(changes, 'isOpen') &&
@@ -143,9 +144,17 @@ const Autocomplete = memo(
           }
         }
 
+        if (allowOtherValues && state.isOpen && !changes.isOpen) {
+          return {
+            ...changes,
+            selectedItem: changes.selectedItem || state.inputValue,
+            inputValue: state.inputValue
+          }
+        }
+
         return changes
       },
-      [props.items]
+      [props.items, props.allowOtherValues]
     )
 
     return (

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -307,6 +307,11 @@ Autocomplete.propTypes = {
    */
   popoverMaxHeight: PropTypes.number,
 
+  /**
+   * Whether or not the input accepts arbitrary user input beyond the provided items
+   */
+  allowOtherValues: PropTypes.bool,
+
   ...Downshift.propTypes
 }
 

--- a/src/autocomplete/stories/index.stories.js
+++ b/src/autocomplete/stories/index.stories.js
@@ -25,128 +25,135 @@ const items = [
   return 0
 })
 
-const handleChange = selectedItem => {
-  // eslint-disable-next-line no-console
-  console.log(selectedItem)
-}
+storiesOf('autocomplete', module).add('Autocomplete', () => {
+  const [selectedItem, setSelectedItem] = React.useState('')
 
-storiesOf('autocomplete', module).add('Autocomplete', () => (
-  <Box>
-    <Box padding={40}>
-      {(() => {
-        document.body.style.margin = '0'
-        document.body.style.height = '100vh'
-      })()}
-      <Autocomplete
-        title="Starwars names"
-        onChange={handleChange}
-        items={items}
-      >
-        {({ getInputProps, getRef, inputValue }) => (
-          <TextInput
-            placeholder="Starwars names"
-            value={inputValue}
-            ref={ref => getRef(ref)}
-            {...getInputProps()}
-          />
-        )}
-      </Autocomplete>
-    </Box>
-    <Box padding={40}>
-      <Autocomplete
-        title="Starwars names"
-        onChange={handleChange}
-        items={items}
-      >
-        {({ getInputProps, getRef, inputValue, openMenu }) => (
-          <TextInput
-            width={160}
-            placeholder="Min width in effect"
-            value={inputValue}
-            ref={ref => getRef(ref)}
-            {...getInputProps({
-              onFocus: () => {
-                openMenu()
-              }
-            })}
-          />
-        )}
-      </Autocomplete>
-    </Box>
-    <Box padding={40}>
-      <Autocomplete onChange={handleChange} items={items}>
-        {({ getInputProps, getRef, inputValue, openMenu }) => (
-          <TextInput
-            placeholder="Open on focus"
-            value={inputValue}
-            ref={ref => getRef(ref)}
-            {...getInputProps({
-              onFocus: () => {
-                openMenu()
-              }
-            })}
-          />
-        )}
-      </Autocomplete>
-    </Box>
-    <Box padding={40}>
-      <Autocomplete
-        isFilterDisabled
-        title="Disable filter"
-        onChange={handleChange}
-        items={items}
-      >
-        {({ getInputProps, getRef, inputValue, openMenu }) => (
-          <TextInput
-            placeholder="Disable filter and open on focus"
-            value={inputValue}
-            ref={ref => getRef(ref)}
-            {...getInputProps({
-              onFocus: () => {
-                openMenu()
-              }
-            })}
-          />
-        )}
-      </Autocomplete>
-    </Box>
-    <Box padding={40}>
-      <Autocomplete title="Suggestions" onChange={handleChange} items={items}>
-        {({ getInputProps, getRef, inputValue, openMenu }) => (
-          <TextInput
-            placeholder="Open on focus with title"
-            value={inputValue}
-            ref={ref => getRef(ref)}
-            {...getInputProps({
-              onFocus: () => {
-                openMenu()
-              }
-            })}
-          />
-        )}
-      </Autocomplete>
-    </Box>
-    <Box padding={40}>
-      <Autocomplete onChange={handleChange} items={items}>
-        {({
-          getInputProps,
-          getRef,
-          getToggleButtonProps,
-          inputValue,
-          toggleMenu
-        }) => (
-          <Box ref={ref => getRef(ref)} display="inline-block">
+  const handleChange = React.useCallback(selection => {
+    // eslint-disable-next-line no-console
+    console.log(selection)
+    setSelectedItem(selection)
+  }, [])
+
+  return (
+    <Box>
+      <Box padding={40}>
+        {(() => {
+          document.body.style.margin = '0'
+          document.body.style.height = '100vh'
+        })()}
+        <Autocomplete
+          title="Starwars names"
+          onChange={handleChange}
+          items={items}
+          selectedItem={selectedItem}
+          allowOtherValues
+        >
+          {({ getInputProps, getRef, inputValue }) => (
             <TextInput
-              placeholder="Trigger with button"
+              placeholder="Starwars names"
               value={inputValue}
+              ref={ref => getRef(ref)}
               {...getInputProps()}
             />
-            <Button onClick={toggleMenu} {...getToggleButtonProps()}>
-              Trigger
-            </Button>
-          </Box>
-        )}
-      </Autocomplete>
+          )}
+        </Autocomplete>
+      </Box>
+      <Box padding={40}>
+        <Autocomplete
+          title="Starwars names"
+          onChange={handleChange}
+          items={items}
+        >
+          {({ getInputProps, getRef, inputValue, openMenu }) => (
+            <TextInput
+              width={160}
+              placeholder="Min width in effect"
+              value={inputValue}
+              ref={ref => getRef(ref)}
+              {...getInputProps({
+                onFocus: () => {
+                  openMenu()
+                }
+              })}
+            />
+          )}
+        </Autocomplete>
+      </Box>
+      <Box padding={40}>
+        <Autocomplete onChange={handleChange} items={items}>
+          {({ getInputProps, getRef, inputValue, openMenu }) => (
+            <TextInput
+              placeholder="Open on focus"
+              value={inputValue}
+              ref={ref => getRef(ref)}
+              {...getInputProps({
+                onFocus: () => {
+                  openMenu()
+                }
+              })}
+            />
+          )}
+        </Autocomplete>
+      </Box>
+      <Box padding={40}>
+        <Autocomplete
+          isFilterDisabled
+          title="Disable filter"
+          onChange={handleChange}
+          items={items}
+        >
+          {({ getInputProps, getRef, inputValue, openMenu }) => (
+            <TextInput
+              placeholder="Disable filter and open on focus"
+              value={inputValue}
+              ref={ref => getRef(ref)}
+              {...getInputProps({
+                onFocus: () => {
+                  openMenu()
+                }
+              })}
+            />
+          )}
+        </Autocomplete>
+      </Box>
+      <Box padding={40}>
+        <Autocomplete title="Suggestions" onChange={handleChange} items={items}>
+          {({ getInputProps, getRef, inputValue, openMenu }) => (
+            <TextInput
+              placeholder="Open on focus with title"
+              value={inputValue}
+              ref={ref => getRef(ref)}
+              {...getInputProps({
+                onFocus: () => {
+                  openMenu()
+                }
+              })}
+            />
+          )}
+        </Autocomplete>
+      </Box>
+      <Box padding={40}>
+        <Autocomplete onChange={handleChange} items={items}>
+          {({
+            getInputProps,
+            getRef,
+            getToggleButtonProps,
+            inputValue,
+            toggleMenu
+          }) => (
+            <Box ref={ref => getRef(ref)} display="inline-block">
+              <TextInput
+                placeholder="Trigger with button"
+                value={inputValue}
+                {...getInputProps()}
+              />
+              <Button onClick={toggleMenu} {...getToggleButtonProps()}>
+                Trigger
+              </Button>
+            </Box>
+          )}
+        </Autocomplete>
+      </Box>
     </Box>
-  </Box>
-))
+  )
+})


### PR DESCRIPTION
**Overview**
This PR introduces a new prop `allowOtherValues` (boolean) that lets users specify when the Autocomplete should accept arbitrary user input that doesn't necessarily match anything in the options list.

**Screenshots (if applicable)**
![Kapture 2021-02-12 at 14 28 24](https://user-images.githubusercontent.com/710752/107819578-03db4100-6d3f-11eb-8626-17590eb5f23c.gif)


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
