### PR TITLE
[SSCX-592] Center EG Autocomplete for TagInput on the input

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lodash.differencewith": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "lodash.merge": "^4.6.2",
+    "lodash.omit": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.2.0",

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -116,9 +116,10 @@ const Autocomplete = memo(
     const [targetRef, setTargetRef] = useState()
 
     useEffect(() => {
-      const boundingWidth = targetRef?.getBoundingClientRect().width
-      setTargetWidth(boundingWidth)
-    }, [targetRef, setTargetWidth, props.items.length])
+      if (targetRef) {
+        setTargetWidth(targetRef.getBoundingClientRect().width)
+      }
+    }, [targetRef])
 
     const stateReducer = useCallback(
       (state, changes) => {

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -119,7 +119,7 @@ const Autocomplete = memo(
       if (targetRef) {
         setTargetWidth(targetRef.getBoundingClientRect().width)
       }
-    }, [targetRef])
+    }, [targetRef, props.items.length])
 
     const stateReducer = useCallback(
       (state, changes) => {

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -116,10 +116,9 @@ const Autocomplete = memo(
     const [targetRef, setTargetRef] = useState()
 
     useEffect(() => {
-      if (targetRef) {
-        setTargetWidth(targetRef.getBoundingClientRect().width)
-      }
-    }, [targetRef, props.items.length])
+      const boundingWidth = targetRef?.getBoundingClientRect().width
+      setTargetWidth(boundingWidth)
+    }, [targetRef, setTargetWidth, props.items.length, props.id])
 
     const stateReducer = useCallback(
       (state, changes) => {

--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -116,10 +116,9 @@ const Autocomplete = memo(
     const [targetRef, setTargetRef] = useState()
 
     useEffect(() => {
-      if (targetRef) {
-        setTargetWidth(targetRef.getBoundingClientRect().width)
-      }
-    }, [targetRef])
+      const boundingWidth = targetRef?.getBoundingClientRect().width
+      setTargetWidth(boundingWidth)
+    }, [targetRef, setTargetWidth, props.items.length])
 
     const stateReducer = useCallback(
       (state, changes) => {

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -63,6 +63,7 @@ const TagInput = memo(
     const [inputValue, setInputValue] = useState('')
     const [isFocused, setIsFocused] = useState(false)
     const id = useId('TagInput')
+    const autocompleteId = `TagInputAutocomplete-${values.length}`
 
     const inputId = inputProps && inputProps.id ? inputProps.id : id
     const hasAutocomplete = Array.isArray(autocompleteItems) && autocompleteItems.length > 0
@@ -193,7 +194,7 @@ const TagInput = memo(
               setInputValue('')
             }}
             items={hasAutocomplete ? autocompleteItems : []}
-            id={inputId}
+            id={autocompleteId}
             selectedItem=""
             inputValue={inputValue}
           >

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -4,6 +4,7 @@
 
 import React, { memo, forwardRef, useState } from 'react'
 import cx from 'classnames'
+import omit from 'lodash.omit'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
 import { Autocomplete } from '../../autocomplete'
@@ -232,6 +233,8 @@ const TagInput = memo(
                   ref={boxInputRef => {
                     autocompleteGetRef(boxInputRef)
                   }}
+                  flexWrap="wrap"
+                  width={inputProps.width}
                 >
                   {values.map(maybeRenderTag)}
 
@@ -239,9 +242,9 @@ const TagInput = memo(
                     appearance="none"
                     disabled={disabled}
                     height={height - 4}
-                    width="100%"
+                    flexGrow="1"
                     type="text"
-                    {...inputProps}
+                    {...omit(inputProps, ['width'])}
                     {...autocompleteRestProps}
                     value={inputValue}
                     id={inputId}

--- a/src/tag-input/src/TagInput.js
+++ b/src/tag-input/src/TagInput.js
@@ -185,7 +185,6 @@ const TagInput = memo(
         {...rest}
         paddingRight={hasAutocomplete ? majorScale(3) : undefined}
       >
-        {values.map(maybeRenderTag)}
         <Box flexGrow="1" display="inline-block">
           <Autocomplete
             onChange={changedItem => {
@@ -228,7 +227,14 @@ const TagInput = memo(
               }
 
               return (
-                <>
+                <Box
+                  display="flex"
+                  ref={boxInputRef => {
+                    autocompleteGetRef(boxInputRef)
+                  }}
+                >
+                  {values.map(maybeRenderTag)}
+
                   <TextInput
                     appearance="none"
                     disabled={disabled}
@@ -240,7 +246,6 @@ const TagInput = memo(
                     value={inputValue}
                     id={inputId}
                     ref={textInputRef => {
-                      autocompleteGetRef(textInputRef)
                       if (inputRef instanceof Function) {
                         inputRef(textInputRef)
                       } else if (inputRef) {
@@ -283,7 +288,7 @@ const TagInput = memo(
                       <CaretDownIcon color="muted" />
                     </Button>
                   )}
-                </>
+                </Box>
               )
             }}
           </Autocomplete>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9538,6 +9538,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
+
 lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"


### PR DESCRIPTION
JIRA: https://segment.atlassian.net/browse/SSCX-592

**Overview**
Currently, this component's autocomplete items only appear on top of the input:

https://user-images.githubusercontent.com/34897995/171701929-10599c4c-01c0-43f6-bc21-c85e9103c0a8.mov

We are changing this so that the autocomplete items appear on top of the whole tag input.

**Screenshots (if applicable)**
No width passed in:
https://user-images.githubusercontent.com/34897995/171701640-8957fe2e-53fa-4f44-bbed-947a69ed0cf3.mov

Width passed in:
https://user-images.githubusercontent.com/34897995/171701659-01f5af8b-ff1c-418b-9104-c49d60c3ca41.mov

**Documentation**
- [ (no need) ] Updated Typescript types and/or component PropTypes
- [ (no need) ] Added / modified component docs
- [ (no need) ] Added / modified Storybook stories
