### PR TITLE
move @types/* dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "@types/react": "^16.9.5",
-    "@types/react-transition-group": "^4.4.0",
     "arrify": "^1.0.1",
     "classnames": "^2.2.6",
     "downshift": "^5.2.0",
@@ -100,6 +98,8 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^13.1.9",
+    "@types/react": "^16.9.5",
+    "@types/react-transition-group": "^4.4.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
**Overview**
Moved `@types/react` and `@types/react-transition-group` to `devDependencies` instead of `depdendencies`, this way those types shouldn't interfere with typescript builds of projects using evergreen.


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
