### PR TITLE
feat: insert test spinner and coverage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Below you can read a description of each script.
 
 - `yarn create-package`: This command scaffolds a package with no specific boilerplate. It's useful for creating utilities.
 
+- `yarn coverage`: This command creates a file with which you can view the test coverage of our components.
+
 For the following command:
 
 ```

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "storybook": "start-storybook -p 6006",
     "test": "yarn lint && yarn tsd && yarn jest",
     "test:watch": "yarn run test -- --watch",
+    "coverage": "yarn run test --coverage --silent",
     "update-docs": "cd docs && yarn add evergreen-ui@latest --exact && git add package.json yarn.lock && git show-branch --no-name HEAD | grep -E 'v[0-9]+.[0-9]+.[0-9]+' && git commit --amend --no-edit || git commit -m \"Updated doc site evergreen version\""
   },
   "engines": {

--- a/src/spinner/__tests__/Spinner.test.js
+++ b/src/spinner/__tests__/Spinner.test.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Spinner from '../src/Spinner'
+
+describe('Spinner', () => {
+  jest.useFakeTimers()
+  jest.spyOn(global, 'setTimeout')
+  it('should not crash when rendering', () => {
+    expect(() => {
+      render(<Spinner />)
+    }).not.toThrowError()
+  })
+
+  it('should render', () => {
+    expect(() => {
+      render(<Spinner />)
+    }).not.toBeNull()
+  })
+
+  it('should render Spinner with delay time', () => {
+    const spinnerDelay = render(<Spinner delay={300} />)
+
+    jest.advanceTimersByTime(300)
+
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 300)
+    expect(spinnerDelay).not.toBeNull()
+  })
+})


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
- creation of unit test for component Spinner
- command insertion for generating reports ``` yarn coverage ```

**Screenshots (if applicable)**
- *When executing the yarn coverage command, a folder called coverage containing the file below is generated in the project root.*
- Command: ``` yarn coverage ```
- Path where the generated file is located:

![image](https://user-images.githubusercontent.com/27088259/194726256-d40e06c5-1291-445f-96b9-72dd982b6312.png)

- Open file **index.html**:
![image](https://user-images.githubusercontent.com/27088259/194726135-b6203d36-a107-446a-b073-935c50c83b8d.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
