### PR TITLE
fix: MenuItems can accept String value now

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1491,7 +1491,7 @@ export interface MenuProps {
 export interface MenuItemOwnProps extends PaneOwnProps {
   onSelect?: (event: React.SyntheticEvent) => void
   icon?: React.ElementType | JSX.Element | null | false
-  secondaryText?: JSX.Element
+  secondaryText?: JSX.Element | string
   appearance?: DefaultAppearance
   intent?: IntentTypes
   disabled?: boolean


### PR DESCRIPTION
**Overview**
This PR is for this issue #1390. The MenuItem component does not accept String type values, while all the examples in the docs say that it does! Made a change to its prop types that should solve this issue.

## Issue: 
[This](https://codesandbox.io/s/menuitem-secondarytext-proptype-doesnt-accept-string-gnqul?file=/src/App.tsx) demonstrates the issue. It throws an error if 'String' value is passed as 'secondaryText' to 'ModalItem'.
Note: This example is importing and using evergreen component.

## Solution: 

Open this [sandbox](https://codesandbox.io/s/menuitem-secondarytext-proptype-doesnt-accept-string-forked-rgyfq?file=/src/App.tsx)
### Step1: 
Open the App.tsx file and see passing string value to 'secondaryText' throws an error. 
### Step2: 
Now go to MenuItem.tsx. The custom component is defined here. I tried to reproduce the actual component but at a very basic level. But, the role of types can be understood.
### Step3: 
Comment lIne 4 and un-comment Line 5.

The error is gone! Because the type String is added to the type declaration for secondaryText.

This is what my PR solves.

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
