### PR TITLE
Bump evergreen from v6.9.0 to v6.9.6 in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "@segment/consent-manager": "^5.1.0",
     "@types/react-github-button": "^0.1.0",
     "@types/react-syntax-highlighter": "^13.5.0",
-    "evergreen-ui": "6.9.0",
+    "evergreen-ui": "6.9.6",
     "lz-string": "^1.4.4",
     "next": "latest",
     "next-mdx-remote": "^2.1.3",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2366,10 +2366,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-evergreen-ui@6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-6.9.0.tgz#5ba819af170da4d6f9368f852760053d0f19b87a"
-  integrity sha512-XPlURTY4W1rqyHPEO2MYeMPvtUGKVcSyEzGdFlGalrGlnhzKAkhynZtwebdKl3k4incHRruciTL7ZGjA09mUaw==
+evergreen-ui@6.9.6:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-6.9.6.tgz#db8f1a90dbe97276f7ba2a9166980b9d855cec5f"
+  integrity sha512-MUBPh2v2KDsABKv0I2LsTcvAVbpyFHyU251fSaXwvakjFMLqspl8Yy53RvbbLKt30uQr2yukeJzhROoqPfoD/w==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@segment/react-tiny-virtual-list" "^2.2.1"


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves #1445

The scrolling issue described was already fixed, but the doc site wasn't updated to include the patched version

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
