### PR TITLE
Set value when children are updated

### DIFF
--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react'
+import React, { memo, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import safeInvoke from '../../lib/safe-invoke'
 import { Portal } from '../../portal'
@@ -26,6 +26,10 @@ const EditableCell = memo(function EditableCell(props) {
   const [mainRef, setMainRef] = useState()
   const [value, setValue] = useState(children)
   const [isEditing, setIsEditing] = useState(autoFocus)
+
+  useEffect(() => {
+    setValue(children)
+  }, [children])
 
   const handleDoubleClick = () => {
     if (disabled || !isSelectable) return
@@ -97,7 +101,7 @@ const EditableCell = memo(function EditableCell(props) {
         }}
         {...rest}
       >
-        {children || placeholder}
+        {value || placeholder}
       </TextTableCell>
       {isEditing && (
         <Portal>

--- a/src/table/src/EditableCell.js
+++ b/src/table/src/EditableCell.js
@@ -96,7 +96,7 @@ const EditableCell = memo(function EditableCell(props) {
         cursor={cursor}
         textProps={{
           size,
-          opacity: disabled || (!children && placeholder) ? 0.5 : 1,
+          opacity: disabled || (!value && placeholder) ? 0.5 : 1,
           ...textProps
         }}
         {...rest}


### PR DESCRIPTION
**Overview**
Storybook code for the following gifs is found here: https://github.com/segmentio/evergreen/compare/cat-editable-cell...cat-example?expand=1

Previous behavior:
When passing in the key to the parent `Row` component, the behavior is as expected:
![prev_key](https://user-images.githubusercontent.com/34897995/116787457-f0479880-aa58-11eb-8c66-b16f7086c4e6.gif)

When not passed in the key to the parent `Row` component, when the value of the cell changed due to conditional rendering, values rendered were not expected:
![Prev_no_key](https://user-images.githubusercontent.com/34897995/116787549-84196480-aa59-11eb-91af-8d1170089565.gif)



**Screenshots (if applicable)**
Current:
With key:
![Working_key](https://user-images.githubusercontent.com/34897995/116787556-8b407280-aa59-11eb-93c6-7611cb69d363.gif)

Without key:
![Working_no_key](https://user-images.githubusercontent.com/34897995/116787553-8976af00-aa59-11eb-8257-5b5c865a0c93.gif)


**Documentation**
None of these changes apply:
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
