### PR TITLE
Add a flag that allows you to disable scrolling to the selected option

### DIFF
--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -51,11 +51,15 @@ const OptionsList = memo(function OptionsList(props) {
     filterPlaceholder = 'Filter...',
     filterIcon = SearchIcon,
     defaultSearchValue = '',
+    shouldScrollToSelectedOnRender = true,
     ...rest
   } = props
 
   const [searchValue, setSearchValue] = useState(defaultSearchValue)
   const [searchRef, setSearchRef] = useState(null)
+  const [scrollToIndex, setScrollToIndex] = useState(undefined);
+
+  const prevOptionsCountRef = useRef();
   const requestId = useRef()
   const theme = useTheme()
   const { tokens } = theme
@@ -90,6 +94,19 @@ const OptionsList = memo(function OptionsList(props) {
   const getCurrentIndex = useCallback(() => {
     return options.findIndex(option => option.value === selected[selected.length - 1])
   }, [selected, options])
+
+  useEffect(() => {
+    const currentIndex = getCurrentIndex();
+    const index = currentIndex === -1 ? 0 : currentIndex;
+    setScrollToIndex(index);
+  }, []);
+
+  useEffect(() => {
+    if (prevOptionsCountRef.current && !shouldScrollToSelectedOnRender) {
+      setScrollToIndex(undefined);
+    }
+    prevOptionsCountRef.current = originalOptions.length;
+  }, [originalOptions]);
 
   const handleArrowUp = useCallback(() => {
     let nextIndex = getCurrentIndex() - 1
@@ -195,8 +212,6 @@ const OptionsList = memo(function OptionsList(props) {
   }, [hasFilter, searchRef, handleKeyDown])
 
   const listHeight = height - (hasFilter ? 32 : 0)
-  const currentIndex = getCurrentIndex()
-  const scrollToIndex = currentIndex === -1 ? 0 : currentIndex
 
   return (
     <Pane height={height} width={width} display="flex" flexDirection="column" {...rest}>
@@ -278,7 +293,8 @@ OptionsList.propTypes = {
   filterPlaceholder: PropTypes.string,
   filterIcon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.element]),
   optionsFilter: PropTypes.func,
-  defaultSearchValue: PropTypes.string
+  defaultSearchValue: PropTypes.string,
+  shouldScrollToSelectedOnRender: PropTypes.bool
 }
 
 export default OptionsList

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -32,6 +32,7 @@ const SelectMenu = memo(function SelectMenu(props) {
     closeOnSelect = false,
     itemRenderer,
     itemHeight,
+    shouldScrollToSelectedOnRender = true,
     ...rest
   } = props
 
@@ -66,6 +67,7 @@ const SelectMenu = memo(function SelectMenu(props) {
           detailView={typeof detailView === 'function' ? detailView({ close }) : detailView}
           emptyView={typeof emptyView === 'function' ? emptyView({ close }) : emptyView}
           closeOnSelect={closeOnSelect}
+          shouldScrollToSelectedOnRender={shouldScrollToSelectedOnRender}
         />
       )}
       {...rest}
@@ -186,7 +188,12 @@ SelectMenu.propTypes = {
   /**
    * The height of the items in the select menu list
    */
-  itemHeight: PropTypes.number
+  itemHeight: PropTypes.number,
+
+  /**
+   * A flag that allows you to disable scrolling to the selected element
+   */
+  shouldScrollToSelectedOnRender: PropTypes.bool
 }
 
 export default SelectMenu

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -49,7 +49,8 @@ const SelectMenuContent = memo(function SelectMenuContent(props) {
     detailView,
     emptyView,
     isMultiSelect,
-    closeOnSelect
+    closeOnSelect,
+    shouldScrollToSelectedOnRender,
   } = props
 
   const headerHeight = 40
@@ -80,6 +81,7 @@ const SelectMenuContent = memo(function SelectMenuContent(props) {
             isMultiSelect={isMultiSelect}
             close={close}
             closeOnSelect={closeOnSelect}
+            shouldScrollToSelectedOnRender={shouldScrollToSelectedOnRender}
             {...listProps}
           />
         )}
@@ -101,6 +103,7 @@ SelectMenuContent.propTypes = {
   filterPlaceholder: PropTypes.string,
   filterIcon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.element]),
   listProps: PropTypes.shape(OptionsList.propTypes),
+  shouldScrollToSelectedOnRender: PropTypes.bool,
 
   /**
    * When true, multi select is accounted for.


### PR DESCRIPTION
**Overview**
Hello everyone
 ~~~~
I added the loading of new options by scrolling in my project. Therefore, I am adding an option `shouldScrollToSelectedOnRender` to `SelectMenu` that allows you to disable scrolling to the selected option. 
If I understood correctly, scrolling to the selected element is needed only in case when a window opens with options. Please correct me if there are other cases.

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
