### PR TITLE
Export IconComponent type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2664,7 +2664,7 @@ export interface IconProps extends BoxProps<'svg'> {
 }
 
 /* Start generated icons */
-type IconComponent = React.ForwardRefExoticComponent<React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>>
+export type IconComponent = React.ForwardRefExoticComponent<React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>>
 export declare const AddIcon: IconComponent
 export declare const AddColumnLeftIcon: IconComponent
 export declare const AddColumnRightIcon: IconComponent

--- a/tools/generate-icons.js
+++ b/tools/generate-icons.js
@@ -1,19 +1,16 @@
 #!/usr/bin/env node
 'use strict'
 const path = require('path')
-const fs = require('fs-extra')
 const { IconSvgPaths16, IconSvgPaths20 } = require('@blueprintjs/icons')
 const camelCase = require('camelcase')
+const fs = require('fs-extra')
 const prettier = require('prettier')
 
 const iconsPath = path.resolve(__dirname, '../src/icons/generated')
 const iconsIndexPath = path.resolve(__dirname, '../src/icons/index.js')
 const indexPath = path.resolve(__dirname, '../src/index.js')
 const typedefPath = path.resolve(__dirname, '../index.d.ts')
-const iconNamesMapperPath = path.resolve(
-  __dirname,
-  '../src/icons/generated/IconNameMapper.js'
-)
+const iconNamesMapperPath = path.resolve(__dirname, '../src/icons/generated/IconNameMapper.js')
 const fileHeader = `// This is a generated file. DO NOT modify directly.\n\n`
 
 async function main() {
@@ -122,22 +119,15 @@ export const ${iconName} = memo(forwardRef(function ${iconName}(props, ref) {
   // update the typedefs to include icons
   // =====================
 
-  const iconTypeDefs = iconNames
-    .map(
-      componentName => `export declare const ${componentName}: IconComponent`
-    )
-    .join('\n')
+  const iconTypeDefs = iconNames.map(componentName => `export declare const ${componentName}: IconComponent`).join('\n')
 
   const iconsTypeDefs = `/* Start generated icons */
-type IconComponent = React.ForwardRefExoticComponent<React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>>
+export type IconComponent = React.ForwardRefExoticComponent<React.PropsWithoutRef<IconProps> & React.RefAttributes<SVGElement>>
 ${iconTypeDefs}
 /* End generated icons */`
 
   let typedefs = await fs.readFile(typedefPath, 'utf8')
-  typedefs = typedefs.replace(
-    /\/\* Start generated icons \*\/[\s\S]*?\/\* End generated icons \*\//i,
-    iconsTypeDefs
-  )
+  typedefs = typedefs.replace(/\/\* Start generated icons \*\/[\s\S]*?\/\* End generated icons \*\//i, iconsTypeDefs)
 
   await fs.writeFile(typedefPath, typedefs)
 }


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

This PR exports the IconComponent type in the Typescript types. This allows components building on top of evergreen to indicate that they need an icon(-ish) component.


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
