### PR TITLE
Use EvergreenLink for text link in doc

### DIFF
--- a/docs/components/MDX/componentMapping.tsx
+++ b/docs/components/MDX/componentMapping.tsx
@@ -4,7 +4,7 @@ import InlineCode from './renderers/InlineCode'
 import Blockquote from './renderers/Blockquote'
 import ColorSwatch from '../ColorSwatch'
 import IconSearch from '../IconSearch'
-import { Paragraph, Strong, Ol, Ul, Li, majorScale } from 'evergreen-ui'
+import { Paragraph, Strong, Ol, Ul, Li, majorScale, Link as EvergreenLink } from 'evergreen-ui'
 
 const componentMapping = {
   h1: (props: any) => <SectionHeading size={800} {...props} />,
@@ -15,6 +15,7 @@ const componentMapping = {
   h6: (props: any) => <SectionHeading size={200} {...props} />,
   code: (props: { className: string; metastring: string; children: any }) => <Code {...props} />,
   p: (props: any) => <Paragraph marginBottom={majorScale(3)} {...props} />,
+  a: (props: any) => <EvergreenLink {...props} />,
   strong: (props: any) => <Strong {...props} />,
   ol: (props: any) => <Ol {...props} />,
   ul: (props: any) => <Ul {...props} />,


### PR DESCRIPTION
Highlight the link in blue using Evergreen Link. Related to https://github.com/segmentio/evergreen/issues/1226
![image](https://user-images.githubusercontent.com/679627/128946121-6eb9f7cd-9142-48dd-9e87-20f1509e0176.png)
