### PR TITLE
Unrequired length check in autocomplete

### DIFF
--- a/src/autocomplete/src/Autocomplete.js
+++ b/src/autocomplete/src/Autocomplete.js
@@ -48,7 +48,7 @@ const AutocompleteItems = ({
   itemsFilter = itemsFilter || fuzzyFilter(itemToString)
   const items = isFilterDisabled || inputValue.trim() === '' ? originalItems : itemsFilter(originalItems, inputValue)
 
-  if (items.length === 0) return null
+  if (items.length <= 0) return null
 
   // Pass the actual DOM ref to downshift, this fixes touch support
   const menuProps = getMenuProps()
@@ -62,33 +62,31 @@ const AutocompleteItems = ({
           </Text>
         </Pane>
       )}
-      {items.length > 0 && (
-        <VirtualList
-          width="100%"
-          height={Math.min(items.length * itemSize, popoverMaxHeight)}
-          itemSize={itemSize}
-          itemCount={items.length}
-          scrollToIndex={highlightedIndex || 0}
-          overscanCount={3}
-          scrollToAlignment="auto"
-          renderItem={({ index, style }) => {
-            const item = items[index]
-            const itemString = itemToString(item)
+      <VirtualList
+        width="100%"
+        height={Math.min(items.length * itemSize, popoverMaxHeight)}
+        itemSize={itemSize}
+        itemCount={items.length}
+        scrollToIndex={highlightedIndex || 0}
+        overscanCount={3}
+        scrollToAlignment="auto"
+        renderItem={({ index, style }) => {
+          const item = items[index]
+          const itemString = itemToString(item)
 
-            return renderItem(
-              getItemProps({
-                item,
-                key: itemString,
-                index,
-                style,
-                children: itemString,
-                isSelected: itemToString(selectedItem) === itemString,
-                isHighlighted: highlightedIndex === index
-              })
-            )
-          }}
-        />
-      )}
+          return renderItem(
+            getItemProps({
+              item,
+              key: itemString,
+              index,
+              style,
+              children: itemString,
+              isSelected: itemToString(selectedItem) === itemString,
+              isHighlighted: highlightedIndex === index
+            })
+          )
+        }}
+      />
     </Pane>
   )
 }


### PR DESCRIPTION
**Overview**
I noticed that we were performing a similar check twice in the same file when reviewing the large upcoming typescript change. I tried to update the code to remove the redundancy. A small change but every little bit helps.

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
