### PR TITLE
Add window resize handler to update position in Positioner component

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
   "size-limit": [
     {
       "path": "commonjs/index.js",
-      "limit": "300 KB",
+      "limit": "303 KB",
       "running": false
     },
     {

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -144,6 +144,18 @@ const Positioner = memo(function Positioner(props) {
     onCloseComplete()
   }
 
+  const handleResize = useCallback(() => {
+    update()
+  }, [update])
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  })
+
   return (
     <Stack value={StackingOrder.POSITIONER}>
       {zIndex => {


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Some users are reporting an issue with our `Popover` component not being visible when they resize their browser windows. This can be reproduced on Storybook or the doc site. 

This PR adds a `window.resize` event listener in the `Positioner` component which forces it to recalculate its position when the window size changes. It seems to solve the issue (a `Popover` being hidden when the browser is resized to be smaller), but I'm not sure if there's a cleaner/more efficient way to handle this. (Do I need to use request/cancelAnimationFrame? Should we debounce it?)

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
