### PR TITLE
added scroll listener to lock popovers from moving when scrolling

### DIFF
--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -144,15 +144,13 @@ const Positioner = memo(function Positioner(props) {
     onCloseComplete()
   }
 
-  const handleResize = useCallback(() => {
-    update()
-  }, [update])
-
   useEffect(() => {
-    window.addEventListener('resize', handleResize)
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update)
 
     return () => {
-      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update)
     }
   })
 


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->
**Overview**
Updates the position of the components when scrolling so that they do not float with the page.
Fixes #1428

**Screenshots (if applicable)**
https://www.loom.com/share/8822694e00d64f8ca89cb72c67d51094

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
