### PR TITLE
[Fix] Popover imperative open/close can break due to dependency array.

### DIFF
--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -41,15 +41,6 @@ const Popover = memo(
     const targetRef = useRef()
     const setTargetRef = useMergedRef(targetRef)
 
-    useImperativeHandle(
-      forwardedRef,
-      () => ({
-        open,
-        close
-      }),
-      [popoverNode.current]
-    )
-
     /**
      * Methods borrowed from BlueprintJS
      * https://github.com/palantir/blueprint/blob/release/2.0.0/packages/core/src/components/overlay/overlay.tsx
@@ -137,6 +128,15 @@ const Popover = memo(
       bringFocusBackToTarget()
       onClose()
     }, [setIsShown, bringFocusBackToTarget, onClose, isShown])
+
+    useImperativeHandle(
+      forwardedRef,
+      () => ({
+        open,
+        close
+      }),
+      [open, close]
+    )
 
     // If `props.isShown` is a boolean, treat as a controlled component
     // `open` and `close` should be applied when it changes


### PR DESCRIPTION
I encountered this reproducible bug while using a `SelectMenu`. The imperative `open()` and `close()` can become "broken" until a React re-render is triggered by something else.

Fix:
Using `ref.current` doesn't make sense in dependency arrays. The dependencies here are `open()` and `close()` which are behind `useCallback()` so perf shouldn't take an unnecessary hit.