### PR TITLE
Fix color props heading component not working properly #1242

### DIFF
--- a/docs/documentation/components/menu.mdx
+++ b/docs/documentation/components/menu.mdx
@@ -181,7 +181,7 @@ function MenuOptionsGroupExample() {
           { label: 'Descending', value: 'desc' },
         ]}
         selected={selectedOrder}
-        onChange={(selected) => setSelectedOrder(selected)}
+        onChange={selected => setSelectedOrder(selected)}
       />
       <Menu.Divider />
       <Menu.OptionsGroup
@@ -194,7 +194,7 @@ function MenuOptionsGroupExample() {
           { label: 'Type', value: 'type' },
         ]}
         selected={selectedField}
-        onChange={(selected) => setSelectedField(selected)}
+        onChange={selected => setSelectedField(selected)}
       />
     </Menu>
   )
@@ -236,4 +236,10 @@ The focus styles are currently not working in the docs, sorry for the inconvenie
 >
   <Button>Custom Menu Items</Button>
 </Popover>
+```
+
+## Menu without items
+
+```jsx
+<Menu></Menu>
 ```

--- a/src/menu/src/Menu.js
+++ b/src/menu/src/Menu.js
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useRef } from 'react'
+import React, { memo, useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { Pane } from '../../layers'
 import MenuDivider from './MenuDivider'
@@ -14,6 +14,8 @@ const Menu = memo(function Menu(props) {
 
   const menuItems = useRef()
 
+  const [isEmpty, setIsEmpty] = useState(false)
+
   useEffect(() => {
     const currentMenuRef = menuRef.current
 
@@ -26,7 +28,8 @@ const Menu = memo(function Menu(props) {
       : []
 
     if (menuItems.current.length === 0) {
-      throw new Error('The menu has no menu items')
+      setIsEmpty(true)
+      // throw new Error('The menu has no menu items')
     }
 
     firstItem.current = menuItems.current[0]
@@ -101,9 +104,19 @@ const Menu = memo(function Menu(props) {
   }, [menuRef])
 
   const { children } = props
+
+  const renderChildren = children => {
+    return isEmpty ? (
+      <MenuGroup>
+        <MenuItem disabled>No menu items...</MenuItem>
+      </MenuGroup>
+    ) : (
+      children
+    )
+  }
   return (
     <Pane is="nav" ref={menuRef} role="menu" outline="none">
-      {children}
+      {renderChildren(children)}
     </Pane>
   )
 })

--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -152,7 +152,7 @@ MenuItem.propTypes = {
   /**
    * Secondary text shown on the right.
    */
-  secondaryText: PropTypes.node,
+  secondaryText: PropTypes.any,
 
   /**
    * The default theme only supports one default appearance.

--- a/src/menu/stories/index.stories.js
+++ b/src/menu/stories/index.stories.js
@@ -195,6 +195,9 @@ storiesOf('menu', module)
       >
         <Button>Hover menus</Button>
       </Popover>
+      <Popover position={Position.BOTTOM_LEFT} content={<Menu></Menu>}>
+        <Button marginTop={16}>Without Menu Items</Button>
+      </Popover>
 
       <UnorderedList marginTop={24}>
         <ListItem>Arrow down on a button will bring focus inside the popover.</ListItem>

--- a/src/theme/src/theme-tools.js
+++ b/src/theme/src/theme-tools.js
@@ -1,6 +1,5 @@
 export function get(obj, path, fallback) {
   const keys = path && path.split ? path.split('.') : [path]
-
   let value = obj
   for (const key of keys) {
     value = value ? value[key] : undefined

--- a/src/typography/src/Heading.js
+++ b/src/typography/src/Heading.js
@@ -9,10 +9,10 @@ const internalStyles = {}
 
 const Heading = memo(
   forwardRef(function Heading(props, ref) {
-    const { className, size = 500, ...restProps } = props
+    const { className, color, size = 500, ...restProps } = props
     const { className: themedClassName, ...styleProps } = useStyleConfig(
       'Heading',
-      { size },
+      { size, color },
       pseudoSelectors,
       internalStyles
     )

--- a/src/typography/src/Paragraph.js
+++ b/src/typography/src/Paragraph.js
@@ -17,7 +17,7 @@ const Paragraph = memo(
     const themedFontFamily = fontFamilies[fontFamily] || fontFamily
     const themedColor = colors[color] || (colors.text && colors.text[color]) || color
 
-    const textStyle = useStyleConfig('Paragraph', { size }, emptyObject, emptyObject)
+    const textStyle = useStyleConfig('Paragraph', { size, color }, emptyObject, emptyObject)
 
     return <Box is="p" ref={ref} {...textStyle} fontFamily={themedFontFamily} color={themedColor} {...restProps} />
   })

--- a/src/typography/src/Text.js
+++ b/src/typography/src/Text.js
@@ -18,7 +18,7 @@ const Text = memo(
     const themedFontFamily = fontFamilies[fontFamily] || fontFamily
     const themedColor = colors[color] || (colors.text && colors.text[color]) || color
 
-    const textStyle = useStyleConfig('Text', { size }, emptyObject, emptyObject)
+    const textStyle = useStyleConfig('Text', { size, color }, emptyObject, emptyObject)
 
     return (
       <Box

--- a/src/typography/stories/index.stories.js
+++ b/src/typography/stories/index.stories.js
@@ -52,7 +52,7 @@ storiesOf('typography', module)
     </Box>
   ))
   .add('Paragraph', () => <div>{previewTextComponent(Paragraph, TextSizes, { marginTop: 24 })}</div>)
-  .add('Heading', () => <div>{previewTextComponent(Heading, HeadingSizes, { marginTop: 24 })}</div>)
+  .add('Heading', () => <div>{previewTextComponent(Heading, HeadingSizes, { marginTop: 24, color: 'red500' })}</div>)
   .add('Code', () => <div>{previewTextComponent(Code)}</div>)
   .add('Pre', () => <div>{previewTextComponent(Pre)}</div>)
   .add('Label', () => <div>{previewTextComponent(Label)}</div>)


### PR DESCRIPTION
**Overview**
- Inside `combineStyles(...args)` first it will check if there is any prop passed as `color` with a `color value`.
- If it's `true` it will change the `config.baseStyle` object `color` property with the new color value.
- I have added `red500` as a `color` in `Heading Stories`.

**Screenshots**
![header-component](https://user-images.githubusercontent.com/54455309/149655389-78f410cc-6574-46c6-be27-a722acca609a.png)

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
