### PR TITLE
Update documentation for Tooltip.isShown prop

### DIFF
--- a/docs/documentation/components/tooltip.mdx
+++ b/docs/documentation/components/tooltip.mdx
@@ -29,10 +29,7 @@ Use with caution, it’s [hard to be completely accessible](https://inclusive-co
 Use with caution, it’s [hard to be completely accessible](https://inclusive-components.design/tooltips-toggletips/).
 
 ```jsx
-<Tooltip
-  content={<Paragraph margin={40}>Card appearance</Paragraph>}
-  appearance="card"
->
+<Tooltip content={<Paragraph margin={40}>Card appearance</Paragraph>} appearance="card">
   <InfoSignIcon />
 </Tooltip>
 ```
@@ -67,4 +64,38 @@ For a `Tooltip` the only really useful sides are `TOP`, `RIGHT`, `BOTTOM` and `L
     <IconButton icon={ArrowLeftIcon} />
   </Tooltip>
 </Pane>
+```
+
+## Conditionally show Tooltip
+
+In some cases you may want to only show a `Tooltip` when a certain condition is true. You can accomplish this by
+manually hiding the `Tooltip` with the `isShown` prop when it should never be shown, and leaving the component uncontrolled
+when you want it to display on hover (standard behavior).
+
+```jsx
+function ConditionalTooltipExample() {
+  const [showTooltipOnHover, setShowTooltipOnHover] = React.useState(false)
+  const handleToggle = React.useCallback(
+    () => setShowTooltipOnHover((prevShowTooltipOnHover) => !prevShowTooltipOnHover),
+    []
+  )
+  return (
+    <React.Fragment>
+      <Checkbox
+        checked={showTooltipOnHover}
+        label="Show Tooltip on hover"
+        marginBottom={majorScale(2)}
+        onChange={handleToggle}
+      />
+      <Tooltip
+        /* Setting isShown to undefined retains standard Tooltip behavior (shows on hover)
+           Setting isShown to false ensures the Tooltip is never shown on hover */
+        isShown={showTooltipOnHover ? undefined : false}
+        content="This Tooltip is showing because the Checkbox is enabled."
+      >
+        <Button>Close</Button>
+      </Tooltip>
+    </React.Fragment>
+  )
+}
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1874,28 +1874,88 @@ export declare const Pill: BoxComponent<PillOwnProps, 'strong'>
 export type PopoverStatelessProps = BoxProps<'div'>
 
 export interface PopoverProps {
+  /**
+   * The position the Popover is on. Smart positioning might override this.
+   */
   position?: PositionTypes
+  /**
+   * Controls whether the Popover is shown or not.
+   * - When `true`, the component is manually shown.
+   * - When `false`, the component is manually hidden.
+   * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
+   */
   isShown?: boolean
+  /**
+   * Open the Popover based on click or hover. Default is click.
+   */
   trigger?: 'click' | 'hover'
+  /**
+   * The content of the Popover.
+   */
   content: React.ReactNode | ((object: { close: () => void }) => React.ReactNode)
+  /**
+   * The target button of the Popover.
+   * When a function the following arguments are passed:
+   * ({ toggle: Function -> Void, getRef: Function -> Ref, isShown: Bool })
+   */
   children:
     | ((props: {
         toggle: () => void
         getRef: (ref: React.RefObject<HTMLElement>) => void
-        isShown: NonNullable<PopoverProps['isShown']>
+        isShown: boolean
       }) => React.ReactNode)
     | React.ReactNode
+  /**
+   * The display property passed to the Popover card.
+   */
   display?: string
+  /**
+   * The min width of the Popover card.
+   */
   minWidth?: number | string
+  /**
+   * The min height of the Popover card.
+   */
   minHeight?: number | string
+  /**
+   * Duration of the animation.
+   */
   animationDuration?: number
+  /**
+   * Function called when the Popover opens.
+   */
   onOpen?: () => void
+  /**
+   * Function fired when Popover closes.
+   */
   onClose?: () => void
+  /**
+   * Function that will be called when the enter transition is complete.
+   */
   onOpenComplete?: () => void
+  /**
+   * Function that will be called when the exit transition is complete.
+   */
   onCloseComplete?: () => void
+  /**
+   * Function that will be called when the body is clicked.
+   */
   onBodyClick?: () => void
+  /**
+   * When true, bring focus inside of the Popover on open.
+   */
   bringFocusInside?: boolean
+  /**
+   * Boolean indicating if clicking outside the dialog should close the dialog.
+   */
   shouldCloseOnExternalClick?: boolean
+  /**
+   * Boolean indicating if pressing the esc key should close the dialog.
+   */
+  shouldCloseOnEscapePress?: boolean
+  /**
+   * Properties passed through to the Popover card.
+   */
   statelessProps?: PopoverStatelessProps
 }
 
@@ -3005,7 +3065,10 @@ export interface TooltipProps {
    */
   showDelay?: number
   /**
-   * When true, manually show the Tooltip.
+   * Controls whether the Tooltip is shown or not.
+   * - When `true`, the component is manually shown.
+   * - When `false`, the component is manually hidden.
+   * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
    */
   isShown?: boolean
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1880,9 +1880,10 @@ export interface PopoverProps {
   position?: PositionTypes
   /**
    * Controls whether the Popover is shown or not.
-   * - When `true`, the component is manually shown.
-   * - When `false`, the component is manually hidden.
+   * - When `true`, the component is always shown, regardless of the click or hover trigger.
+   * - When `false`, the component is never shown, regardless of the click or hover trigger.
    * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
+   * (i.e. the Popover is shown based on the click or hover trigger)
    */
   isShown?: boolean
   /**
@@ -3066,9 +3067,10 @@ export interface TooltipProps {
   showDelay?: number
   /**
    * Controls whether the Tooltip is shown or not.
-   * - When `true`, the component is manually shown.
-   * - When `false`, the component is manually hidden.
+   * - When `true`, the component is always shown, regardless of the whether the target is hovered.
+   * - When `false`, the component is never shown, regardless of the whether the target is hovered.
    * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
+   * (i.e. the Tooltip is shown when the target is hovered)
    */
   isShown?: boolean
   /**

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -335,9 +335,10 @@ Popover.propTypes = {
 
   /**
    * Controls whether the Popover is shown or not.
-   * - When `true`, the component is manually shown.
-   * - When `false`, the component is manually hidden.
+   * - When `true`, the component is always shown, regardless of the click or hover trigger.
+   * - When `false`, the component is never shown, regardless of the click or hover trigger.
    * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
+   * (i.e. the Popover is shown based on the click or hover trigger)
    */
   isShown: PropTypes.bool,
   /**

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -334,7 +334,10 @@ Popover.propTypes = {
   ]),
 
   /**
-   * When true, the Popover is manually shown.
+   * Controls whether the Popover is shown or not.
+   * - When `true`, the component is manually shown.
+   * - When `false`, the component is manually hidden.
+   * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
    */
   isShown: PropTypes.bool,
   /**

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -184,9 +184,10 @@ Tooltip.propTypes = {
 
   /**
    * Controls whether the Tooltip is shown or not.
-   * - When `true`, the component is manually shown.
-   * - When `false`, the component is manually hidden.
+   * - When `true`, the component is always shown, regardless of the whether the target is hovered.
+   * - When `false`, the component is never shown, regardless of the whether the target is hovered.
    * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
+   * (i.e. the Tooltip is shown when the target is hovered)
    */
   isShown: PropTypes.bool,
 

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -183,7 +183,10 @@ Tooltip.propTypes = {
   showDelay: PropTypes.number,
 
   /**
-   * When True, manually show the Tooltip.
+   * Controls whether the Tooltip is shown or not.
+   * - When `true`, the component is manually shown.
+   * - When `false`, the component is manually hidden.
+   * - When `undefined`, the component is uncontrolled and the isShown state is handled internally
    */
   isShown: PropTypes.bool,
 


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves #1493 

Adds more explicit documentation on what each of the states of the `isShown` prop for the Tooltip (and Popover) do. I added an example to the Tooltip page to demo this functionality. 


**Screenshots (if applicable)**

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/11774799/179000250-9510cb62-dec8-49e8-829c-875ebff45633.png">



**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
