### PR TITLE
remove css-nil classes from glamor

### DIFF
--- a/src/alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/src/alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`<Alert /> appearance snapshot 1`] = `
 <div
-  className="css-nil ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
+  className="ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
   role="alert"
 >
   <div
-    className="css-nil ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
+    className="ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
   >
     <svg
       className="css-1ffn9ia ub-w_16px ub-h_16px ub-box-szg_border-box"
@@ -20,7 +20,7 @@ exports[`<Alert /> appearance snapshot 1`] = `
     </svg>
   </div>
   <div
-    className="css-nil ub-flx_1 ub-box-szg_border-box"
+    className="ub-flx_1 ub-box-szg_border-box"
   >
     <h4
       className="ub-mt_0px ub-mb_0px ub-color_inherit ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_14px ub-ln-ht_1 ub-ltr-spc_-0-05px ub-box-szg_border-box"
@@ -28,7 +28,7 @@ exports[`<Alert /> appearance snapshot 1`] = `
       Test title
     </h4>
     <div
-      className="css-nil ub-box-szg_border-box"
+      className="ub-box-szg_border-box"
     />
   </div>
 </div>
@@ -36,11 +36,11 @@ exports[`<Alert /> appearance snapshot 1`] = `
 
 exports[`<Alert /> basic snapshot 1`] = `
 <div
-  className="css-nil ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
+  className="ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
   role="alert"
 >
   <div
-    className="css-nil ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
+    className="ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
   >
     <svg
       className="css-1ffn9ia ub-w_16px ub-h_16px ub-box-szg_border-box"
@@ -54,7 +54,7 @@ exports[`<Alert /> basic snapshot 1`] = `
     </svg>
   </div>
   <div
-    className="css-nil ub-flx_1 ub-box-szg_border-box"
+    className="ub-flx_1 ub-box-szg_border-box"
   >
     <h4
       className="ub-mt_0px ub-mb_0px ub-color_inherit ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_14px ub-ln-ht_1 ub-ltr-spc_-0-05px ub-box-szg_border-box"
@@ -62,7 +62,7 @@ exports[`<Alert /> basic snapshot 1`] = `
       A simple general message
     </h4>
     <div
-      className="css-nil ub-box-szg_border-box"
+      className="ub-box-szg_border-box"
     />
   </div>
 </div>
@@ -70,11 +70,11 @@ exports[`<Alert /> basic snapshot 1`] = `
 
 exports[`<Alert /> intent snapshot 1`] = `
 <div
-  className="css-nil ub-b-top_1px-solid-D14343 ub-b-rgt_1px-solid-D14343 ub-b-btm_1px-solid-D14343 ub-b-lft_1px-solid-D14343 ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_FDF4F4 ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_A73636 ub-box-szg_border-box"
+  className="ub-b-top_1px-solid-D14343 ub-b-rgt_1px-solid-D14343 ub-b-btm_1px-solid-D14343 ub-b-lft_1px-solid-D14343 ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_FDF4F4 ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_A73636 ub-box-szg_border-box"
   role="alert"
 >
   <div
-    className="css-nil ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
+    className="ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
   >
     <svg
       className="css-tn1wco ub-w_16px ub-h_16px ub-box-szg_border-box"
@@ -88,7 +88,7 @@ exports[`<Alert /> intent snapshot 1`] = `
     </svg>
   </div>
   <div
-    className="css-nil ub-flx_1 ub-box-szg_border-box"
+    className="ub-flx_1 ub-box-szg_border-box"
   >
     <h4
       className="ub-mt_0px ub-mb_0px ub-color_inherit ub-fnt-fam_b77syt ub-f-wght_500 ub-fnt-sze_14px ub-ln-ht_1 ub-ltr-spc_-0-05px ub-box-szg_border-box"
@@ -96,7 +96,7 @@ exports[`<Alert /> intent snapshot 1`] = `
       Test title
     </h4>
     <div
-      className="css-nil ub-box-szg_border-box"
+      className="ub-box-szg_border-box"
     />
   </div>
 </div>

--- a/src/hooks/use-style-config.js
+++ b/src/hooks/use-style-config.js
@@ -110,8 +110,9 @@ function useGlamorAndBox(styles, pseudoSelectors) {
 
     // Take all the "non-compatible" props and give those to glamor (since ui-box doesn't know how to handle them yet)
     if (!isEqual(glamorStylesRef.current, glamorStyles)) {
+      const className = css(glamorStyles).toString()
       glamorStylesRef.current = glamorStyles
-      classNameRef.current = css(glamorStyles).toString()
+      classNameRef.current = className === 'css-nil' ? undefined : className
     }
 
     return {


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
This PR removes those pesky `css-nil` classnames. This occurs whenever there are no styles to give to glamor:
```
{}
{ foo: false }
null
undefined
```

We are typically only dealing with `{}` in our style config hook, but this will uniformly omit the `css-nil` class.

**Screenshots (if applicable)**
NA

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
