### PR TITLE
fix(example)Next JS _document error

### DIFF
--- a/examples/ssr-next/pages/_document.js
+++ b/examples/ssr-next/pages/_document.js
@@ -4,8 +4,8 @@ import { extractStyles } from 'evergreen-ui'
 import Document, { Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {
-  static getInitialProps({ renderPage }) {
-    const page = renderPage()
+  static async getInitialProps({ renderPage }) {
+    const page = await renderPage()
     // `css` is a string with css from both glamor and ui-box.
     // No need to get the glamor css manually if you are using it elsewhere in your app.
     //


### PR DESCRIPTION
**Overview**
If using nextjs `=>12.1.6` , may get `error: "MyDocument.getInitialProps()" should resolve to an object with a "html" prop set with a valid html string`

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
