### PR TITLE
Info Intent bug on toaster.notify() rectified

### DIFF
--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -98,7 +98,7 @@ Alert.propTypes = {
   /**
    * The intent of the alert.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The title of the alert.

--- a/src/alert/src/InlineAlert.js
+++ b/src/alert/src/InlineAlert.js
@@ -58,7 +58,7 @@ InlineAlert.propTypes = {
   /**
    * The intent of the alert. This should always be set explicitly.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * When true, show a icon on the left matching the type.

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -78,7 +78,7 @@ IconButton.propTypes = {
   /**
    * The intent of the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The appearance of the button.

--- a/src/constants/src/Intent.js
+++ b/src/constants/src/Intent.js
@@ -2,5 +2,6 @@ export default {
   NONE: 'none',
   SUCCESS: 'success',
   WARNING: 'warning',
-  DANGER: 'danger'
+  DANGER: 'danger',
+  INFO: 'info'
 }

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -184,7 +184,7 @@ CornerDialog.propTypes = {
   /**
    * The intent of the CornerDialog. Used for the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * When true, the dialog is shown.

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -233,7 +233,7 @@ Dialog.propTypes = {
   /**
    * The intent of the Dialog. Used for the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * When true, the dialog is shown.

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -162,7 +162,7 @@ MenuItem.propTypes = {
   /**
    * The intent of the menu item.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * Flag to indicate whether the menu item is disabled or not

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -157,7 +157,7 @@ TableRow.propTypes = {
   /**
    * The intent of the alert.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The appearance of the table row. Default theme only support default.

--- a/src/toaster/src/Toast.js
+++ b/src/toaster/src/Toast.js
@@ -177,7 +177,7 @@ Toast.propTypes = {
   /**
    * The type of the alert.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The title of the alert.


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
This warning was occurring because info was not provided in the intent's propTypes array. Like in the SS. 

I have added 'info' as the Proptype option in all the files wherever required. Here are thee file names:
1. InlineAlert.js
2. IconButton.js
3. CornerDialog.js
4. Dialog.js
5. MenuItem.js
6. TableRow.js
7. Toast.js

**Screenshots (if applicable)**
From
![image](https://user-images.githubusercontent.com/43092030/130613964-d83b939d-16f4-4b46-8af8-2291833079ec.png)

To
![image](https://user-images.githubusercontent.com/43092030/130614623-0f28dfb6-f30a-4364-8057-3bda90f02b27.png)


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
