### PR TITLE
Fix codesandbox dependency parsing and typography page anchor urls

### DIFF
--- a/docs/documentation/foundations/typography.mdx
+++ b/docs/documentation/foundations/typography.mdx
@@ -1,13 +1,13 @@
 ## Text components
 
-- [**Heading**](#heading_heading_component): used for headings. A `h2` element by default.
-- [**Text**](#heading_text_component): used for single line text. A `span` element by default.
-- [**Paragraph**](#heading_paragraph_component): used for multiline text. A `p` element by default.
-- [**Link**](#heading_link_component): used for links. A `a` element by default.
-- [**Strong**](#heading_strong_component): used to make text strong. A `strong` element by default.
-- [**Small**](#heading_small_component): used for inline small text. A `small` element by default.
-- [**Pre**](#heading_pre_component): used for preformatted content. A `pre` element by default.
-- [**Code**](#heading_code_component): used for inline code. A `code` element by default.
+- [**Heading**](#heading_component): used for headings. A `h2` element by default.
+- [**Text**](#text_component): used for single line text. A `span` element by default.
+- [**Paragraph**](#paragraph_component): used for multiline text. A `p` element by default.
+- [**Link**](#link_component): used for links. A `a` element by default.
+- [**Strong**](#strong_component): used to make text strong. A `strong` element by default.
+- [**Small**](#small_component): used for inline small text. A `small` element by default.
+- [**Pre**](#pre_component): used for preformatted content. A `pre` element by default.
+- [**Code**](#code_component): used for inline code. A `code` element by default.
 
 ## List components
 

--- a/docs/lib/codesandbox.ts
+++ b/docs/lib/codesandbox.ts
@@ -19,7 +19,7 @@ export const getCodeSandboxLink: (source: string) => string = (source) => {
     : 'Demo'
 
   const usedComponents = Array.from(
-    new Set((source.match(/<((\w+))/g) || []).map((component) => component.replace('<', '')))
+    new Set((source.match(/<((\w+))|minorScale|majorScale/g) || []).map((component) => component.replace('<', '')))
   ).join(', ')
 
   const codeContent = `


### PR DESCRIPTION
**Overview**
Fix documentation pages for:
 1) dependency parsing for code sandbox snippets. Exported functions `majorScale` and `minorScale` were previously not picked up.
 2) Typography page anchor urls had an extra `heading_` term prepended to them

**Screenshots (if applicable)**
<img width="1304" alt="Screen Shot 2021-05-14 at 3 48 38 PM" src="https://user-images.githubusercontent.com/1166181/118338857-11ce6880-b4cc-11eb-80ed-c2731210821d.png">


**Documentation**
- [ n/a ] Updated Typescript types and/or component PropTypes
- [ n/a] Added / modified component docs
- [ n/a ] Added / modified Storybook stories
