### PR TITLE
Allow button to accept color prop

### DIFF
--- a/src/buttons/stories/index.stories.js
+++ b/src/buttons/stories/index.stories.js
@@ -197,6 +197,11 @@ buttonsStory.add('Common', () => (
               Permanently Delete Workspace...
             </Button>
           </Pane>
+          <Pane marginTop={16}>
+            <Button appearance="minimal" color="#36f">
+              Click Me
+            </Button>
+          </Pane>
         </React.Fragment>
       )}
     </Component>
@@ -219,9 +224,7 @@ buttonsStory.add('Button types', () => (
       <Button appearance="primary" marginRight={16}>
         Primary
       </Button>
-      <Button marginRight={16} intent="success">
-        Default
-      </Button>
+      <Button marginRight={16}>Default</Button>
       <Button appearance="destructive" marginRight={16} intent="danger">
         Destructive
       </Button>
@@ -234,7 +237,7 @@ buttonsStory.add('Button types', () => (
       <Button disabled appearance="primary" marginRight={16}>
         Primary
       </Button>
-      <Button disabled marginRight={16} intent="success">
+      <Button disabled marginRight={16}>
         Default
       </Button>
       <Button

--- a/src/themes/default/components/button.js
+++ b/src/themes/default/components/button.js
@@ -30,7 +30,7 @@ const colorKeyForAppearanceOrIntent = (appearance, intent) => {
   }
 }
 
-const colorKeyForIntent = (intent) => {
+const colorKeyForIntent = intent => {
   if (intent === 'danger') {
     return `red500`
   } else if (intent === 'success') {
@@ -50,12 +50,12 @@ const borderColorForIntent = (intent, isHover) => {
   }
 }
 
-const getPrimaryButtonAppearance = (appearance, intent, theme) => {
+const getPrimaryButtonAppearance = (appearance, intent, textColor, theme) => {
   const color = colorKeyForAppearanceOrIntent(appearance, intent)
   return {
     backgroundColor: `colors.${color}500`,
     borderColor: `colors.${color}500`,
-    color: 'white',
+    color: textColor || 'white',
     _hover: {
       backgroundColor: `colors.${color}600`,
       borderColor: `colors.${color}600`
@@ -77,13 +77,14 @@ const getPrimaryButtonAppearance = (appearance, intent, theme) => {
 }
 
 const appearances = {
-  primary: (theme, { appearance, intent }) =>
-    getPrimaryButtonAppearance(appearance, intent, theme),
+  primary: (theme, { appearance, color, intent }) =>
+    getPrimaryButtonAppearance(appearance, intent, color, theme),
   default: {
     backgroundColor: 'white',
     border: (theme, props) =>
       `1px solid ${theme.colors[borderColorForIntent(props.intent)]}`,
-    color: (theme, props) => theme.colors[colorKeyForIntent(props.intent)],
+    color: (theme, props) =>
+      props.color || theme.colors[colorKeyForIntent(props.intent)],
 
     _disabled: {
       color: 'colors.gray500',
@@ -92,7 +93,7 @@ const appearances = {
 
     _hover: {
       border: (theme, props) =>
-      `1px solid ${theme.colors[borderColorForIntent(props.intent, true)]}`,
+        `1px solid ${theme.colors[borderColorForIntent(props.intent, true)]}`,
       backgroundColor: 'colors.gray50'
     },
 
@@ -102,7 +103,8 @@ const appearances = {
   },
   minimal: {
     backgroundColor: 'transparent',
-    color: (theme, props) => theme.colors[colorKeyForIntent(props.intent)],
+    color: (theme, props) =>
+      props.color || theme.colors[colorKeyForIntent(props.intent)],
 
     _disabled: {
       color: 'colors.gray500',


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Enabling the button theme to make use of the color prop as expected

```jsx
<Button
    appearance="minimal"
    color={colors.blue500}
>
    Click Me
</Button>
```
![image](https://user-images.githubusercontent.com/17129452/108260352-17a7ee00-7117-11eb-82f9-ae4b1ea94ed8.png)
