### PR TITLE
Fix 'alignItems' attribute in getting-started example

### DIFF
--- a/docs/documentation/introduction/getting-started.mdx
+++ b/docs/documentation/introduction/getting-started.mdx
@@ -32,7 +32,7 @@ import { Button, Pane, Text, majorScale } from 'evergreen-ui'
 Then, you can use those components in your code like:
 
 ```jsx readonly
-<Pane display="flex" alginItems="center" marginX={majorScale(2)}>
+<Pane display="flex" alignItems="center" marginX={majorScale(2)}>
   <Button>Click me!</Button>
   <Text>This is a clickable Button</Text>
 </Pane>


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Stumbled upon this framework. I copied the code from the docs into CodeSandbox, and Typescript put the red squiggly under it.

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
