### PR TITLE
[SSCX-517] update positioner to check for dynamic children

### DIFF
--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -119,7 +119,7 @@ const Positioner = memo(function Positioner(props) {
   )
 
   // Call `update` whenever the component has "entered" and dimensions change
-  // additionally, when have dynamic children
+  // additionally, when there are dynamic children
   useEffect(() => {
     if (transitionState.current === 'entered') {
       latestAnimationFrame.current = requestAnimationFrame(() => {

--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -119,6 +119,7 @@ const Positioner = memo(function Positioner(props) {
   )
 
   // Call `update` whenever the component has "entered" and dimensions change
+  // additionally, when have dynamic children
   useEffect(() => {
     if (transitionState.current === 'entered') {
       latestAnimationFrame.current = requestAnimationFrame(() => {
@@ -131,7 +132,7 @@ const Positioner = memo(function Positioner(props) {
         cancelAnimationFrame(latestAnimationFrame.current)
       }
     }
-  }, [previousDimensions.height, previousDimensions.width, update])
+  }, [previousDimensions.height, previousDimensions.width, update, children])
 
   const handleEnter = () => {
     transitionState.current = 'entered'


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Updated the positioner to check for dynamically added children to allow them to be tied to the parent coordinates. Previously, children could render outside the viewport.

JIRA: https://segment.atlassian.net/browse/SSCX-517

**Screenshots (if applicable)**

https://www.loom.com/share/aff18bb8127d4901aa327a315b172558

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
