### PR TITLE
Refactor/extract expose dialog utility components

### DIFF
--- a/src/dialog-body/index.js
+++ b/src/dialog-body/index.js
@@ -1,0 +1,1 @@
+export { default as DialogBody } from './src/DialogBody'

--- a/src/dialog-body/src/DialogBody.js
+++ b/src/dialog-body/src/DialogBody.js
@@ -1,19 +1,74 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
-import Box from 'ui-box'
+import { useStyleConfig } from '../../hooks'
+import { Pane } from '../../layers'
+import { Paragraph } from '../../typography'
 
-const DialogBody = memo(forwardRef((props, ref) => {
-  const { ...restProps } = props
+const closeHandler = close => close()
 
-  return (
-    <Box ref={ref} {...restProps}>
-      DialogBody
-    </Box>
-  )
-}))
+const renderChildren = (children, close) => {
+  if (typeof children === 'function') {
+    return children({ close })
+  }
+
+  if (typeof children === 'string') {
+    return <Paragraph>{children}</Paragraph>
+  }
+
+  return children
+}
+
+const DialogBody = memo(
+  forwardRef(function DialogBody(props, ref) {
+    const emptyProps = {}
+
+    const themedBodyProps = useStyleConfig('DialogBody', emptyProps, emptyProps, emptyProps)
+
+    const { contentContainerProps, minHeightContent = 80, onCancel = closeHandler, state, children } = props
+
+    return (
+      <Pane
+        ref={ref}
+        data-state={state}
+        display="flex"
+        overflow="auto"
+        flexDirection="column"
+        minHeight={minHeightContent}
+        {...themedBodyProps}
+        {...contentContainerProps}
+      >
+        <Pane>{renderChildren(children, onCancel)}</Pane>
+      </Pane>
+    )
+  })
+)
 
 DialogBody.propTypes = {
-
+  /**
+   * Children can be a string, node or a function accepting `({ close })`.
+   * When passing a string, <Paragraph /> is used to wrap the string.
+   */
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  /**
+   * Props that are passed to the content container.
+   */
+  contentContainerProps: PropTypes.object,
+  /**
+   * The min height of the body content.
+   * Makes it less weird when only showing little content.
+   */
+  minHeightContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Function that will be called when the cancel button is clicked.
+   * This closes the Dialog by default.
+   *
+   * `onCancel={(close) => close()}`
+   */
+  onCancel: PropTypes.func,
+  /**
+   * State of the dialog passed to dialog.
+   */
+  state: PropTypes.string
 }
 
 export default DialogBody

--- a/src/dialog-body/src/DialogBody.js
+++ b/src/dialog-body/src/DialogBody.js
@@ -1,0 +1,19 @@
+import React, { memo, forwardRef } from 'react'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+
+const DialogBody = memo(forwardRef((props, ref) => {
+  const { ...restProps } = props
+
+  return (
+    <Box ref={ref} {...restProps}>
+      DialogBody
+    </Box>
+  )
+}))
+
+DialogBody.propTypes = {
+
+}
+
+export default DialogBody

--- a/src/dialog-body/stories/index.stories.js
+++ b/src/dialog-body/stories/index.stories.js
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import Box from 'ui-box'
+import { DialogBody } from '../../dialog-body'
+
+storiesOf('dialog-body', module)
+  .add('DialogBody', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <DialogBody>DialogBody</DialogBody>
+    </Box>
+  ))

--- a/src/dialog-body/stories/index.stories.js
+++ b/src/dialog-body/stories/index.stories.js
@@ -1,15 +1,16 @@
-import { storiesOf } from '@storybook/react'
 import React from 'react'
+import { storiesOf } from '@storybook/react'
 import Box from 'ui-box'
 import { DialogBody } from '../../dialog-body'
 
