### PR TITLE
Widen EmptyState description PropType to accept ReactNode

### DIFF
--- a/src/empty-states/__tests__/EmptyState.test.js
+++ b/src/empty-states/__tests__/EmptyState.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { LockIcon } from '../../icons'
 import { defaultTheme } from '../../themes'
+import { Text } from '../../typography/index'
 import SmallExample from '../fixtures/SmallExample'
 import SmallMinimalExample from '../fixtures/SmallMinimalExample'
 import EmptyState from '../src/EmptyState'
@@ -40,6 +41,18 @@ describe('Empty States', () => {
       />
     )
     expect(getByText('Some description')).toBeVisible()
+  })
+
+  it('should render react component when react component is passed as a description prop', () => {
+    const { getByText } = render(
+      <EmptyState
+        title="My Empty States"
+        icon={<LockIcon color={defaultTheme.tokens.colors.gray500} />}
+        iconBgColor={defaultTheme.tokens.colors.gray200}
+        description={<Text>Example Text</Text>}
+      />
+    )
+    expect(getByText('Example Text')).toBeVisible()
   })
 
   it('should render primary button when passed in', () => {

--- a/src/empty-states/src/EmptyState.js
+++ b/src/empty-states/src/EmptyState.js
@@ -176,7 +176,7 @@ EmptyState.propTypes = {
   /** The direction in which to align the empty state elements */
   orientation: PropTypes.oneOf(['vertical', 'horizontal']),
   /** The description of the empty state */
-  description: PropTypes.string,
+  description: PropTypes.node,
   /** The background used for the entire empty state container */
   background: PropTypes.oneOf(['light', 'dark']),
   /** The primary CTA of the empty state */


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
`description` prop validation is set to accept `React.node`. So Now the `EmptyState` component will not throw a console warning if we pass the `React.node`.

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
