### PR TITLE
correctly forward className in code component

### DIFF
--- a/src/typography/__tests__/Code.test.js
+++ b/src/typography/__tests__/Code.test.js
@@ -44,11 +44,11 @@ describe('Code', () => {
   it('should pass through `className` prop', () => {
     const expected = faker.random.word().toLowerCase()
     const component = (
-      <Code data-testid="text" className={expected}>
+      <Code data-testid="code" className={expected}>
         Testing
       </Code>
     )
     const { getByTestId } = render(component)
-    expect(getByTestId('text')).toHaveClass(expected)
+    expect(getByTestId('code')).toHaveClass(expected)
   })
 })

--- a/src/typography/__tests__/Code.test.js
+++ b/src/typography/__tests__/Code.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import faker from 'faker'
+import Code from '../src/Code'
+
+describe('Props', () => {
+  test('<Code /> accepts arbitrary props', () => {
+    const propKey = faker.random
+      .word()
+      .toLowerCase()
+      .replace(/ /g, '')
+    const propValue = faker.random
+      .word()
+      .toLowerCase()
+      .replace(/ /g, '')
+    const component = (
+      <Code data-testid="text" {...{ [propKey]: propValue }}>
+        Testing
+      </Code>
+    )
+    const { getByTestId } = render(component)
+    expect(getByTestId('text')).toHaveAttribute(propKey, propValue)
+  })
+
+  test('<Code /> forwards `className` prop', () => {
+    const expected = faker.random.word().toLowerCase()
+    const component = (
+      <Code data-testid="text" className={expected}>
+        Testing
+      </Code>
+    )
+    const { getByTestId } = render(component)
+    expect(getByTestId('text')).toHaveClass(expected)
+  })
+})

