### PR TITLE
Update classnames version range to ^2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/react": "^16.9.5",
     "@types/react-transition-group": "^4.4.0",
     "arrify": "^1.0.1",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.0",
     "downshift": "^5.2.0",
     "fuzzaldrin-plus": "^0.6.0",
     "glamor": "^2.20.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4680,7 +4680,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2, classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2, classnames@^2.2.5, classnames@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==


### PR DESCRIPTION
**Overview**
This PR simply updates the classnames version range to align with what is being used in the yarn.lock, and resolves the #1479 bug

**Documentation**
N/A
