### PR TITLE
Bring back icon search in the docs

### DIFF
--- a/docs/components/IconSearch.tsx
+++ b/docs/components/IconSearch.tsx
@@ -51,7 +51,7 @@ const IconSearch: React.FC<Props> = () => {
 
   return (
     <Pane width="100%" minHeight={250}>
-      <SearchBar query={query} onQueryChange={setQuery} placeholder="Search through icons below:" />
+      <SearchBar query={query} onQueryChange={setQuery} placeholder="Search through icons below" />
       {iconComponentNames.length > 0 ? (
         <Pane
           marginTop={majorScale(5)}

--- a/docs/components/IconSearch.tsx
+++ b/docs/components/IconSearch.tsx
@@ -1,42 +1,52 @@
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import SearchBar from './SearchBar'
 import { css } from 'otion'
+import CopyToClipboard from 'react-copy-to-clipboard'
 import * as evergreen from 'evergreen-ui'
 
-const { Pane, majorScale, Text } = evergreen
+const { Pane, majorScale, Text, toaster } = evergreen
 
 interface Props {}
 
 const Item: React.FC<{ name: string }> = ({ name }) => {
   const readableName = name.slice(0, name.indexOf('Icon'))
+
+  const handleCopy = useCallback(() => {
+    toaster.success('Successfully copied icon name to clipboard!')
+  }, [])
+
   // @ts-ignore
   if (evergreen[name]) {
     return (
-      <Pane
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        flexDirection="column"
-        cursor="pointer"
-        borderRadius={5}
-        paddingY={majorScale(3)}
-        className={css({
-          ':hover': {
-            opacity: 0.8,
-            background: '#efefef60',
-          },
-        })}
-      >
-        {/*  @ts-ignore */}
-        {React.createElement(evergreen[name] as any, {
-          size: majorScale(3),
-          color: 'default',
-          marginBottom: majorScale(3),
-        })}
-        <Text color="muted" size={300} maxWidth="100%">
-          {readableName}
-        </Text>
-      </Pane>
+      <CopyToClipboard text={name} onCopy={handleCopy}>
+        <Pane
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexDirection="column"
+          cursor="pointer"
+          borderRadius={5}
+          paddingY={majorScale(3)}
+          className={css({
+            ':hover': {
+              background: '#efefef60',
+            },
+            ':active': {
+              background: '#efefef90',
+            },
+          })}
+        >
+          {/*  @ts-ignore */}
+          {React.createElement(evergreen[name] as any, {
+            size: majorScale(3),
+            color: 'default',
+            marginBottom: majorScale(3),
+          })}
+          <Text color="muted" size={300} maxWidth="100%">
+            {readableName}
+          </Text>
+        </Pane>
+      </CopyToClipboard>
     )
   } else {
     return null

--- a/docs/components/IconSearch.tsx
+++ b/docs/components/IconSearch.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react'
+import SearchBar from './SearchBar'
+import { css } from 'otion'
+import * as evergreen from 'evergreen-ui'
+
+const { Pane, majorScale, Text } = evergreen
+
+interface Props {}
+
+const Item: React.FC<{ name: string }> = ({ name }) => {
+  const readableName = name.slice(0, name.indexOf('Icon'))
+  // @ts-ignore
+  if (evergreen[name]) {
+    return (
+      <Pane
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        flexDirection="column"
+        cursor="pointer"
+        borderRadius={5}
+        paddingY={majorScale(3)}
+        className={css({
+          ':hover': {
+            opacity: 0.8,
+            background: '#efefef60',
+          },
+        })}
+      >
+        {/*  @ts-ignore */}
+        {React.createElement(evergreen[name] as any, {
+          size: majorScale(3),
+          color: 'default',
+          marginBottom: majorScale(3),
+        })}
+        <Text color="muted" size={300} maxWidth="100%">
+          {readableName}
+        </Text>
+      </Pane>
+    )
+  } else {
+    return null
+  }
+}
+const IconSearch: React.FC<Props> = () => {
+  const [query, setQuery] = useState<string>('')
+
+  const iconComponentNames = Object.keys(evergreen)
+    .filter((componentName) => componentName.endsWith('Icon') && componentName !== 'Icon')
+    .filter((componentName) => componentName.toLowerCase().indexOf(query.toLowerCase()) !== -1)
+
+  return (
+    <Pane width="100%" minHeight={250}>
+      <SearchBar query={query} onQueryChange={setQuery} placeholder="Search through icons below:" />
+      {iconComponentNames.length > 0 ? (
+        <Pane
+          marginTop={majorScale(5)}
+          display="grid"
+          rowGap={majorScale(5)}
+          columnGap={majorScale(8)}
+          gridTemplateColumns="repeat(auto-fill, 168px)"
+        >
+          {iconComponentNames.map((componentName) => {
+            console.log(componentName.slice(0, componentName.indexOf('Icon')))
+            return <Item key={componentName} name={componentName} />
+          })}
+        </Pane>
+      ) : (
+        <Pane display="flex" alignItems="center" justifyContent="center" width="100%" marginTop={majorScale(5)}>
+          <Text color="muted">{`No results found for term ${query}`} </Text>
+        </Pane>
+      )}
+    </Pane>
+  )
+}
+
+export default IconSearch

--- a/docs/components/MDX/componentMapping.tsx
+++ b/docs/components/MDX/componentMapping.tsx
@@ -3,6 +3,7 @@ import Code from './renderers/Code'
 import InlineCode from './renderers/InlineCode'
 import Blockquote from './renderers/Blockquote'
 import ColorSwatch from '../ColorSwatch'
+import IconSearch from '../IconSearch'
 import { Paragraph, Strong, Ol, Ul, Li, majorScale } from 'evergreen-ui'
 
 const componentMapping = {
@@ -21,6 +22,7 @@ const componentMapping = {
   inlineCode: (props: any) => <InlineCode {...props} />,
   blockquote: Blockquote,
   ColorSwatch,
+  IconSearch,
 }
 
 export default componentMapping

--- a/docs/documentation/foundations/icons.mdx
+++ b/docs/documentation/foundations/icons.mdx
@@ -6,10 +6,9 @@ Evergreen uses the amazing [@blueprintjs/icons](https://blueprintjs.com/docs/#ic
 
 All of Evergreen's icons are exported as individual components, and can be imported directly like so:
 
- `import { CrossIcon } from 'evergreen-ui'`
+`import { CrossIcon } from 'evergreen-ui'`
 
- `import { InfoSignIcon, EditIcon } from 'evergreen-ui'`
-
+`import { InfoSignIcon, EditIcon } from 'evergreen-ui'`
 
 ### Icons are not buttons
 
@@ -57,3 +56,5 @@ There is an exported `Icon` component which acts as a convenient wrapper around 
 
 Each icon has two different `svg` variations, a `16px` and `20px` variation.
 Evergreen will choose the most appropriate size based on the `size` passed to the icon.
+
+<IconSearch />


### PR DESCRIPTION
**Overview**
This PR brings back icon searching into the docs site so that users can quickly find what they're looking for. 

**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/5349500/121274186-d599e800-c87e-11eb-9cbf-43610108741f.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
