### PR TITLE
fix: 🐛 Add position prop to the CornerDialogProps type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -824,6 +824,10 @@ export interface CornerDialogProps {
    * Props that are passed to the dialog container.
    */
   containerProps?: React.ComponentProps<typeof Card>
+  /**
+   * Props that will set position of corner dialog
+   */
+  position?: Exclude<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
 }
 
 export declare const CornerDialog: React.FC<CornerDialogProps>


### PR DESCRIPTION
**Overview**
As per the documentation and the source code, the `CornerDialog` component should have position as an optional prop, however, that's not the case in `index.d.ts`.

✅  Closes: #1368

**Screenshots**
Current documentation page
![image](https://user-images.githubusercontent.com/2552277/142868636-e7ed14db-25a3-4093-950b-14354f5d4a45.png)

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
