### PR TITLE
forward ref to input on SearchInput

### DIFF
--- a/src/search-input/src/SearchInput.js
+++ b/src/search-input/src/SearchInput.js
@@ -29,7 +29,6 @@ const SearchInput = memo(
         position="relative"
         display="inline-flex"
         height={height}
-        ref={ref}
         {...matchedProps}
       >
         <Box
@@ -48,6 +47,7 @@ const SearchInput = memo(
           />
         </Box>
         <TextInput
+          ref={ref}
           height={height}
           paddingLeft={height}
           appearance={appearance}


### PR DESCRIPTION
**Overview**
This changes how we are forwarding refs in the SearchInput component. Right now we are passing the ref to the container component, which doesn't make a ton of sense. In reality we probably want to control the _input_ component. 

**Screenshots (if applicable)**
NA

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
