### PR TITLE
Update meta viewport to better scale the homepage

### DIFF
--- a/docs/components/document/Head.tsx
+++ b/docs/components/document/Head.tsx
@@ -17,6 +17,7 @@ const DocumentHead: React.FC<Props> = ({ title }) => {
     <Head>
       <title>{`Evergreen ${title || ''}`}</title>
       <meta property="og:title" content="Evergreen" />
+      <meta name="viewport" content="width=device-width, initial-scale=0.65, maximum-scale=5.0, minimum-scale=0.65" />
       <meta property="og:url" content={absolutePath()} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={absolutePath('/og-image.png')} />


### PR DESCRIPTION
**Overview**
On mobile, the site is scaled in a weird way. Here, we add a meta tag to scale it properly. Still imperfect, but a start. 


**Screenshots (if applicable)**
Goes from: 
![image](https://user-images.githubusercontent.com/5349500/118025146-59aa8f80-b314-11eb-9853-9bb51bc81ec1.png)

To: 
![image](https://user-images.githubusercontent.com/5349500/118025168-5dd6ad00-b314-11eb-9652-10ff7945ad20.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
