### PR TITLE
Add info type to intent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -149,6 +149,7 @@ export interface Colors {
     none: string
     success: string
     warning: string
+    info: string
   }
   text: {
     danger: string

--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -98,7 +98,7 @@ Alert.propTypes = {
   /**
    * The intent of the alert.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The title of the alert.

--- a/src/alert/src/InlineAlert.js
+++ b/src/alert/src/InlineAlert.js
@@ -58,7 +58,7 @@ InlineAlert.propTypes = {
   /**
    * The intent of the alert. This should always be set explicitly.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * When true, show a icon on the left matching the type.

--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -78,7 +78,7 @@ IconButton.propTypes = {
   /**
    * The intent of the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The appearance of the button.

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -184,7 +184,7 @@ CornerDialog.propTypes = {
   /**
    * The intent of the CornerDialog. Used for the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * When true, the dialog is shown.

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -233,7 +233,7 @@ Dialog.propTypes = {
   /**
    * The intent of the Dialog. Used for the button.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * When true, the dialog is shown.

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -162,7 +162,7 @@ MenuItem.propTypes = {
   /**
    * The intent of the menu item.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * Flag to indicate whether the menu item is disabled or not

--- a/src/table/src/TableRow.js
+++ b/src/table/src/TableRow.js
@@ -157,7 +157,7 @@ TableRow.propTypes = {
   /**
    * The intent of the alert.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The appearance of the table row. Default theme only support default.

--- a/src/themes/classic/deprecated/foundational-styles/colors.js
+++ b/src/themes/classic/deprecated/foundational-styles/colors.js
@@ -76,6 +76,7 @@ export default {
     none: palette.blue.base,
     success: palette.green.base,
     danger: palette.red.base,
-    warning: palette.orange.base
+    warning: palette.orange.base,
+    info: palette.blue.base
   }
 }

--- a/src/themes/deprecated/foundational-styles/colors.js
+++ b/src/themes/deprecated/foundational-styles/colors.js
@@ -76,6 +76,7 @@ export default {
     none: palette.blue.base,
     success: palette.green.base,
     danger: palette.red.base,
-    warning: palette.orange.base
+    warning: palette.orange.base,
+    info: palette.blue.base
   }
 }

--- a/src/toaster/src/Toast.js
+++ b/src/toaster/src/Toast.js
@@ -177,7 +177,7 @@ Toast.propTypes = {
   /**
    * The type of the alert.
    */
-  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger']),
+  intent: PropTypes.oneOf(['none', 'success', 'warning', 'danger', 'info']),
 
   /**
    * The title of the alert.

--- a/src/toaster/src/Toaster.js
+++ b/src/toaster/src/Toaster.js
@@ -66,6 +66,10 @@ export default class Toaster {
     return this.notifyHandler(title, { ...settings, intent: 'danger' })
   }
 
+  info = (title, settings = {}) => {
+    return this.notifyHandler(title, { ...settings, intent: 'info' })
+  }
+
   remove = id => {
     return this.removeHandler(id)
   }

--- a/src/toaster/stories/index.stories.js
+++ b/src/toaster/stories/index.stories.js
@@ -115,6 +115,22 @@ storiesOf('toaster', module).add('examples', () => (
           Danger remove notification with id
         </Button>
       </Box>
+      <Box marginBottom={12}>
+        <Button marginRight={8} onClick={() => toaster.info('Changes will affect all Warehouses.')}>
+          Info
+        </Button>
+
+        <Button
+          marginRight={8}
+          onClick={() =>
+            toaster.info('Changes will affect all Warehouses.', {
+              description: loremIpsum
+            })
+          }
+        >
+          Info with Text
+        </Button>
+      </Box>
     </Box>
   </Box>
 ))


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Fix for the issue #1319 

I realized that "info" is exactly the same as "none" but doesn't exist in the documentation. This PR add "info" to intent proptype to avoid having warnings but I could also remove the type from TypeScript definition. 

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
