### PR TITLE
Update onBeforeClose prop typing for SideSheet and Overlay components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1860,7 +1860,7 @@ export interface SideSheetProps {
   isShown?: boolean
   onCloseComplete?: () => void
   onOpenComplete?: () => void
-  onBeforeClose?: () => void
+  onBeforeClose?: () => boolean
   shouldCloseOnOverlayClick?: boolean
   shouldCloseOnEscapePress?: boolean
   width?: string | number
@@ -2614,7 +2614,7 @@ export interface OverlayProps {
   preventBodyScrolling?: boolean
   shouldCloseOnClick?: boolean
   shouldCloseOnEscapePress?: boolean
-  onBeforeClose?: () => void
+  onBeforeClose?: () => boolean
   onExit?: TransitionProps['onExit']
   onExiting?: TransitionProps['onExiting']
   onExited?: TransitionProps['onExited']


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves typing discrepancy for `OverlayProps.onBeforeClose` and `SideSheetProps.onBeforeClose` as described in *#1330 interface SidesheetProps does not match the function signature*


**Screenshots (if applicable)**
N/A

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] *[N/A]* Added / modified component docs
- [x] *[N/A]* Added / modified Storybook stories
