### PR TITLE
Add isInvalid field to tagInput

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2499,6 +2499,7 @@ export interface TagInputOwnProps {
   addOnBlur?: boolean
   className?: string
   disabled?: boolean
+  isInvalid?: boolean
   height?: number
   inputProps?: PolymorphicBoxProps<'input', TextOwnProps>
   inputRef?: React.Ref<HTMLInputElement>

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -10,7 +10,6 @@ import { useId, useStyleConfig } from '../../hooks'
 import safeInvoke from '../../lib/safe-invoke'
 import { majorScale } from '../../scales'
 import { TextInput } from '../../text-input'
-import { useTheme } from '../../theme'
 import Tag from './Tag'
 
 const GET_KEY_FOR_TAG_DELIMITER = {
@@ -29,7 +28,8 @@ const internalStyles = {
 
 const pseudoSelectors = {
   _focused: '&[aria-activedescendant]',
-  _disabled: '&[aria-disabled="true"]'
+  _disabled: '&[aria-disabled="true"]',
+  _invalid: '&[aria-invalid="true"]:not(:focus)'
 }
 
 const TagInput = memo(
@@ -57,7 +57,6 @@ const TagInput = memo(
     const [inputValue, setInputValue] = useState('')
     const [isFocused, setIsFocused] = useState(false)
     const id = useId('TagInput')
-    const theme = useTheme()
 
     const getValues = (inputValue = '') =>
       separator
@@ -168,10 +167,10 @@ const TagInput = memo(
       <Box
         aria-disabled={disabled || undefined}
         aria-activedescendant={isFocused ? id : undefined}
+        aria-invalid={isInvalid}
         className={cx(themedContainerClassName, className)}
         ref={ref}
         onBlur={handleBlur}
-        borderColor={isInvalid ? theme.colors.red600 : undefined}
         {...boxProps}
         {...rest}
       >

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -10,6 +10,7 @@ import { useId, useStyleConfig } from '../../hooks'
 import safeInvoke from '../../lib/safe-invoke'
 import { majorScale } from '../../scales'
 import { TextInput } from '../../text-input'
+import { useTheme } from '../../theme'
 import Tag from './Tag'
 
 const GET_KEY_FOR_TAG_DELIMITER = {
@@ -22,8 +23,7 @@ const emptyArray = []
 
 const internalStyles = {
   alignItems: 'center',
-  display: 'inline-flex',
-  flexWrap: 'wrap'
+  display: 'inline-flex'
 }
 
 const pseudoSelectors = {
@@ -50,11 +50,13 @@ const TagInput = memo(
       className,
       inputProps = emptyProps,
       inputRef,
+      isInvalid,
       ...rest
     } = props
     const [inputValue, setInputValue] = useState('')
     const [isFocused, setIsFocused] = useState(false)
     const id = useId('TagInput')
+    const theme = useTheme()
 
     const getValues = (inputValue = '') =>
       separator
@@ -168,6 +170,7 @@ const TagInput = memo(
         className={cx(themedContainerClassName, className)}
         ref={ref}
         onBlur={handleBlur}
+        borderColor={isInvalid ? theme.colors.red600 : undefined}
         {...boxProps}
         {...rest}
       >
@@ -199,6 +202,8 @@ TagInput.propTypes = {
   className: PropTypes.string,
   /** Whether or not the input should be disabled. */
   disabled: PropTypes.bool,
+  /** Whether or not the input is invalid. */
+  isInvalid: PropTypes.bool,
   /** The vertical size of the input */
   height: PropTypes.number,
   /** Props to pass to the input component. Note that `ref` and `key` are not supported. See `inputRef`. */

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -23,7 +23,8 @@ const emptyArray = []
 
 const internalStyles = {
   alignItems: 'center',
-  display: 'inline-flex'
+  display: 'inline-flex',
+  flexWrap: 'wrap'
 }
 
 const pseudoSelectors = {

--- a/src/tag-input/stories/TagInput.stories.js
+++ b/src/tag-input/stories/TagInput.stories.js
@@ -124,6 +124,22 @@ storiesOf('tag-input', module).add('TagInput', () => (
     </StorySection>
     <StorySection>
       <StoryHeader>
+        <StoryHeading>Invalid</StoryHeading>
+      </StoryHeader>
+      <StateManager>
+        {({ addValues, removeValue, values }) => (
+          <TagInput
+            inputProps={{ placeholder: 'Enter something...', validationMessage: 'This field should not be empty' }}
+            values={values}
+            onAdd={addValues}
+            onRemove={removeValue}
+            isInvalid={true}
+          />
+        )}
+      </StateManager>
+    </StorySection>
+    <StorySection>
+      <StoryHeader>
         <StoryHeading>With `tagProps`</StoryHeading>
       </StoryHeader>
       <StateManager values={['valid', 'invalid']}>

--- a/src/themes/default/components/tag-input.js
+++ b/src/themes/default/components/tag-input.js
@@ -17,6 +17,9 @@ const appearances = {
     _disabled: {
       cursor: 'not-allowed',
       backgroundColor: 'colors.gray100'
+    },
+    _invalid: {
+      borderColor: 'colors.red600'
     }
   }
 }


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
We're introducing an `isInvalid` field to the tag input component.

**Screenshots (if applicable)**
<img width="492" alt="Screen Shot 2022-01-31 at 4 00 59 PM" src="https://user-images.githubusercontent.com/34897995/151892881-02868f9c-d5d8-4a54-88b8-0629c812170b.png">


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
