### PR TITLE
[Fix] Prevent Scrolling gets stuck when other packages/script also change document.body.style.overflow

### DIFF
--- a/src/lib/__tests__/prevent-body-scroll.test.js
+++ b/src/lib/__tests__/prevent-body-scroll.test.js
@@ -1,0 +1,62 @@
+import preventBodyScroll from '../prevent-body-scroll'
+
+describe('preventBodyScroll', () => {
+  it('Should change body overflow to hidden on true and reset overflow on false', async () => {
+    expect(document.body.style.overflow).toEqual('')
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('')
+  })
+  it('Should be able to handle changes from other scripts changing body overflow', async () => {
+    // Repeat logic of first test
+    expect(document.body.style.overflow).toEqual('')
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('')
+
+    // Outside source changes overflow to hidden
+    document.body.style.overflow = 'hidden'
+    // Restores 'hidden' as expected
+    expect(document.body.style.overflow).toEqual('hidden')
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('hidden')
+    // 'hidden' should no longer be apart of the history
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('')
+
+    // Outside source changes overflow to ''
+    document.body.style.overflow = ''
+    // Repeat steps from first test to ensure it is not affected
+    expect(document.body.style.overflow).toEqual('')
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('')
+  })
+  it('Should be able to restore multiple layers of overflow values', async () => {
+    document.body.style.overflow = ''
+    // First overlay
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+    // Second overlay
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+    // Third overlay
+    preventBodyScroll(true)
+    expect(document.body.style.overflow).toEqual('hidden')
+
+    // Remove third overlay
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('hidden')
+    // Remove second overlay
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('hidden')
+    // Remove first overlay
+    preventBodyScroll(false)
+    expect(document.body.style.overflow).toEqual('')
+  })
+})

--- a/src/lib/prevent-body-scroll.js
+++ b/src/lib/prevent-body-scroll.js
@@ -1,5 +1,5 @@
-let previousOverflow
-let previousPaddingRight
+const previousOverflow = []
+const previousPaddingRight = []
 
 /**
  * Toggle the body scroll / overflow and additional styling
@@ -13,10 +13,10 @@ export default function preventBodyScroll(preventScroll) {
 
   /** Apply or remove overflow style */
   if (preventScroll) {
-    previousOverflow = document.body.style.overflow
+    previousOverflow.push(document.body.style.overflow)
     document.body.style.overflow = 'hidden'
   } else {
-    document.body.style.overflow = previousOverflow || ''
+    document.body.style.overflow = previousOverflow.pop() || ''
   }
 
   /** Get the _new width_ of the body (this will tell us the scrollbar width) */
@@ -25,9 +25,9 @@ export default function preventBodyScroll(preventScroll) {
 
   /** If there's a diff due to scrollbars, then account for it with padding */
   if (preventScroll) {
-    previousPaddingRight = document.body.style.paddingRight
+    previousPaddingRight.push(document.body.style.paddingRight)
     document.body.style.paddingRight = Math.max(0, scrollBarWidth || 0) + 'px'
   } else {
-    document.body.style.paddingRight = previousPaddingRight || ''
+    document.body.style.paddingRight = previousPaddingRight.pop() || ''
   }
 }


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

When another package/script _OR_ multiple complements use prevent-body-scroll together _previousOverflow_ and _previousPaddingRight_ get stuck.

Scenario observed:

1. React app creates fullscreen overlay(not evergreen), manually sets `document.body.style.overflow = 'hidden'`
2. React app opens Evergreen overlay with `preventBodyScrolling` set overtop the fullscreen. `previousOverflow` is set to `hidden`
3. Evergreen overlay is closed -> `document.body.style.overflow = previousOverflow` keeps it at hidden. Now only the fullscreen overlay(not evergreen) is up
4. The fullscreen module is closed and the React app manually sets `document.body.style.overflow = ''`
5. At this point `document.body.style.overflow` is not set, however, the _next_ Evergreen overlay that does not use `preventBodyScrolling` will default to using the old `previousOverflow` which was never cleared, disabling all scrolling on the overlay, when it was not intended to

The proposed change will create a history of the overlay changes, and once restored, remove it from the history. This will allow multiple overlays to have `preventBodyScrolling` up at a time without having to figure out if another is already up, and it will allow it to play nicely with outside scripts that are also dealing with setting `document.body.style.overflow`

**Screenshots (if applicable)**


**Documentation** (n/a to this change)
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
