### PR TITLE
fix ToastManager hasCloseButton logic

### DIFF
--- a/src/toaster/src/ToastManager.js
+++ b/src/toaster/src/ToastManager.js
@@ -71,7 +71,7 @@ const ToastManager = memo(function ToastManager(props) {
       id,
       title,
       description: settings.description,
-      hasCloseButton: settings.hasCloseButton || true,
+      hasCloseButton: settings.hasCloseButton ?? true,
       duration: settings.duration || 5,
       close: () => safeCloseToast(id),
       intent: settings.intent

--- a/src/toaster/stories/index.stories.js
+++ b/src/toaster/stories/index.stories.js
@@ -50,6 +50,16 @@ storiesOf('toaster', module).add('examples', () => (
         >
           Notify once
         </Button>
+        <Button
+          marginRight={8}
+          onClick={() =>
+            toaster.notify('Cannot be closed by user', {
+              hasCloseButton: false
+            })
+          }
+        >
+          Notify without close button
+        </Button>
       </Box>
       <Box marginBottom={12}>
         <Button marginRight={8} onClick={() => toaster.success('Hooray! You did it. Your Source is now sending data.')}>


### PR DESCRIPTION
**Overview**
related to #1317. `hasCloseButton` option has no effect on toaster at the moment. This change will respect the option. 


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