-storiesOf('dialog-body', module)
-  .add('DialogBody', () => (
-    <Box padding={40}>
-      {(() => {
-        document.body.style.margin = '0'
-        document.body.style.height = '100vh'
-      })()}
-      <DialogBody>DialogBody</DialogBody>
-    </Box>
-  ))
+storiesOf('dialog-body', module).add('DialogBody', () => (
+  <Box padding={40}>
+    {(() => {
+      document.body.style.margin = '0'
+      document.body.style.height = '100vh'
+    })()}
+    <DialogBody state="dialog body" onCancel={close}>
+      Its a example of DialogBody
+    </DialogBody>
+  </Box>
+))

--- a/src/dialog-footer/index.js
+++ b/src/dialog-footer/index.js
@@ -1,0 +1,1 @@
+export { default as DialogFooter } from './src/DialogFooter'

--- a/src/dialog-footer/src/DialogFooter.js
+++ b/src/dialog-footer/src/DialogFooter.js
@@ -1,19 +1,135 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
-import Box from 'ui-box'
+import { Button } from '../../buttons'
+import { useStyleConfig } from '../../hooks'
+import { Pane } from '../../layers'
 
-const DialogFooter = memo(forwardRef((props, ref) => {
-  const { ...restProps } = props
+const closeHandler = close => close()
+const emptyProps = {}
 
-  return (
-    <Box ref={ref} {...restProps}>
-      DialogFooter
-    </Box>
-  )
-}))
+const renderNode = (node, close) => {
+  if (typeof node === 'function') {
+    return node({ close })
+  }
+
+  return node
+}
+
+const DialogFooter = memo(
+  forwardRef(function DialogFooter(props, ref) {
+    const {
+      footer,
+      isConfirmDisabled = false,
+      isConfirmLoading = false,
+      hasCancel = true,
+      hasFooter = true,
+      intent = 'none',
+      cancelLabel = 'Cancel',
+      confirmLabel = 'Confirm',
+      onCancel = closeHandler,
+      onConfirm = closeHandler
+    } = props
+    const themedFooterProps = useStyleConfig('DialogFooter', emptyProps, emptyProps, emptyProps)
+
+    if (!footer && !hasFooter) {
+      return null
+    }
+
+    return (
+      <Pane ref={ref} display="flex" justifyContent="flex-end" {...themedFooterProps}>
+        <Pane>
+          {footer ? (
+            renderNode(footer, close)
+          ) : (
+            <>
+              {/* Cancel should be first to make sure focus gets on it first. */}
+              {hasCancel && (
+                <Button tabIndex={0} onClick={() => onCancel(close)}>
+                  {cancelLabel}
+                </Button>
+              )}
+
+              <Button
+                tabIndex={0}
+                marginLeft={8}
+                appearance="primary"
+                intent={intent}
+                isLoading={isConfirmLoading}
+                disabled={isConfirmDisabled}
+                onClick={() => onConfirm(close)}
+              >
+                {confirmLabel}
+              </Button>
+            </>
+          )}
+        </Pane>
+      </Pane>
+    )
+  })
+)
 
 DialogFooter.propTypes = {
+  /**
+   * Function that will be called when the confirm button is clicked.
+   * This does not close the Dialog. A close function will be passed
+   * as a paramater you can use to close the dialog.
+   *
+   * `onConfirm={(close) => close()}`
+   */
+  onConfirm: PropTypes.func,
 
+  /**
+   * Label of the confirm button.
+   */
+  confirmLabel: PropTypes.string,
+
+  /**
+   * The intent of the Dialog. Used for the button.
+   */
+  intent: PropTypes.string,
+
+  /**
+   * When true, the footer with the cancel and confirm button is shown.
+   */
+  hasFooter: PropTypes.bool,
+
+  /**
+   * You can override the default footer with your own custom component.
+   *
+   * This is useful if you want to provide a custom header and footer, while
+   * also enabling your Dialog's content to scroll.
+   *
+   * Footer can either be a React node or a function accepting `({ close })`.
+   */
+  footer: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+
+  /**
+   * When true, the cancel button is shown.
+   */
+  hasCancel: PropTypes.bool,
+
+  /**
+   * When true, the confirm button is set to loading.
+   */
+  isConfirmLoading: PropTypes.bool,
+
+  /**
+   * When true, the confirm button is set to disabled.
+   */
+  isConfirmDisabled: PropTypes.bool,
+
+  /**
+   * Function that will be called when the cancel button is clicked.
+   * This closes the Dialog by default.
+   *
+   * `onCancel={(close) => close()}`
+   */
+  onCancel: PropTypes.func,
+
+  /**
+   * Label of the cancel button.
+   */
+  cancelLabel: PropTypes.string
 }
 
 export default DialogFooter

