### PR TITLE
update evergreen-ui and add docs for TagInput autocompleteItems prop

### DIFF
--- a/docs/documentation/components/tag-input.mdx
+++ b/docs/documentation/components/tag-input.mdx
@@ -19,7 +19,7 @@ function BasicTagInputExample() {
     <TagInput
       inputProps={{ placeholder: 'Add trees...' }}
       values={values}
-      onChange={values => {
+      onChange={(values) => {
         setValues(values)
       }}
     />
@@ -40,7 +40,7 @@ function SubmitKeyTagInputExample() {
       inputProps={{ placeholder: 'Add trees...' }}
       values={values}
       tagSubmitKey="space"
-      onChange={values => {
+      onChange={(values) => {
         setValues(values)
       }}
     />
@@ -60,7 +60,7 @@ function FullWidthTagInputExample() {
       inputProps={{ placeholder: 'Add trees...' }}
       values={values}
       width="100%"
-      onChange={values => {
+      onChange={(values) => {
         setValues(values)
       }}
     />
@@ -80,7 +80,7 @@ function DisabledTagInputExample() {
       inputProps={{ placeholder: 'Add trees...' }}
       values={values}
       disabled
-      onChange={values => {
+      onChange={(values) => {
         setValues(values)
       }}
     />
@@ -102,9 +102,9 @@ function TagPropTagInputExample() {
       values={values}
       disabled
       tagProps={{
-        color: 'red'
+        color: 'red',
       }}
-      onChange={values => {
+      onChange={(values) => {
         setValues(values)
       }}
     />
@@ -122,15 +122,38 @@ function TagPropCallbackTagInputExample() {
   const [values, setValues] = React.useState(['Kauri', 'Willow'])
   return (
     <TagInput
-      tagProps={value => {
+      tagProps={(value) => {
         if (!value.includes('@')) return { color: 'red' }
         return {}
       }}
       inputProps={{ placeholder: 'Add email...' }}
       values={values}
-      onChange={values => {
+      onChange={(values) => {
         setValues(values)
       }}
+    />
+  )
+}
+```
+
+## Autocomplete
+
+Provide an `autocompleteItems` prop to enable autocomplete functionality. Note that this array of items needs to be
+manually controlled. `TagInput` will not remove items from this list after they are selected.
+
+```jsx
+function AutoCompleteTagInputExample() {
+  const [values, setValues] = React.useState(['First', 'Second'])
+
+  const allValues = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth']
+  const autocompleteItems = React.useMemo(() => allValues.filter((i) => !values.includes(i)), [allValues, values])
+
+  return (
+    <TagInput
+      inputProps={{ placeholder: 'Enter something...' }}
+      values={values}
+      onChange={setValues}
+      autocompleteItems={autocompleteItems}
     />
   )
 }
@@ -152,7 +175,7 @@ function OnAddOnRemoveTagInputExample() {
     <TagInput
       inputProps={{ placeholder: 'Add email...' }}
       values={values}
-      onAdd={value => {
+      onAdd={(value) => {
         if (!value.includes('@')) {
           toaster.danger('Oops, you tried entering a invalid email. Try again.')
           return

--- a/docs/documentation/components/tag-input.mdx
+++ b/docs/documentation/components/tag-input.mdx
@@ -175,12 +175,12 @@ function OnAddOnRemoveTagInputExample() {
     <TagInput
       inputProps={{ placeholder: 'Add email...' }}
       values={values}
-      onAdd={(value) => {
-        if (!value.includes('@')) {
+      onAdd={(newValues) => {
+        if (newValues.some((val) => !val.includes('@'))) {
           toaster.danger('Oops, you tried entering a invalid email. Try again.')
           return
         }
-        setValues([...values, value])
+        setValues([...values, ...newValues])
       }}
       onRemove={(_value, index) => {
         setValues(values.filter((_, i) => i !== index))

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "@segment/consent-manager": "^5.1.0",
     "@types/react-github-button": "^0.1.0",
     "@types/react-syntax-highlighter": "^13.5.0",
-    "evergreen-ui": "6.7.1",
+    "evergreen-ui": "6.8.2",
     "lz-string": "^1.4.4",
     "next": "latest",
     "next-mdx-remote": "^2.1.3",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2460,10 +2460,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-evergreen-ui@6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-6.7.1.tgz#fdedf7a5bcfd9700fa6f67a0f44c0bf1b3180683"
-  integrity sha512-LRdH7Ai61/y8XLixn0EZsO07ekTMh7Wiifjwmln2i1nngVu4zZAx9zpvw9qtv2+yTTpj17OfhdryaLUZvSQVFQ==
+evergreen-ui@6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-6.8.2.tgz#b90d49f097b93ac7fbdd69943108d9d44e0450d2"
+  integrity sha512-w6ktcNoGF957GInQkfguhc5Jr9ZXKITVANhuWu93wdkvJNgobqal54MWDNnusr5LlG/ibtOI5PARYvUo5jhJZA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@segment/react-tiny-virtual-list" "^2.2.1"


### PR DESCRIPTION
**Overview**
Update evergreen-ui package in docs and add autocomplete demo for `TagInput`.

**Screenshots (if applicable)**
<img width="768" alt="Screen Shot 2022-02-25 at 11 38 43 AM" src="https://user-images.githubusercontent.com/1144042/155761504-2a065c48-532d-473d-8dd8-2c114a4aee00.png">

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
