### PR TITLE
upgrade faker to ^5.5.3 and replace alternatives for deprecated methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-sort-destructure-keys": "^1.3.5",
     "eslint-plugin-standard": "4.0.0",
-    "faker": "^4.1.0",
+    "faker": "^5.5.3",
     "file-loader": "^6.0.0",
     "fs-extra": "^7.0.0",
     "husky": "^4.0.10",

--- a/src/badges/stories/index.stories.js
+++ b/src/badges/stories/index.stories.js
@@ -18,7 +18,7 @@ const range = N => Array.from({ length: N }, (v, k) => k + 1)
 
 faker.seed(7816)
 const randomNumbers = range(8).map(() => {
-  return faker.random.number({
+  return faker.datatype.number({
     min: 1,
     max: 100
   })

--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -14,7 +14,7 @@ const range = N => Array.from({ length: N }, (v, k) => k + 1)
 
 faker.seed(500)
 const dynamicHeights = range(500).map(() => {
-  return faker.random.number({
+  return faker.datatype.number({
     min: 32,
     max: 100
   })

--- a/src/textarea/__tests__/Textarea.test.js
+++ b/src/textarea/__tests__/Textarea.test.js
@@ -47,7 +47,7 @@ describe('Textarea', () => {
   })
 
   it('Should pass through `spellCheck` prop to textarea', () => {
-    const expected = faker.random.boolean()
+    const expected = faker.datatype.boolean()
     const { container } = render(makeTextareaFixture({ spellCheck: expected }))
 
     const textarea = container.querySelector('textarea')
@@ -55,7 +55,7 @@ describe('Textarea', () => {
   })
 
   it('Should render with `aria-invalid` when isInvalid provided', () => {
-    const expected = faker.random.boolean()
+    const expected = faker.datatype.boolean()
     const { container } = render(makeTextareaFixture({ isInvalid: expected }))
 
     const textarea = container.querySelector('textarea')
@@ -63,7 +63,7 @@ describe('Textarea', () => {
   })
 
   it('Should render with `data-gramm_editor` when grammarly provided', () => {
-    const expected = faker.random.boolean()
+    const expected = faker.datatype.boolean()
     const { container } = render(makeTextareaFixture({ grammarly: expected }))
 
     const textarea = container.querySelector('textarea')
@@ -71,7 +71,7 @@ describe('Textarea', () => {
   })
 
   it('Should pass through `width` prop to textarea', () => {
-    const expected = faker.random.number({ min: 10, max: 100 })
+    const expected = faker.datatype.number({ min: 10, max: 100 })
     const { container } = render(makeTextareaFixture({ width: expected }))
 
     const textarea = container.querySelector('textarea')
@@ -79,7 +79,7 @@ describe('Textarea', () => {
   })
 
   it('Should pass through `height` prop to textarea', () => {
-    const expected = faker.random.number({ min: 10, max: 100 })
+    const expected = faker.datatype.number({ min: 10, max: 100 })
     const { container } = render(makeTextareaFixture({ height: expected }))
 
     const textarea = container.querySelector('textarea')

--- a/src/textarea/__tests__/TextareaField.test.js
+++ b/src/textarea/__tests__/TextareaField.test.js
@@ -96,7 +96,7 @@ describe('TextareaField', () => {
     })
 
     it('Should pass through `spellCheck` prop to textarea', () => {
-      const expected = faker.random.boolean()
+      const expected = faker.datatype.boolean()
       const { container } = render(makeTextareaFieldFixture({ spellCheck: expected }))
 
       const textarea = container.querySelector('textarea')
@@ -104,7 +104,7 @@ describe('TextareaField', () => {
     })
 
     it('Should render with `aria-invalid` when isInvalid provided', () => {
-      const expected = faker.random.boolean()
+      const expected = faker.datatype.boolean()
       const { container } = render(makeTextareaFieldFixture({ isInvalid: expected }))
 
       const textarea = container.querySelector('textarea')
@@ -112,7 +112,7 @@ describe('TextareaField', () => {
     })
 
     it('Should render with `data-gramm_editor` when grammarly provided', () => {
-      const expected = faker.random.boolean()
+      const expected = faker.datatype.boolean()
       const { container } = render(makeTextareaFieldFixture({ grammarly: expected }))
 
       const textarea = container.querySelector('textarea')
@@ -120,7 +120,7 @@ describe('TextareaField', () => {
     })
 
     it('Should pass through `inputWidth` prop to textarea', () => {
-      const expected = faker.random.number({ min: 10, max: 100 })
+      const expected = faker.datatype.number({ min: 10, max: 100 })
       const { container } = render(makeTextareaFieldFixture({ inputWidth: expected }))
 
       const textarea = container.querySelector('textarea')
@@ -128,7 +128,7 @@ describe('TextareaField', () => {
     })
 
     it('Should pass through `inputHeight` prop to textarea', () => {
-      const expected = faker.random.number({ min: 10, max: 100 })
+      const expected = faker.datatype.number({ min: 10, max: 100 })
       const { container } = render(makeTextareaFieldFixture({ inputHeight: expected }))
 
       const textarea = container.querySelector('textarea')

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,10 +6564,10 @@ fake-tag@^2.0.0:
   resolved "https://registry.yarnpkg.com/fake-tag/-/fake-tag-2.0.0.tgz#08ea5df950ef8635833186247f569e8406ffb4da"
   integrity sha512-QDz+8qiNQ9AfBZ31EXlID5JIbUkU3e1nXDWk4tidFzd2gy8XJaEUW1HCuDY6DUy6t2Y0nvhD6PsUc+2WYy5w0w==
 
-faker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
-  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
**Overview**
upgrade faker to ^5.5.3 and replace alternatives for deprecated methods

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [src/badges/stories/index.stories.js , src/table/stories/index.stories.js] Modified Storybook stories by replacing deprecated method to alternate one
