### PR TITLE
[bug] set default width on TagInput input element to 100% instead of auto

### DIFF
--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -233,7 +233,7 @@ const TagInput = memo(
                     appearance="none"
                     disabled={disabled}
                     height={height - 4}
-                    width="auto"
+                    width="100%"
                     type="text"
                     {...inputProps}
                     {...autocompleteRestProps}


### PR DESCRIPTION
**Overview**
The input element on `TagInput` wasn't filling its container and was cutting off longer placeholder text like so:
![image](https://user-images.githubusercontent.com/1144042/157106551-e6234030-8320-42d8-98a8-48236a94a1ba.png)

Changing the default width of the inner input element resolves this issue.

**Screenshots (if applicable)**

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
