### PR TITLE
Fix Positioner rendering, Autocomplete + Combobox positioning issues

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -187,11 +187,9 @@ const Autocomplete = memo(
                   isShown: isShownPopover,
                   toggle,
                   getRef: ref => {
-                    if (ref !== targetRef) {
-                      // Use the ref internally to determine the width
-                      setTargetRef(ref)
-                      getRef(ref)
-                    }
+                    // Use the ref internally to determine the width
+                    setTargetRef(ref)
+                    getRef(ref)
                   },
                   inputValue,
                   selectedItem,

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -223,10 +223,8 @@ const Popover = memo(
         const isTooltipInside = children && children.type === Tooltip
 
         const getTargetRef = ref => {
-          if (ref !== targetRef) {
-            setTargetRef(ref)
-            getRef(ref)
-          }
+          setTargetRef(ref)
+          getRef(ref)
         }
 
         /**


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Fixes #1354 Combobox position issue
Fixes #1329 Autocomplete 'children' function continuously invoked

The root issue for #1329 was not the ref updates but the `useEffect` in `src/positioner/src/Positioner.js`. It was watching `dimensions` as a dependency while it was using `previousDimensions` and also calling `update`, which wasn't wrapped in a `useCallback`. This should only re-render when those values change. Tested out in storybook using the same console log in the children function as described in #1329


**Screenshots (if applicable)**

Autocomplete rendering before `Positioner` change
https://www.loom.com/share/353e9a69b7f744d2816bcdab7aff8dda

Autocomplete rendering after `Positioner` change
https://www.loom.com/share/6f9963d7966046fdbd579ea2e3565a35

Note that both of these are after the `ref` changes in `Autocomplete` and `Combobox` were reverted, so those are appearing in the correct location.

Combobox positioning (also demoable from [Storybook](https://github.com/segmentio/evergreen/pull/1362#:~:text=https%3A//deploy-preview-1362--evergreen-storybook.netlify.app))
![image](https://user-images.githubusercontent.com/11774799/142026516-e3cbb3f3-db1b-47f2-85e4-1758df851d3d.png)

Autocomplete positioning (also demoable from [Storybook](https://deploy-preview-1362--evergreen-storybook.netlify.app/))
![image](https://user-images.githubusercontent.com/11774799/142026592-edea6aa8-c59a-4a39-be8d-fbd15eefe190.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