--- a/src/typography/__tests__/Code.test.js
+++ b/src/typography/__tests__/Code.test.js
@@ -1,9 +1,46 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import faker from 'faker'
+import renderer from 'react-test-renderer'
+import { ThemeProvider } from '../../theme'
+import { defaultTheme } from '../../themes'
 import Code from '../src/Code'
 
 describe('Code', () => {
+  it('Should render', () => {
+    expect(() => render(<Code>This is my code</Code>)).not.toThrow()
+  })
+
+  it.each([
+    ['size 300', 300],
+    ['size 400', 400],
+    ['size 500', 500],
+    ['size 600', 600]
+  ])('<Code /> %s renders as expected', (_, size) => {
+    const component = (
+      <ThemeProvider value={defaultTheme}>
+        <Code size={size}>{`Text ${size}`}</Code>
+      </ThemeProvider>
+    )
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it.each([
+    ['size 300', 300],
+    ['size 400', 400],
+    ['size 500', 500],
+    ['size 600', 600]
+  ])('<Code /> %s with minimal appearance specified renders as expected', (_, size) => {
+    const component = (
+      <ThemeProvider value={defaultTheme}>
+        <Code size={size} appearance="minimal">{`Text ${size}`}</Code>
+      </ThemeProvider>
+    )
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
   it('should pass through `className` prop', () => {
     const expected = faker.random.word().toLowerCase()
     const component = (

--- a/src/typography/__tests__/Code.test.js
+++ b/src/typography/__tests__/Code.test.js
@@ -2,9 +2,12 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import faker from 'faker'
 import renderer from 'react-test-renderer'
+import { UIBoxSerializer } from '../../../lib/testing'
 import { ThemeProvider } from '../../theme'
 import { defaultTheme } from '../../themes'
 import Code from '../src/Code'
+
+expect.addSnapshotSerializer(UIBoxSerializer)
 
 describe('Code', () => {
   it('Should render', () => {

--- a/src/typography/__tests__/Code.test.js
+++ b/src/typography/__tests__/Code.test.js
@@ -3,26 +3,8 @@ import { render } from '@testing-library/react'
 import faker from 'faker'
 import Code from '../src/Code'
 
-describe('Props', () => {
-  test('<Code /> accepts arbitrary props', () => {
-    const propKey = faker.random
-      .word()
-      .toLowerCase()
-      .replace(/ /g, '')
-    const propValue = faker.random
-      .word()
-      .toLowerCase()
-      .replace(/ /g, '')
-    const component = (
-      <Code data-testid="text" {...{ [propKey]: propValue }}>
-        Testing
-      </Code>
-    )
-    const { getByTestId } = render(component)
-    expect(getByTestId('text')).toHaveAttribute(propKey, propValue)
-  })
-
-  test('<Code /> forwards `className` prop', () => {
+describe('Code', () => {
+  it('should pass through `className` prop', () => {
     const expected = faker.random.word().toLowerCase()
     const component = (
       <Code data-testid="text" className={expected}>

--- a/src/typography/__tests__/Text.test.js
+++ b/src/typography/__tests__/Text.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+import faker from 'faker'
 import renderer from 'react-test-renderer'
 import { UIBoxSerializer } from '../../../lib/testing'
 import { ThemeProvider } from '../../theme'
@@ -68,5 +69,36 @@ describe('Sizing', () => {
 
       "Warning: Failed %s type: %s%s"
     `)
+  })
+})
+
+describe('Props', () => {
+  test('<Text /> accepts arbitrary props', () => {
+    const propKey = faker.random
+      .word()
+      .toLowerCase()
+      .replace(/ /g, '')
+    const propValue = faker.random
+      .word()
+      .toLowerCase()
+      .replace(/ /g, '')
+    const component = (
+      <Text data-testid="text" {...{ [propKey]: propValue }}>
+        Testing
+      </Text>
+    )
+    const { getByTestId } = render(component)
+    expect(getByTestId('text')).toHaveAttribute(propKey, propValue)
+  })
+
+  test('<Text/> forwards className prop', () => {
+    const MY_CLASS = 'my-custom-class'
+    const component = (
+      <Text data-testid="text" className={`${MY_CLASS}`}>
+        Testing
+      </Text>
+    )
+    const { getByTestId } = render(component)
+    expect(getByTestId('text')).toHaveClass(MY_CLASS)
   })
 })

--- a/src/typography/__tests__/Text.test.js
+++ b/src/typography/__tests__/Text.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import faker from 'faker'
 import renderer from 'react-test-renderer'
 import { UIBoxSerializer } from '../../../lib/testing'
 import { ThemeProvider } from '../../theme'
@@ -73,25 +72,7 @@ describe('Sizing', () => {
 })
 
 describe('Props', () => {
-  test('<Text /> accepts arbitrary props', () => {
-    const propKey = faker.random
-      .word()
-      .toLowerCase()
-      .replace(/ /g, '')
-    const propValue = faker.random
-      .word()
-      .toLowerCase()
-      .replace(/ /g, '')
-    const component = (
-      <Text data-testid="text" {...{ [propKey]: propValue }}>
-        Testing
-      </Text>
-    )
-    const { getByTestId } = render(component)
-    expect(getByTestId('text')).toHaveAttribute(propKey, propValue)
-  })
-
-  test('<Text/> forwards className prop', () => {
+  it('should forward `className` prop', () => {
     const MY_CLASS = 'my-custom-class'
     const component = (
       <Text data-testid="text" className={`${MY_CLASS}`}>

--- a/src/typography/__tests__/Text.test.js
+++ b/src/typography/__tests__/Text.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
+import faker from 'faker'
 import renderer from 'react-test-renderer'
 import { UIBoxSerializer } from '../../../lib/testing'
 import { ThemeProvider } from '../../theme'
@@ -73,13 +74,13 @@ describe('Sizing', () => {
 
 describe('Props', () => {
   it('should forward `className` prop', () => {
-    const MY_CLASS = 'my-custom-class'
+    const expected = faker.random.word().toLowerCase()
     const component = (
-      <Text data-testid="text" className={`${MY_CLASS}`}>
+      <Text data-testid="text" className={expected}>
         Testing
       </Text>
     )
     const { getByTestId } = render(component)
-    expect(getByTestId('text')).toHaveClass(MY_CLASS)
+    expect(getByTestId('text')).toHaveClass(expected)
   })
 })

--- a/src/typography/__tests__/__snapshots__/Code.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Code.test.js.snap
@@ -1,6 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Code <Code /> size 300 renders as expected 1`] = `
+Extracted Styles:
+background-color: rgba(16, 112, 202, 0.06);
+border-bottom-left-radius: 4px;
+border-bottom-right-radius: 4px;
+border-top-left-radius: 4px;
+border-top-right-radius: 4px;
+box-shadow: inset 0 0 0 1px rgba(16, 112, 202, 0.14);
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 12px;
+font-size: 14px;
+font-weight: 400;
+letter-spacing: -0.05px;
+letter-spacing: 0;
+line-height: 16px;
+line-height: 20px;
+padding-bottom: 3px;
+padding-left: 6px;
+padding-right: 6px;
+padding-top: 3px;
+
+
 <code
   className="ub-fnt-sze_12px ub-f-wght_400 ub-ln-ht_16px ub-ltr-spc_0 ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
 >
@@ -9,6 +32,16 @@ exports[`Code <Code /> size 300 renders as expected 1`] = `
 `;
 
 exports[`Code <Code /> size 300 with minimal appearance specified renders as expected 1`] = `
+Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 12px;
+font-weight: 400;
+letter-spacing: 0;
+line-height: 16px;
+
+
 <code
   className="ub-fnt-sze_12px ub-f-wght_400 ub-ln-ht_16px ub-ltr-spc_0 ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
 >
@@ -17,6 +50,26 @@ exports[`Code <Code /> size 300 with minimal appearance specified renders as exp
 `;
 
 exports[`Code <Code /> size 400 renders as expected 1`] = `
+Extracted Styles:
+background-color: rgba(16, 112, 202, 0.06);
+border-bottom-left-radius: 4px;
+border-bottom-right-radius: 4px;
+border-top-left-radius: 4px;
+border-top-right-radius: 4px;
+box-shadow: inset 0 0 0 1px rgba(16, 112, 202, 0.14);
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 14px;
+font-weight: 400;
+letter-spacing: -0.05px;
+line-height: 20px;
+padding-bottom: 3px;
+padding-left: 6px;
+padding-right: 6px;
+padding-top: 3px;
+
+
 <code
   className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
 >
@@ -25,6 +78,16 @@ exports[`Code <Code /> size 400 renders as expected 1`] = `
 `;
 
 exports[`Code <Code /> size 400 with minimal appearance specified renders as expected 1`] = `
+Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 14px;
+font-weight: 400;
+letter-spacing: -0.05px;
+line-height: 20px;
+
+
 <code
   className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
 >
@@ -33,6 +96,26 @@ exports[`Code <Code /> size 400 with minimal appearance specified renders as exp
 `;
 
 exports[`Code <Code /> size 500 renders as expected 1`] = `
+Extracted Styles:
+background-color: rgba(16, 112, 202, 0.06);
+border-bottom-left-radius: 4px;
+border-bottom-right-radius: 4px;
+border-top-left-radius: 4px;
+border-top-right-radius: 4px;
+box-shadow: inset 0 0 0 1px rgba(16, 112, 202, 0.14);
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 16px;
+font-weight: 400;
+letter-spacing: -0.05px;
+line-height: 20px;
+padding-bottom: 3px;
+padding-left: 6px;
+padding-right: 6px;
+padding-top: 3px;
+
+
 <code
   className="ub-fnt-sze_16px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
 >
@@ -41,6 +124,16 @@ exports[`Code <Code /> size 500 renders as expected 1`] = `
 `;
 
 exports[`Code <Code /> size 500 with minimal appearance specified renders as expected 1`] = `
+Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 16px;
+font-weight: 400;
+letter-spacing: -0.05px;
+line-height: 20px;
+
+
 <code
   className="ub-fnt-sze_16px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
 >
@@ -49,6 +142,26 @@ exports[`Code <Code /> size 500 with minimal appearance specified renders as exp
 `;
 
 exports[`Code <Code /> size 600 renders as expected 1`] = `
+Extracted Styles:
+background-color: rgba(16, 112, 202, 0.06);
+border-bottom-left-radius: 4px;
+border-bottom-right-radius: 4px;
+border-top-left-radius: 4px;
+border-top-right-radius: 4px;
+box-shadow: inset 0 0 0 1px rgba(16, 112, 202, 0.14);
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 18px;
+font-weight: 400;
+letter-spacing: -0.07px;
+line-height: 24px;
+padding-bottom: 3px;
+padding-left: 6px;
+padding-right: 6px;
+padding-top: 3px;
+
+
 <code
   className="ub-fnt-sze_18px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
 >
@@ -57,6 +170,16 @@ exports[`Code <Code /> size 600 renders as expected 1`] = `
 `;
 
 exports[`Code <Code /> size 600 with minimal appearance specified renders as expected 1`] = `
+Extracted Styles:
+box-sizing: border-box;
+color: #474d66;
+font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+font-size: 18px;
+font-weight: 400;
+letter-spacing: -0.07px;
+line-height: 24px;
+
+
 <code
   className="ub-fnt-sze_18px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
 >

--- a/src/typography/__tests__/__snapshots__/Code.test.js.snap
+++ b/src/typography/__tests__/__snapshots__/Code.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code <Code /> size 300 renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_12px ub-f-wght_400 ub-ln-ht_16px ub-ltr-spc_0 ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
+>
+  Text 300
+</code>
+`;
+
+exports[`Code <Code /> size 300 with minimal appearance specified renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_12px ub-f-wght_400 ub-ln-ht_16px ub-ltr-spc_0 ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 300
+</code>
+`;
+
+exports[`Code <Code /> size 400 renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
+>
+  Text 400
+</code>
+`;
+
+exports[`Code <Code /> size 400 with minimal appearance specified renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_14px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 400
+</code>
+`;
+
+exports[`Code <Code /> size 500 renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_16px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
+>
+  Text 500
+</code>
+`;
+
+exports[`Code <Code /> size 500 with minimal appearance specified renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_16px ub-f-wght_400 ub-ln-ht_20px ub-ltr-spc_-0-05px ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 500
+</code>
+`;
+
+exports[`Code <Code /> size 600 renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_18px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_tawojy ub-color_474d66 ub-bg-clr_rgba16-112-202-0-06 ub-bs_1o2cska ub-pl_6px ub-pr_6px ub-pb_3px ub-pt_3px ub-bblr_4px ub-bbrr_4px ub-btlr_4px ub-btrr_4px ub-box-szg_border-box"
+>
+  Text 600
+</code>
+`;
+
+exports[`Code <Code /> size 600 with minimal appearance specified renders as expected 1`] = `
+<code
+  className="ub-fnt-sze_18px ub-f-wght_400 ub-ln-ht_24px ub-ltr-spc_-0-07px ub-fnt-fam_tawojy ub-color_474d66 ub-box-szg_border-box"
+>
+  Text 600
+</code>
+`;

--- a/src/typography/src/Code.js
+++ b/src/typography/src/Code.js
@@ -12,7 +12,7 @@ const Code = memo(
 
     const styleProps = useStyleConfig('Code', { appearance }, pseudoSelectors, internalStyles)
 
-    return <Text is="code" ref={ref} className={className} fontFamily="mono" {...styleProps} {...restProps} />
+    return <Text is="code" ref={ref} {...styleProps} fontFamily="mono" className={className} {...restProps} />
   })
 )
 

--- a/src/typography/stories/index.stories.js
+++ b/src/typography/stories/index.stories.js
@@ -53,7 +53,12 @@ storiesOf('typography', module)
   ))
   .add('Paragraph', () => <div>{previewTextComponent(Paragraph, TextSizes, { marginTop: 24 })}</div>)
   .add('Heading', () => <div>{previewTextComponent(Heading, HeadingSizes, { marginTop: 24 })}</div>)
-  .add('Code', () => <div>{previewTextComponent(Code)}</div>)
+  .add('Code', () => (
+    <div>
+      {previewTextComponent(Code)}
+      {previewTextComponent(Code, TextSizes, { appearance: 'minimal' })}
+    </div>
+  ))
   .add('Pre', () => <div>{previewTextComponent(Pre)}</div>)
   .add('Label', () => <div>{previewTextComponent(Label)}</div>)
   .add('Small', () => (


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

This PR changes the order the props are spread in `<Code>` so `className` is correctly forwarded. 

Fixes #1351 

**Screenshots (if applicable)**

Before:
![Screen Shot 2021-10-29 at 10 32 33 AM](https://user-images.githubusercontent.com/1812749/139478960-d688ce0c-4080-4da5-863f-01fd7b270d44.png)

After:
![Screen Shot 2021-10-29 at 10 32 54 AM](https://user-images.githubusercontent.com/1812749/139478966-409386f7-2824-4093-a228-1dcc6ab6b2ca.png)



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
