### PR TITLE
Omit children, items, and onChange from Combobox.autocompleteProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1054,7 +1054,7 @@ export interface ComboboxOwnProps {
   /**
    * Properties forwarded to the autocomplete component. Use with caution.
    */
-  autocompleteProps?: AutocompleteProps
+  autocompleteProps?: Omit<AutocompleteProps, 'children' | 'items' | 'onChange'>
   /**
    * When true, open the autocomplete on focus.
    */

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectType, expectError } from 'tsd'
-import { defaultTheme, mergeTheme, StyleProps, Intent, Theme, Fill, Partial, Pick, Color } from '.'
+import { defaultTheme, mergeTheme, StyleProps, Intent, Theme, Fill, Partial, Pick, Color, ComboboxProps } from '.'
 
 interface ThemeOverrides extends Partial<Pick<Theme, 'colors' | 'fills' | 'components'>> {
   colors: {
@@ -125,3 +125,7 @@ const themeWithTopLevelColorsArray = {
   colors: ['#0f4880', '#1d781d', '#db0a5b', '#8d6708', '#d43900']
 }
 expectError(mergeTheme(defaultTheme, themeWithTopLevelColorsArray))
+
+expectError<ComboboxProps>({ autocompleteProps: { children: 'error' } })
+expectError<ComboboxProps>({ autocompleteProps: { onChange: () => {} } })
+expectError<ComboboxProps>({ autocompleteProps: { items: [] } })


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

Fixes #1525

`items`, `children` and `onChange` are required properties in `AutocompleteProps`, but they are passed in as top-level props for the `Combobox`. You'd need to cast any object you pass in if you wanted to override specific Autocomplete behavior. This should be closer to the intended usage of the component and ease the need to cast any props you're sending thru it, if you really need to.

**Overview**


**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