--- a/src/dialog-footer/src/DialogFooter.js
+++ b/src/dialog-footer/src/DialogFooter.js
@@ -1,0 +1,19 @@
+import React, { memo, forwardRef } from 'react'
+import PropTypes from 'prop-types'
+import Box from 'ui-box'
+
+const DialogFooter = memo(forwardRef((props, ref) => {
+  const { ...restProps } = props
+
+  return (
+    <Box ref={ref} {...restProps}>
+      DialogFooter
+    </Box>
+  )
+}))
+
+DialogFooter.propTypes = {
+
+}
+
+export default DialogFooter

--- a/src/dialog-footer/stories/index.stories.js
+++ b/src/dialog-footer/stories/index.stories.js
@@ -1,15 +1,52 @@
-import { storiesOf } from '@storybook/react'
 import React from 'react'
+import { storiesOf } from '@storybook/react'
 import Box from 'ui-box'
 import { DialogFooter } from '../../dialog-footer'
 
-storiesOf('dialog-footer', module)
-  .add('DialogFooter', () => (
-    <Box padding={40}>
-      {(() => {
-        document.body.style.margin = '0'
-        document.body.style.height = '100vh'
-      })()}
-      <DialogFooter>DialogFooter</DialogFooter>
-    </Box>
-  ))
+storiesOf('dialog-footer', module).add('DialogFooter', () => (
+  <Box padding={40}>
+    {(() => {
+      document.body.style.margin = '0'
+      document.body.style.height = '100vh'
+    })()}
+    <DialogFooter
+      isConfirmDisabled={true}
+      isConfirmLoading={true}
+      hasCancel={true}
+      intent="none"
+      cancelLabel="Cancel"
+      confirmLabel="Confirm"
+      onCancel={close}
+      onConfirm={close}
+    />
+    <DialogFooter
+      isConfirmDisabled={true}
+      isConfirmLoading={false}
+      hasCancel={true}
+      intent="none"
+      cancelLabel="Cancel"
+      confirmLabel="Confirm"
+      onCancel={close}
+      onConfirm={close}
+    />
+    <DialogFooter
+      isConfirmDisabled={false}
+      isConfirmLoading={false}
+      hasCancel={true}
+      intent="none"
+      cancelLabel="Cancel"
+      confirmLabel="Confirm"
+      onCancel={close}
+      onConfirm={close}
+    />
+    <DialogFooter
+      isConfirmDisabled={false}
+      isConfirmLoading={false}
+      hasCancel={false}
+      intent="none"
+      cancelLabel="Cancel"
+      confirmLabel="Confirm"
+      onConfirm={close}
+    />
+  </Box>
+))

--- a/src/dialog-footer/stories/index.stories.js
+++ b/src/dialog-footer/stories/index.stories.js
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import Box from 'ui-box'
+import { DialogFooter } from '../../dialog-footer'
+
+storiesOf('dialog-footer', module)
+  .add('DialogFooter', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <DialogFooter>DialogFooter</DialogFooter>
+    </Box>
+  ))

--- a/src/dialog-header/index.js
+++ b/src/dialog-header/index.js
@@ -1,0 +1,1 @@
+export { default as DialogHeader } from './src/DialogHeader'

