### PR TITLE
Forward SelectField ref, update ts definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2243,12 +2243,12 @@ export interface SelectOwnProps {
   size?: 'small' | 'medium' | 'large'
 }
 
-export type SelectProps = PolymorphicBoxProps<'div', SelectOwnProps>
-export declare const Select: BoxComponent<SelectOwnProps, 'div'>
+export type SelectProps = PolymorphicBoxProps<'select', SelectOwnProps>
+export declare const Select: BoxComponent<SelectOwnProps, 'select'>
 
 export type SelectFieldOwnProps = FormFieldOwnProps & SelectOwnProps
-export type SelectFieldProps = PolymorphicBoxProps<'div', SelectFieldOwnProps>
-export declare const SelectField: BoxComponent<SelectFieldOwnProps, 'div'>
+export type SelectFieldProps = PolymorphicBoxProps<'select', SelectFieldOwnProps>
+export declare const SelectField: BoxComponent<SelectFieldOwnProps, 'select'>
 
 export interface SelectMenuContentProps {
   close?: OptionsListProps['close']

--- a/src/select/__tests__/SelectField.test.js
+++ b/src/select/__tests__/SelectField.test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { SelectField } from '../'
+import { mockRef } from '../../test/utils'
+
+const makeSelectFieldFixture = (props = {}) => <SelectField data-testid="select-field" label="SelectField" {...props} />
+
+describe('SelectField', () => {
+  it('should forward ref to underlying <select />', () => {
+    const ref = mockRef()
+
+    render(makeSelectFieldFixture({ ref }))
+
+    expect(ref.current).toBeInstanceOf(HTMLSelectElement)
+  })
+})

--- a/src/select/src/SelectField.js
+++ b/src/select/src/SelectField.js
@@ -1,65 +1,68 @@
-import React, { memo } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { splitBoxProps } from 'ui-box'
 import { FormField } from '../../form-field'
 import { useId } from '../../hooks'
 import Select from './Select'
 
-const SelectField = memo(function SelectField(props) {
-  const id = useId('SelectField', props.id)
+const SelectField = memo(
+  forwardRef(function SelectField(props, ref) {
+    const id = useId('SelectField', props.id)
 
-  const {
-    // We are using the id from the state
-    appearance,
+    const {
+      // We are using the id from the state
+      appearance,
 
-    // FormField props
-    description,
-    disabled,
-    hint,
-    id: unusedId,
+      // FormField props
+      description,
+      disabled,
+      hint,
+      id: unusedId,
 
-    // TextInput props
-    inputHeight = 32,
-    /** The input width should be as wide as the form field. */
-    inputWidth = '100%',
-    isInvalid,
-    label,
-    required,
-    validationMessage,
+      // TextInput props
+      inputHeight = 32,
+      /** The input width should be as wide as the form field. */
+      inputWidth = '100%',
+      isInvalid,
+      label,
+      required,
+      validationMessage,
 
-    // Rest props are spread on the FormField
-    ...rest
-  } = props
+      // Rest props are spread on the FormField
+      ...rest
+    } = props
 
-  /**
-   * Split the wrapper props from the input props.
-   */
-  const { matchedProps, remainingProps } = splitBoxProps(rest)
+    /**
+     * Split the wrapper props from the input props.
+     */
+    const { matchedProps, remainingProps } = splitBoxProps(rest)
 
-  return (
-    <FormField
-      marginBottom={24}
-      label={label}
-      isRequired={required}
-      hint={hint}
-      description={description}
-      validationMessage={validationMessage}
-      labelFor={id}
-      {...matchedProps}
-    >
-      <Select
-        id={id}
-        width={inputWidth}
-        height={inputHeight}
-        disabled={disabled}
-        required={required}
-        isInvalid={isInvalid}
-        appearance={appearance}
-        {...remainingProps}
-      />
-    </FormField>
-  )
-})
+    return (
+      <FormField
+        marginBottom={24}
+        label={label}
+        isRequired={required}
+        hint={hint}
+        description={description}
+        validationMessage={validationMessage}
+        labelFor={id}
+        {...matchedProps}
+      >
+        <Select
+          id={id}
+          width={inputWidth}
+          height={inputHeight}
+          disabled={disabled}
+          required={required}
+          isInvalid={isInvalid}
+          appearance={appearance}
+          ref={ref}
+          {...remainingProps}
+        />
+      </FormField>
+    )
+  })
+)
 
 SelectField.propTypes = {
   /**


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Resolves #1434

The `SelectField` component was not forwarding refs, and the typescript definitions for `SelectProps`/`Select`/etc were still marked as `BoxComponent<'div'>` types, which would probably cause ts errors when passing a ref despite it actually going to the correct underlying element.

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
