### PR TITLE
Adds HTML name attribute support for RadioGroup

### DIFF
--- a/src/radio/__tests__/RadioGroup.test.js
+++ b/src/radio/__tests__/RadioGroup.test.js
@@ -56,5 +56,12 @@ describe('Radio Group', () => {
     })
   })
 
+  it('should render the radio buttons with auto-generated HTML name attributes when name property is empty', () => {
+    render(<RadioGroup options={options} label="Permissions" />)
+    screen.getAllByRole('radio').forEach(element => {
+      expect(element.getAttribute('name')).toContain('RadioGroup')
+    })
+  })
+
   // untested props: defaultValue, size
 })

--- a/src/radio/__tests__/RadioGroup.test.js
+++ b/src/radio/__tests__/RadioGroup.test.js
@@ -49,5 +49,12 @@ describe('Radio Group', () => {
     expect(onChangeMock).toBeCalledTimes(1)
   })
 
+  it('should render the radio buttons with HTML name attributes specified', () => {
+    render(<RadioGroup options={options} label="Permissions" name="RadioInput" />)
+    screen.getAllByRole('radio').forEach(element => {
+      expect(element.getAttribute('name')).toEqual('RadioInput')
+    })
+  })
+
   // untested props: defaultValue, size
 })

--- a/src/radio/__tests__/RadioGroup.test.js
+++ b/src/radio/__tests__/RadioGroup.test.js
@@ -59,7 +59,7 @@ describe('Radio Group', () => {
   it('should render the radio buttons with auto-generated HTML name attributes when name property is empty', () => {
     render(<RadioGroup options={options} label="Permissions" />)
     screen.getAllByRole('radio').forEach(element => {
-      expect(element.getAttribute('name')).toContain('RadioGroup')
+      expect(element.getAttribute('name')).not.toBe('')
     })
   })
 

--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -8,6 +8,7 @@ import Radio from './Radio'
 
 const noop = () => {}
 const emptyArray = []
+const emptyString = ''
 
 const RadioGroup = memo(
   forwardRef(function RadioGroup(props, ref) {
@@ -19,10 +20,14 @@ const RadioGroup = memo(
       options = emptyArray,
       onChange = noop,
       isRequired = false,
+      name = emptyString,
       ...rest
     } = props
 
-    const name = useId('RadioGroup')
+    const autoNameAttribute = useId('RadioGroup')
+
+    const nameAttribute = name || autoNameAttribute
+
     const selected = value || defaultValue || props.options[0].value
 
     return (
@@ -36,7 +41,7 @@ const RadioGroup = memo(
           <Radio
             key={item.value}
             size={size}
-            name={name}
+            name={nameAttribute}
             value={item.value}
             label={item.label}
             checked={selected === item.value}
@@ -98,7 +103,12 @@ RadioGroup.propTypes = {
   /**
    * When true, the radio get the required attribute.
    */
-  isRequired: PropTypes.bool
+  isRequired: PropTypes.bool,
+
+  /**
+   * The name attribute for HTML radio button. Default to auto-generated string with 'RadioGroup' prefix
+   */
+  name: PropTypes.string
 }
 
 export default RadioGroup


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Currently the `RadioGroup` component automatically generates a string prefix 'RadioGroup' for the HTML `name` attribute on input type radio. This PR is about to add a name prop support for the component so the developer can set the attribute on their own and have more controls of form radio buttons on both client side and server side if they need it.

A recent issue is #1522 

**Screenshots (if applicable)**

***Before this change***
![image](https://user-images.githubusercontent.com/99985579/192859145-e7122e9a-9127-4e8e-873a-b65293f7ca87.png)

***After this change***
![image](https://user-images.githubusercontent.com/99985579/192858826-2b7776bc-8653-417e-a019-697b58e29ac9.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories

**Testing**

Added new unit test and run test on local

![image](https://user-images.githubusercontent.com/99985579/192857580-098c90fc-602c-438b-9e8c-561366ef3924.png)
