### PR TITLE
Add generated icon support for codesandbox docs

### DIFF
--- a/docs/lib/codesandbox.ts
+++ b/docs/lib/codesandbox.ts
@@ -19,7 +19,11 @@ export const getCodeSandboxLink: (source: string) => string = (source) => {
     : 'Demo'
 
   const usedComponents = Array.from(
-    new Set((source.match(/<((\w+))|minorScale|majorScale/g) || []).map((component) => component.replace('<', '')))
+    new Set(
+      (source.match(/<((\w+))|minorScale|majorScale|(((\w+)Icon))/g) || []).map((component) =>
+        component.replace('<', '')
+      )
+    )
   ).join(', ')
 
   const codeContent = `


### PR DESCRIPTION
**Overview** 
We have docs that leverage IconButton, so in order to fix those docs, we should grep for any instance of `*Icon`. 


**Screenshots (if applicable)**



**Documentation**
- [ ] ~Updated Typescript types and/or component PropTypes~
- [ ] ~Added / modified component docs~
- [ ] ~Added / modified Storybook stories~