--- a/src/dialog-header/src/DialogHeader.js
+++ b/src/dialog-header/src/DialogHeader.js
@@ -1,0 +1,70 @@
+import React, { memo, forwardRef } from 'react'
+import PropTypes from 'prop-types'
+import { Pane } from '../../layers'
+import { Heading } from '../../typography'
+import { IconButton } from '../../buttons'
+import { CrossIcon } from '../../icons'
+import { useStyleConfig } from '../../hooks'
+
+const renderNode = (node, close) => {
+  if (typeof node === 'function') {
+    return node({ close })
+  }
+
+  return node
+}
+
+const emptyProps = {}
+
+const DialogHeader = memo(
+  forwardRef(function DialogHeader({ title, hasClose, header }) {
+    const themedHeaderProps = useStyleConfig('DialogHeader', emptyProps, emptyProps, emptyProps)
+
+    if (!header && !hasHeader) {
+      return null
+    }
+
+    return (
+      <Pane flexShrink={0} display="flex" alignItems="center" {...themedHeaderProps}>
+        {header ? (
+          renderNode(header, close)
+        ) : (
+          <>
+            <Heading is="h4" size={600} flex="1">
+              {title}
+            </Heading>
+            {hasClose && <IconButton appearance="minimal" icon={CrossIcon} onClick={() => onCancel(close)} />}
+          </>
+        )}
+      </Pane>
+    )
+  })
+)
+
+DialogHeader.propTypes = {
+  /**
+   * Children can be a string, node or a function accepting `({ close })`.
+   * When passing a string, <Paragraph /> is used to wrap the string.
+   */
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+
+  /**
+   * Title of the Dialog. Titles should use Title Case.
+   */
+  title: PropTypes.node,
+
+  /**
+   * When true, the close button is shown
+   */
+  hasClose: PropTypes.bool,
+
+  /**
+   * Function that will be called when the cancel button is clicked.
+   * This closes the Dialog by default.
+   *
+   * `onCancel={(close) => close()}`
+   */
+  onCancel: PropTypes.func
+}
+
+export default DialogHeader

--- a/src/dialog-header/src/DialogHeader.js
+++ b/src/dialog-header/src/DialogHeader.js
@@ -1,10 +1,10 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
+import { IconButton } from '../../buttons'
+import { useStyleConfig } from '../../hooks'
+import { CrossIcon } from '../../icons'
 import { Pane } from '../../layers'
 import { Heading } from '../../typography'
