### PR TITLE
include yarnhook in devDeps so it doesnt fail when not globally installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "size-limit": "^4.5.0",
     "starwars-names": "^1.6.0",
     "url-loader": "^1.1.2",
-    "webpack": "^4.43.0"
+    "webpack": "^4.43.0",
+    "yarnhook": "^0.5.1"
   },
   "prettier": {
     "semi": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6563,7 +6563,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^4.0.0, execa@^4.1.0:
+execa@^4.0.0, execa@^4.0.3, execa@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -6931,6 +6931,11 @@ find-cache-dir@^3.3.1:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-parent-dir@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.1.tgz#c5c385b96858c3351f95d446cab866cbf9f11125"
+  integrity sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -15226,6 +15231,14 @@ yarn-or-npm@^3.0.1:
   dependencies:
     cross-spawn "^6.0.5"
     pkg-dir "^4.2.0"
+
+yarnhook@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/yarnhook/-/yarnhook-0.5.1.tgz#27d47947412bd124874d56aa75725b76b68cc398"
+  integrity sha512-YPLLXO/PzsFXKvRfsOG/r60WBz8RT7VbkkQv2oHDb6o+EjX0vcUSeA3aw5el2AEWjbcg1sgemjHyCwRIvQxZWw==
+  dependencies:
+    execa "^4.0.3"
+    find-parent-dir "^0.3.0"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
**Overview**
This PR adds a dev dep that the package.json relies on. You'll get command failures like `yarnhook: command not found` when not installed globally. The recommendation is to install as a devDependency.


**Screenshots (if applicable)**
NA

**Documentation**
- [ ] ~~Updated Typescript types and/or component PropTypes~~
- [ ] ~~Added / modified component docs~~
- [ ] ~~Added / modified Storybook stories~~
