### PR TITLE
Fixup path generation for in-progress pattern components

### DIFF
--- a/docs/pages/patterns/[id]/props/index.tsx
+++ b/docs/pages/patterns/[id]/props/index.tsx
@@ -66,8 +66,7 @@ const PatternPropsPage: React.FC<Props> = ({ componentProps, foundation, foundat
 }
 
 export async function getStaticPaths() {
-  const files = await fs.readdirSync(path.join(process.cwd(), 'documentation', 'patterns'))
-  const paths = files.map((file) => `/patterns/${file.split('.')[0]}/props`)
+  const paths = IA.patterns.items.filter((item) => !item.inProgress).map((item) => `/patterns/${item.id}`)
 
   return {
     paths,


### PR DESCRIPTION
**Overview**
We were erroneously relying on the file system to generate this particular path. While for the overview page, we should still count that as a part of path generation, we should skip out the `/props` specifically if the component is in progress.


**Screenshots (if applicable)**
N/A build should work as expected


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
