### PR TITLE
Fix: allow OptionsList to not focus on the search bar

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2388,7 +2388,8 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
    */
   hasFilter?: boolean
   /**
-   * @default true. When true, auto focuses on the search/filter bar. 
+   * When true, auto focuses on the search/filter bar. 
+   * @default true
    */
    shouldAutoFocus?: boolean
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -2388,6 +2388,10 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
    */
   hasFilter?: boolean
   /**
+   * @default true. When true, auto focuses on the search/filter bar. 
+   */
+   shouldAutoFocus?: boolean
+  /**
    * The position of the Select Menu.
    */
   position?: Omit<PositionTypes, 'left' | 'right'>

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -51,6 +51,7 @@ const OptionsList = memo(function OptionsList(props) {
     filterPlaceholder = 'Filter...',
     filterIcon = SearchIcon,
     defaultSearchValue = '',
+    shouldAutoFocus = true,
     ...rest
   } = props
 
@@ -181,7 +182,7 @@ const OptionsList = memo(function OptionsList(props) {
   useEffect(() => {
     if (hasFilter) {
       requestId.current = requestAnimationFrame(() => {
-        if (searchRef) {
+        if (searchRef && shouldAutoFocus) {
           searchRef.focus()
         }
       })

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -193,7 +193,7 @@ const OptionsList = memo(function OptionsList(props) {
         window.removeEventListener('keydown', handleKeyDown)
       }
     }
-  }, [hasFilter, searchRef, handleKeyDown])
+  }, [hasFilter, searchRef, handleKeyDown, shouldAutoFocus])
 
   const listHeight = height - (hasFilter ? 32 : 0)
   const currentIndex = getCurrentIndex()
@@ -270,6 +270,11 @@ OptionsList.propTypes = {
    * This holds the values of the options
    */
   selected: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+
+  /**
+   * When true, menu auto focuses on the search/filter bar.
+   */
+  shouldAutoFocus: PropTypes.bool,
   onSelect: PropTypes.func,
   onDeselect: PropTypes.func,
   onFilterChange: PropTypes.func,

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -186,7 +186,12 @@ SelectMenu.propTypes = {
   /**
    * The height of the items in the select menu list
    */
-  itemHeight: PropTypes.number
+  itemHeight: PropTypes.number,
+
+  /**
+   * When true, menu auto focuses on the search/filter bar.
+   */
+  shouldAutoFocus: PropTypes.bool
 }
 
 export default SelectMenu

--- a/src/select-menu/src/SelectMenu.js
+++ b/src/select-menu/src/SelectMenu.js
@@ -32,6 +32,7 @@ const SelectMenu = memo(function SelectMenu(props) {
     closeOnSelect = false,
     itemRenderer,
     itemHeight,
+    shouldAutoFocus,
     ...rest
   } = props
 
@@ -60,7 +61,8 @@ const SelectMenu = memo(function SelectMenu(props) {
             onFilterChange,
             selected: selectedArray,
             renderItem: itemRenderer,
-            optionSize: itemHeight
+            optionSize: itemHeight,
+            shouldAutoFocus: shouldAutoFocus
           }}
           close={close}
           detailView={typeof detailView === 'function' ? detailView({ close }) : detailView}

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -125,12 +125,7 @@ SelectMenuContent.propTypes = {
   /**
    * Node that is displayed instead of options list when there are no options.
    */
-  emptyView: PropTypes.node,
-
-  /**
-   * When true, menu auto focuses on the search/filter bar.
-   */
-  shouldAutoFocus: PropTypes.bool
+  emptyView: PropTypes.node
 }
 
 export default SelectMenuContent

--- a/src/select-menu/src/SelectMenuContent.js
+++ b/src/select-menu/src/SelectMenuContent.js
@@ -125,7 +125,12 @@ SelectMenuContent.propTypes = {
   /**
    * Node that is displayed instead of options list when there are no options.
    */
-  emptyView: PropTypes.node
+  emptyView: PropTypes.node,
+
+  /**
+   * When true, menu auto focuses on the search/filter bar.
+   */
+  shouldAutoFocus: PropTypes.bool
 }
 
 export default SelectMenuContent


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

Original Jira ticket: https://segment.atlassian.net/browse/PROT-4257
Loom: https://www.loom.com/share/79fd27a5ac2a415c93aac856c50c427a

**Overview**
There's a bug in Protocols tracking plan, where the focus of the input changes to the focus of the filter search bar. This happens because the tracking plan editor pages refreshes every few seconds and the focus is autofocused to the search bar  component. This PR adds a prop `shouldAutoFocus` to `OptionsList` so that we can disable the autofocus as needed. The change will not affect existing behaviors. 

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
