### PR TITLE
Typescript definition update for EmptyStateOwnProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1314,7 +1314,7 @@ export interface EmptyStateOwnProps {
   /** specify the orientation of how the content flows */
   orientation?: 'horizontal' | 'vertical'
   /** the description of the empty state */
-  description?: string
+  description?: React.ReactNode
   /** the background used for the entire empty state container */
   background?: 'light' | 'dark'
   /** the primary cta of the empty state */


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Typescript definition updated to accept `React.ReactNode`

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
