### PR TITLE
(fix): Properly handle event bubbling from within Popover body

### DIFF
--- a/docs/documentation/components/popover.mdx
+++ b/docs/documentation/components/popover.mdx
@@ -28,14 +28,7 @@ When you pass a function to the `content` prop you will be able to close the pop
 ```jsx
 <Popover
   content={
-    <Pane
-      width={240}
-      height={240}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      flexDirection="column"
-    >
+    <Pane width={240} height={240} display="flex" alignItems="center" justifyContent="center" flexDirection="column">
       <Text>PopoverContent</Text>
     </Pane>
   }
@@ -65,7 +58,7 @@ When closing, it will return back focus on the target if nothing else has focus.
       justifyContent="center"
       flexDirection="column"
     >
-      <TextInput autoFocus width="100%" />
+      <TextInput width="100%" />
     </Pane>
   }
 >

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@storybook/theming": "^6.0.21",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
+    "@testing-library/user-event": "^13.1.9",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.1.0",

--- a/src/popover/__tests__/Popover.test.js
+++ b/src/popover/__tests__/Popover.test.js
@@ -5,14 +5,46 @@ import PopoverWithTextInputFixture from '../fixtures/PopoverWithTextInputChild'
 
 describe('Popover', () => {
   it('Should not be dismissed when clicking on a child within the popover', async () => {
-    const onBodyClick = jest.fn()
-    const { findByTestId } = render(<PopoverWithTextInputFixture onBodyClick={onBodyClick} />)
+    const { findByTestId } = render(<PopoverWithTextInputFixture />)
     const trigger = await findByTestId('popover-trigger')
     userEvent.click(trigger)
 
     const container = await findByTestId('popover-container')
+    const input = await findByTestId('popover-input')
 
+    // Simulate a user click event on the immediate child node
     userEvent.click(container)
+    expect(container).toBeVisible()
+
+    // Click on a child node a level deeper
+    userEvent.click(input)
+    expect(container).toBeVisible()
+    expect(input).toBeVisible()
+  })
+
+  it('Should render its content body to the DOM if `isShown` is set to `true`', async () => {
+    const { findByTestId } = render(<PopoverWithTextInputFixture isShown={true} />)
+    const container = await findByTestId('popover-container')
+
+    expect(container).toBeVisible()
+  })
+
+  it('Should properly report back the event, if the popover body is clicked', async () => {
+    const mockBodyClick = jest.fn()
+    render(<PopoverWithTextInputFixture isShown={true} onBodyClick={mockBodyClick} />)
+
+    userEvent.click(document.body)
+
+    expect(mockBodyClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('Should remain open if a user clicks somewhere outside of the popover area and `shouldCloseOnExternalClick` is `false`', async () => {
+    const { findByTestId } = render(<PopoverWithTextInputFixture isShown shouldCloseOnExternalClick={false} />)
+    const container = await findByTestId('popover-container')
+    expect(container).toBeVisible()
+    userEvent.click(document.body)
+
+    // Container should still be after document body was clicked
     expect(container).toBeVisible()
   })
 })

--- a/src/popover/__tests__/Popover.test.js
+++ b/src/popover/__tests__/Popover.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PopoverWithTextInputFixture from '../fixtures/PopoverWithTextInputChild'
+
+describe('Popover', () => {
+  it('Should not be dismissed when clicking on a child within the popover', async () => {
+    const onBodyClick = jest.fn()
+    const { findByTestId } = render(<PopoverWithTextInputFixture onBodyClick={onBodyClick} />)
+    const trigger = await findByTestId('popover-trigger')
+    userEvent.click(trigger)
+
+    const container = await findByTestId('popover-container')
+
+    userEvent.click(container)
+    expect(container).toBeVisible()
+  })
+})

--- a/src/popover/fixtures/PopoverWithTextInputChild.js
+++ b/src/popover/fixtures/PopoverWithTextInputChild.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Popover } from '../'
+import { Button } from '../../buttons'
+import { Pane } from '../../layers'
+import { TextInput } from '../../text-input'
+
+function PopoverWithTextInputChild(props) {
+  return (
+    <Popover
+      content={
+        <Pane
+          data-testid="popover-container"
+          width={320}
+          height={320}
+          paddingX={40}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          flexDirection="column"
+        >
+          <TextInput data-testid="popover-input" width="100%" />
+        </Pane>
+      }
+      {...props}
+    >
+      <Button data-testid="popover-trigger">Trigger Popover</Button>
+    </Popover>
+  )
+}
+
+export default PopoverWithTextInputChild

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -72,7 +72,6 @@ const Popover = memo(
           ) {
             return
           }
-          // Always delay focus manipulation to just before repaint to prevent scroll jumping
 
           const isFocusOutsideModal = !popoverNode.current.contains(document.activeElement)
           if (isFocusOutsideModal) {
@@ -184,6 +183,13 @@ const Popover = memo(
         if (targetRef.current && targetRef.current.contains(event.target)) {
           return
         }
+
+        if (popoverNode.current && popoverNode.current.contains(event.target)) {
+          return
+        }
+
+        // Notify body click
+        onBodyClick(event)
 
         if (shouldCloseOnExternalClick !== false) {
           close()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,6 +2651,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^13.1.9":
+  version "13.1.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.1.9.tgz#29e49a42659ac3c1023565ff56819e0153a82e99"
+  integrity sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
**Overview**: 
Looks like this bug was caused by a bad merge from the master <> v6 branch. Essentially, we want to cancel any event bubbling / dismissal of the popover from within its children by checking: 

- If the event originated at its trigger (i.e. a button) 
- If the event originated inside a child element (i.e. from a text input or button within the content body)

The first case was accounted for, while the other case wasn't. In addition, I added back the callback invocation for `onBodyClick`


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