-import { IconButton } from '../../buttons'
-import { CrossIcon } from '../../icons'
-import { useStyleConfig } from '../../hooks'
 
 const renderNode = (node, close) => {
   if (typeof node === 'function') {
@@ -17,7 +17,9 @@ const renderNode = (node, close) => {
 const emptyProps = {}
 
 const DialogHeader = memo(
-  forwardRef(function DialogHeader({ title, hasClose, header }) {
+  forwardRef(function DialogHeader(props, ref) {
+    const { hasClose, hasHeader, header, onCancel, title } = props
+
     const themedHeaderProps = useStyleConfig('DialogHeader', emptyProps, emptyProps, emptyProps)
 
     if (!header && !hasHeader) {
@@ -25,7 +27,7 @@ const DialogHeader = memo(
     }
 
     return (
-      <Pane flexShrink={0} display="flex" alignItems="center" {...themedHeaderProps}>
+      <Pane ref={ref} flexShrink={0} display="flex" alignItems="center" {...themedHeaderProps}>
         {header ? (
           renderNode(header, close)
         ) : (
@@ -43,10 +45,19 @@ const DialogHeader = memo(
 
 DialogHeader.propTypes = {
   /**
-   * Children can be a string, node or a function accepting `({ close })`.
-   * When passing a string, <Paragraph /> is used to wrap the string.
+   * When true, the header with the title and close icon button is shown.
    */
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  hasHeader: PropTypes.bool,
+
+  /**
+   * You can override the default header with your own custom component.
+   *
+   * This is useful if you want to provide a custom header and footer, while
+   * also enabling your Dialog's content to scroll.
+   *
+   * Header can either be a React node or a function accepting `({ close })`.
+   */
+  header: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 
   /**
    * Title of the Dialog. Titles should use Title Case.

--- a/src/dialog-header/stories/index.stories.js
+++ b/src/dialog-header/stories/index.stories.js
@@ -1,15 +1,15 @@
-import { storiesOf } from '@storybook/react'
 import React from 'react'
+import { storiesOf } from '@storybook/react'
 import Box from 'ui-box'
 import { DialogHeader } from '../../dialog-header'
 
-storiesOf('dialog-header', module)
-  .add('DialogHeader', () => (
-    <Box padding={40}>
-      {(() => {
-        document.body.style.margin = '0'
-        document.body.style.height = '100vh'
-      })()}
-      <DialogHeader>DialogHeader</DialogHeader>
-    </Box>
-  ))
+storiesOf('dialog-header', module).add('DialogHeader', () => (
+  <Box padding={40}>
+    {(() => {
+      document.body.style.margin = '0'
+      document.body.style.height = '100vh'
+    })()}
+    <DialogHeader hasHeader={true} header="Dialog Header" />
+    <DialogHeader hasHeader={true} title="Custom title Example" hasClose={true} />
+  </Box>
+))

--- a/src/dialog-header/stories/index.stories.js
+++ b/src/dialog-header/stories/index.stories.js
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import Box from 'ui-box'
+import { DialogHeader } from '../../dialog-header'
+
+storiesOf('dialog-header', module)
+  .add('DialogHeader', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <DialogHeader>DialogHeader</DialogHeader>
+    </Box>
+  ))

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -2,12 +2,11 @@ import React, { memo } from 'react'
 import cx from 'classnames'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
-import { Button, IconButton } from '../../buttons'
-import { useStyleConfig } from '../../hooks'
-import { CrossIcon } from '../../icons'
+import { DialogBody } from '../../dialog-body/index'
+import { DialogFooter } from '../../dialog-footer/index'
+import { DialogHeader } from '../../dialog-header/index'
 import { Pane } from '../../layers'
 import { Overlay } from '../../overlay'
-import { Paragraph, Heading } from '../../typography'
 
 const animationEasing = {
   deceleration: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
@@ -47,7 +46,6 @@ const animationStyles = {
   }
 }
 
-const closeHandler = close => close()
 const emptyProps = {}
 
 const Dialog = memo(function Dialog({
@@ -56,6 +54,7 @@ const Dialog = memo(function Dialog({
   confirmLabel = 'Confirm',
   containerProps = emptyProps,
   contentContainerProps,
+  minHeightContent = 80,
   footer,
   hasCancel = true,
   hasClose = true,
@@ -66,10 +65,7 @@ const Dialog = memo(function Dialog({
   isConfirmDisabled = false,
   isConfirmLoading = false,
   isShown = false,
-  minHeightContent = 80,
-  onCancel = closeHandler,
   onCloseComplete,
-  onConfirm = closeHandler,
   onOpenComplete,
   overlayProps = emptyProps,
   preventBodyScrolling = false,
@@ -85,88 +81,6 @@ const Dialog = memo(function Dialog({
 
   const topOffsetWithUnit = Number.isInteger(topOffset) ? `${topOffset}px` : topOffset
   const maxHeight = `calc(100% - ${topOffsetWithUnit} * 2)`
-
-  const renderChildren = close => {
-    if (typeof children === 'function') {
-      return children({ close })
-    }
-
-    if (typeof children === 'string') {
-      return <Paragraph>{children}</Paragraph>
-    }
-
-    return children
-  }
-
-  const renderNode = (node, close) => {
-    if (typeof node === 'function') {
-      return node({ close })
-    }
-
-    return node
-  }
-
-  const themedHeaderProps = useStyleConfig('DialogHeader', emptyProps, emptyProps, emptyProps)
-  const themedBodyProps = useStyleConfig('DialogBody', emptyProps, emptyProps, emptyProps)
-  const themedFooterProps = useStyleConfig('DialogFooter', emptyProps, emptyProps, emptyProps)
-
-  const renderHeader = close => {
-    if (!header && !hasHeader) {
-      return undefined
-    }
-
-    return (
-      <Pane flexShrink={0} display="flex" alignItems="center" {...themedHeaderProps}>
-        {header ? (
-          renderNode(header, close)
-        ) : (
-          <>
-            <Heading is="h4" size={600} flex="1">
-              {title}
-            </Heading>
-            {hasClose && <IconButton appearance="minimal" icon={CrossIcon} onClick={() => onCancel(close)} />}
-          </>
-        )}
-      </Pane>
-    )
-  }
-
-  const renderFooter = close => {
-    if (!footer && !hasFooter) {
-      return undefined
-    }
-
-    return (
-      <Pane display="flex" justifyContent="flex-end" {...themedFooterProps}>
-        <Pane>
-          {footer ? (
-            renderNode(footer, close)
-          ) : (
-            <>
-              {/* Cancel should be first to make sure focus gets on it first. */}
-              {hasCancel && (
-                <Button tabIndex={0} onClick={() => onCancel(close)}>
-                  {cancelLabel}
-                </Button>
-              )}
-
-              <Button
-                tabIndex={0}
-                marginLeft={8}
-                appearance="primary"
-                intent={intent}
-                isLoading={isConfirmLoading}
-                disabled={isConfirmDisabled}
-                onClick={() => onConfirm(close)}
-              >
-                {confirmLabel}
-              </Button>
-            </>
-          )}
-        </Pane>
-      </Pane>
-    )
-  }
 
   const { className: containerClassName, ...remainingContainerProps } = containerProps
 
@@ -202,26 +116,37 @@ const Dialog = memo(function Dialog({
           data-state={state}
           {...remainingContainerProps}
         >
-          {renderHeader(close)}
+          <DialogHeader hasHeader={hasHeader} header={header} title={title} hasClose={hasClose} onCancel={close} />
 
-          <Pane
-            data-state={state}
-            display="flex"
-            overflow="auto"
-            flexDirection="column"
+          <DialogBody
+            state={state}
             minHeight={minHeightContent}
-            {...themedBodyProps}
-            {...contentContainerProps}
+            onCancel={close}
+            contentContainerProps={contentContainerProps}
           >
-            <Pane>{renderChildren(close)}</Pane>
-          </Pane>
-
-          {renderFooter(close)}
+            {children}
+          </DialogBody>
+          <DialogFooter
+            footer={footer}
+            isConfirmDisabled={isConfirmDisabled}
+            isConfirmLoading={isConfirmLoading}
+            hasCancel={hasCancel}
+            hasFooter={hasFooter}
+            intent={intent}
+            cancelLabel={cancelLabel}
+            confirmLabel={confirmLabel}
+            onCancel={close}
+            onConfirm={close}
+          />
         </Pane>
       )}
     </Overlay>
   )
 })
+
+Dialog.DialogHeader = DialogHeader
+Dialog.DialogBody = DialogBody
+Dialog.DialogFooter = DialogFooter
 
 Dialog.propTypes = {
   /**
@@ -318,14 +243,6 @@ Dialog.propTypes = {
    * When true, the confirm button is set to disabled.
    */
   isConfirmDisabled: PropTypes.bool,
-
-  /**
-   * Function that will be called when the cancel button is clicked.
-   * This closes the Dialog by default.
-   *
-   * `onCancel={(close) => close()}`
-   */
-  onCancel: PropTypes.func,
 
   /**
    * Label of the cancel button.


### PR DESCRIPTION
**Overview**

Extracted the `renderHeader , renderChildren, renderFooter ` JSX functions and exposed them as standalone components.

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
