### PR TITLE
Call `onBeforeCose` before closing overlay

### DIFF
--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -93,7 +93,7 @@ const Overlay = memo(function Overlay({
   }, [isShown])
 
   const close = () => {
-    const shouldClose = safeInvoke(props.onBeforeClose)
+    const shouldClose = safeInvoke(onBeforeClose)
     if (shouldClose !== false) {
       setStatus('exiting')
     }

--- a/src/overlay/stories/index.stories.js
+++ b/src/overlay/stories/index.stories.js
@@ -1,9 +1,18 @@
-import React, { PureComponent } from 'react'
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  PureComponent
+} from 'react'
 import { storiesOf } from '@storybook/react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { Overlay } from '..'
 import { Button } from '../../buttons'
+import { Card } from '../../layers'
+import { majorScale } from '../../scales'
+import { Paragraph } from '../../typography'
 
 class OverlayManager extends PureComponent {
   static propTypes = {
@@ -67,3 +76,54 @@ storiesOf('overlay', module)
       </OverlayManager>
     </Box>
   ))
+  .add('Override close behavior', () => {
+    useEffect(() => {
+      document.body.style.margin = '0'
+      document.body.style.height = '100vh'
+    }, [])
+
+    const [isShown, setIsShown] = useState(false)
+
+    const show = useCallback(() => {
+      setIsShown(true)
+    }, [])
+
+    const timesClicked = useRef(0)
+
+    const hide = useCallback(() => {
+      setIsShown(false)
+      timesClicked.current = 0
+    }, [])
+
+    const beforeClose = useCallback(() => {
+      return ++timesClicked.current > 2
+    }, [])
+
+    return (
+      <Box padding={40}>
+        <Overlay
+          isShown={isShown}
+          containerProps={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+          onBeforeClose={beforeClose}
+          onExited={hide}
+        >
+          <Card
+            elevation={2}
+            background="white"
+            padding={majorScale(2)}
+            zIndex={30}
+            position="relative"
+            pointerEvents="none"
+          >
+            <Paragraph>Click 3 times to close it</Paragraph>
+          </Card>
+        </Overlay>
+
+        <Button onClick={show}>Show Overlay</Button>
+      </Box>
+    )
+  })


### PR DESCRIPTION
**Overview**

`<Overlay>` doesn't call `onBeforeClose`, because it was destructured from `props` and yet the component is still trying to find it in `props.onBeforeClose`.


**Documentation**
- [ ] ~Updated Typescript types and/or component PropTypes~
- [ ] ~Added / modified component docs~
- [x] Added / modified Storybook stories
