### PR TITLE
Update deploy-docs script to amend version commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,17 +40,18 @@
     "clean": "git clean -Xdf",
     "create-package": "./tools/create-package.js",
     "create-package:components": "./tools/create-package-components.js",
-    "deploy-docs": "cd docs && yarn add evergreen-ui@latest --exact && git add package.json yarn.lock && git commit -m \"Updated doc site evergreen version\" || yarn install && yarn deploy",
+    "deploy-docs": "cd docs && yarn install && yarn deploy",
     "dev": "start-storybook -p 6006",
     "generate-icons": "./tools/generate-icons.js",
     "lint": "eslint \"src/**/*.js\" --cache",
-    "postpublish": "branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD); if [[ $branch == \"master\" ]]; then yarn deploy-docs; else echo \"not on main branch, skipping docs deploy\"; fi;",
+    "postpublish": "branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD); if [[ $branch == \"master\" ]]; then yarn update-docs || yarn deploy-docs; else echo \"not on main branch, skipping docs deploy\"; fi;",
     "prepublishOnly": "rm -rf esm commonjs umd && yarn build",
     "release": "np",
     "size": "size-limit",
     "storybook": "start-storybook -p 6006",
     "test": "yarn lint && yarn tsd && yarn jest",
-    "test:watch": "yarn run test -- --watch"
+    "test:watch": "yarn run test -- --watch",
+    "update-docs": "cd docs && yarn add evergreen-ui@latest --exact && git add package.json yarn.lock && git show-branch --no-name HEAD | grep -E 'v[0-9]+.[0-9]+.[0-9]+' && git commit --amend --no-edit || git commit -m \"Updated doc site evergreen version\""
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION


<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**



Small tweak to the previous change to `yarn deploy-docs` that is run in the `postpublish` step. For one:
1. I separated out the two for clarity (bumping the evergreen version in docs/ from actually deploying the doc site)
1. If the previous commit matches a version number, i.e. `v6.9.10` from running `yarn release`, we'll amend the commit that bumps the doc site `package.json`/`yarn.lock` instead of adding a new one. If for some reason there was another commit in between, it'll just add a new commit.

This should hopefully keep our history a little cleaner while keeping the doc site up-to-date! (I started noticing these doc site version bump commits showing up in each set of release notes and it just adds noise)

Examples of how I tested:
```
git commit --allow-empty -m 'v1.1.1'
git commit --allow-empty -m 'something else'
git show-branch --no-name HEAD | grep -E 'v[0-9]+.[0-9]+.[0-9]+' && echo 'matches release commit' && echo 'should amend commit' || echo 'create new commit'
```

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
