### PR TITLE
Fix MenuItem disabled colors/styling

### DIFF
--- a/src/menu/src/MenuItem.js
+++ b/src/menu/src/MenuItem.js
@@ -62,12 +62,12 @@ const MenuItem = memo(
     let iconColor = intent === 'none' ? 'default' : intent
 
     if (disabled) {
-      iconColor = 'disabled'
+      iconColor = 'muted'
     }
 
-    const textColor = disabled ? 'disabled' : intent
+    const textColor = disabled ? 'muted' : intent
 
-    const secondaryTextColor = disabled ? textColor : 'muted'
+    const secondaryTextColor = 'muted'
 
     const disabledProps = useMemo(() => {
       return disabled
@@ -100,14 +100,7 @@ const MenuItem = memo(
         tabIndex={tabIndex}
         onKeyDown={onKeyDown}
       >
-        <IconWrapper
-          icon={icon}
-          color={disabled ? 'disabled' : iconColor}
-          marginLeft={16}
-          marginRight={-4}
-          size={16}
-          flexShrink={0}
-        />
+        <IconWrapper icon={icon} color={iconColor} marginLeft={16} marginRight={-4} size={16} flexShrink={0} />
         <Text color={textColor} marginLeft={16} marginRight={16} flex={1}>
           {children}
         </Text>

--- a/src/themes/default/components/menu-item.js
+++ b/src/themes/default/components/menu-item.js
@@ -11,7 +11,7 @@ const baseStyle = {
 
   _disabled: {
     cursor: 'not-allowed',
-    pointerEvents: 'none'
+    userSelect: 'none'
   }
 }
 


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Resolves #1497 

Fixes up the few styling discrepancies that were noted, which should be testable in the existing Storybook story
- Cursor is now actually `not-allowed` (the `pointerEvents: 'none'` style was preventing this)
- Secondary text is always muted
- Primary text is muted when disabled, or the intent color
- Icon color is muted when disabled, or the intent color

**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/11774799/179313889-04894baf-b711-4839-b270-4cefbafdd2e9.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
