### PR TITLE
Remove actual File class reference from FileUploader src file

### DIFF
--- a/src/file-uploader/src/FileUploader.js
+++ b/src/file-uploader/src/FileUploader.js
@@ -343,8 +343,9 @@ FileUploader.propTypes = {
   renderFile: PropTypes.func,
   /**
    * File values to render underneath the uploader
+   * @type {File}
    */
-  values: PropTypes.arrayOf(PropTypes.instanceOf(File))
+  values: PropTypes.array
 }
 
 export default FileUploader


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

Fixes #1423

**Overview**

Removes the `File` reference from `FileUploader.propTypes`. 

**Screenshots (if applicable)**
N/A, but I tested out the package in our app using `yalc` and it compiles fine!

The `FileUploader` compiled src looks like this now:
```js
  /**
   * File values to render underneath the uploader
   * @type {File}
   */
  values: _propTypes["default"].array
```

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
