### PR TITLE
fix esc on tagInput component

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -138,6 +138,15 @@ const Autocomplete = memo(
           }
         }
 
+        if (Downshift.stateChangeTypes.keyDownEscape) {
+          return {
+            ...changes,
+            ...state,
+            isOpen: false,
+            inputValue: state.selectedItem.label
+          }
+        }
+
         return changes
       },
       [props.items, props.allowOtherValues]

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -138,7 +138,7 @@ const Autocomplete = memo(
           }
         }
 
-        if (Downshift.stateChangeTypes.keyDownEscape) {
+        if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {
           return {
             ...changes,
             ...state,

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -138,15 +138,6 @@ const Autocomplete = memo(
           }
         }
 
-        if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {
-          return {
-            ...changes,
-            ...state,
-            isOpen: false,
-            inputValue: state.selectedItem.label
-          }
-        }
-
         return changes
       },
       [props.items, props.allowOtherValues]

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -66,13 +66,16 @@ const TagInput = memo(
     const inputId = inputProps && inputProps.id ? inputProps.id : id
     const hasAutocomplete = Array.isArray(autocompleteItems) && autocompleteItems.length > 0
 
-    const getValues = (inputValue = '') =>
-      separator
+    const getValues = (inputValue = '') => {
+      inputValue = inputValue || ''
+
+      return separator
         ? inputValue
             .split(separator)
             .map(v => v.trim())
             .filter(v => v.length > 0)
         : [inputValue]
+    }
 
     const addTags = (value = '') => {
       const newValues = getValues(value)


### PR DESCRIPTION
**Overview**
Resolves #1472 

The proposed behavior for pressing `esc`:
- On the TagInput Autocomplete, pressing `esc` will close the dropdown
- On the any other TagInput components, pressing `esc` will do nothing (the same as `TextInput` and `TextArea` component)

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
