### PR TITLE
Add shouldAutoFocus prop to Overlay, SideSheet, and Dialog components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2460,18 +2460,43 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
 
 export declare const SelectMenu: React.FC<SelectMenuProps>
 
-export interface SideSheetProps {
+export interface SideSheetProps
+  extends Pick<
+    OverlayProps,
+    'isShown' | 'onBeforeClose' | 'preventBodyScrolling' | 'shouldAutoFocus' | 'shouldCloseOnEscapePress'
+  > {
   children: React.ReactNode | (() => React.ReactNode)
-  isShown?: boolean
+
+  /**
+   * Function that will be called when the exit transition is complete.
+   */
   onCloseComplete?: () => void
+
+  /**
+   * Function that will be called when the enter transition is complete.
+   */
   onOpenComplete?: () => void
-  onBeforeClose?: () => boolean
+
+  /**
+   * Boolean indicating if clicking the overlay should close the overlay.
+   * @default true
+   */
   shouldCloseOnOverlayClick?: boolean
-  shouldCloseOnEscapePress?: boolean
+
+  /**
+   * Width of the SideSheet.
+   */
   width?: string | number
+
+  /**
+   * Properties to pass through the SideSheet container Pane.
+   */
   containerProps?: PaneOwnProps & BoxProps<'div'>
+
+  /**
+   * Positions the sheet to the top, left, right, or bottom of the screen.
+   */
   position?: Extract<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
-  preventBodyScrolling?: boolean
 }
 
 export declare const SideSheet: React.FC<SideSheetProps>
@@ -3238,7 +3263,7 @@ export interface OverlayProps
   preventBodyScrolling?: boolean
 
   /**
-   * Controls whether the the overlay should automatically try to bring focus inside.
+   * Controls whether the overlay should automatically try to bring focus inside.
    * @default true
    */
   shouldAutoFocus?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -1172,29 +1172,31 @@ export interface CornerDialogProps {
 
 export declare const CornerDialog: React.FC<CornerDialogProps>
 
-export interface DialogProps {
+export interface DialogProps
+  extends Pick<OverlayProps, 'isShown' | 'preventBodyScrolling' | 'shouldAutoFocus' | 'shouldCloseOnEscapePress'> {
   /**
    * Children can be a string, node or a function accepting `({ close })`.
    * When passing a string, <Paragraph /> is used to wrap the string.
    */
   children?: React.ReactNode | (({ close }: { close: () => void }) => void)
+
   /**
-   * The intent of the Dialog. Used for the button. Defaults to none.
+   * The intent of the Dialog. Used for the button.
+   * @default none
    */
   intent?: IntentTypes
-  /**
-   * When true, the dialog is shown. Defaults to false.
-   */
-  isShown?: boolean
+
   /**
    * Title of the Dialog. Titles should use Title Case.
    */
   title?: React.ReactNode
+
   /**
    * When true, the header with the title and close icon button is shown.
-   * Defaults to true.
+   * @default true
    */
   hasHeader?: boolean
+
   /**
    * You can override the default header with your own custom component.
    *
@@ -1204,11 +1206,13 @@ export interface DialogProps {
    * Header can either be a React node or a function accepting `({ close })`.
    */
   header?: React.ReactNode | (({ close }: { close: () => void }) => void)
+
   /**
    * When true, the footer with the cancel and confirm button is shown.
-   * Defaults to true.
+   * @default true
    */
   hasFooter?: boolean
+
   /**
    * You can override the default footer with your own custom component.
    *
@@ -1218,92 +1222,107 @@ export interface DialogProps {
    * Footer can either be a React node or a function accepting `({ close })`.
    */
   footer?: React.ReactNode | (({ close }: { close: () => void }) => void)
+
   /**
-   * When true, the cancel button is shown. Defaults to true.
+   * When true, the cancel button is shown.
+   * @default true
    */
   hasCancel?: boolean
+
   /**
-   * When true, the close button is shown. Defaults to true.
+   * When true, the close button is shown.
+   * @default true
    */
   hasClose?: boolean
+
   /**
    * Function that will be called when the exit transition is complete.
    */
   onCloseComplete?: () => void
+
   /**
    * Function that will be called when the enter transition is complete.
    */
   onOpenComplete?: () => void
+
   /**
    * Function that will be called when the confirm button is clicked.
    * This does not close the Dialog. A close function will be passed
-   * as a paramater you can use to close the dialog.
+   * as a parameter you can use to close the dialog.
    * If unspecified, this defaults to closing the Dialog.
    */
   onConfirm?: (close: () => void) => void
+
   /**
-   * Label of the confirm button. Default to 'Confirm'.
+   * Label of the confirm button.
+   * @default Confirm
    */
   confirmLabel?: string
+
   /**
-   * When true, the confirm button is set to loading. Defaults to false.
+   * When true, the confirm button is set to loading.
+   * @default false
    */
   isConfirmLoading?: boolean
+
   /**
-   * When true, the confirm button is set to disabled. Defaults to false.
+   * When true, the confirm button is set to disabled.
+   * @default false
    */
   isConfirmDisabled?: boolean
+
   /**
    * Function that will be called when the cancel button is clicked.
    * This closes the Dialog by default.
    */
   onCancel?: (close: () => void) => void
+
   /**
-   * Label of the cancel button. Defaults to 'Cancel'.
+   * Label of the cancel button.
+   * @default Cancel
    */
   cancelLabel?: string
+
   /**
    * Boolean indicating if clicking the overlay should close the overlay.
-   * Defaults to true.
+   * @default true
    */
   shouldCloseOnOverlayClick?: boolean
-  /**
-   * Boolean indicating if pressing the esc key should close the overlay.
-   * Defaults to true.
-   */
-  shouldCloseOnEscapePress?: boolean
+
   /**
    * Width of the Dialog.
    */
   width?: string | number
+
   /**
    * The space above the dialog.
    * This offset is also used at the bottom when there is not enough vertical
    * space available on screen — and the dialog scrolls internally.
    */
   topOffset?: string | number
+
   /**
    * The space on the left/right sides of the dialog when there isn't enough
    * horizontal space available on screen.
    */
   sideOffset?: string | number
+
   /**
    * The min height of the body content.
    * Makes it less weird when only showing little content.
    */
   minHeightContent?: string | number
+
   /**
    * Props that are passed to the dialog container.
    */
   containerProps?: React.ComponentProps<typeof Pane>
+
   /**
    * Props that are passed to the content container.
    */
   contentContainerProps?: React.ComponentProps<typeof Pane>
-  /**
-   * Whether or not to prevent scrolling in the outer body. Defaults to false.
-   */
-  preventBodyScrolling?: boolean
+
   /**
    * Props that are passed to the Overlay component.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -2388,10 +2388,10 @@ export interface SelectMenuProps extends Omit<PopoverProps, 'position' | 'conten
    */
   hasFilter?: boolean
   /**
-   * When true, auto focuses on the search/filter bar. 
+   * When true, auto focuses on the search/filter bar.
    * @default true
    */
-   shouldAutoFocus?: boolean
+  shouldAutoFocus?: boolean
   /**
    * The position of the Select Menu.
    */
@@ -3217,21 +3217,49 @@ export const toaster: {
   getToasts: () => Toast[]
 }
 
-export interface OverlayProps {
+export interface OverlayProps
+  extends Pick<TransitionProps, 'onExit' | 'onExiting' | 'onExited' | 'onEnter' | 'onEntering' | 'onEntered'> {
   children: React.ReactNode | ((props: { state: TransitionStatus; close: () => void }) => JSX.Element)
 
+  /**
+   * Show the component; triggers the enter or exit states.
+   */
   isShown?: boolean
+
+  /**
+   * Props to be passed through on the inner Box.
+   */
   containerProps?: BoxProps<'div'>
+
+  /**
+   * Whether or not to prevent body scrolling outside the context of the overlay
+   * @default false
+   */
   preventBodyScrolling?: boolean
+
+  /**
+   * Controls whether the the overlay should automatically try to bring focus inside.
+   * @default true
+   */
+  shouldAutoFocus?: boolean
+
+  /**
+   * Boolean indicating if clicking the overlay should close the overlay.
+   * @default true
+   */
   shouldCloseOnClick?: boolean
+
+  /**
+   * Boolean indicating if pressing the esc key should close the overlay.
+   * @default true
+   */
   shouldCloseOnEscapePress?: boolean
+
+  /**
+   * Function called when overlay is about to close.
+   * Return `false` to prevent the sheet from closing.
+   */
   onBeforeClose?: () => boolean
-  onExit?: TransitionProps['onExit']
-  onExiting?: TransitionProps['onExiting']
-  onExited?: TransitionProps['onExited']
-  onEnter?: TransitionProps['onEnter']
-  onEntering?: TransitionProps['onEntering']
-  onEntered?: TransitionProps['onEntered']
 }
 
 export declare const Overlay: React.FC<OverlayProps>

--- a/src/dialog/__tests__/Dialog.test.js
+++ b/src/dialog/__tests__/Dialog.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Dialog from '../src/Dialog'
+
+const makeDialogFixture = (props = {}) => <Dialog containerProps={{ 'data-testid': 'Dialog' }} {...props} />
+
+describe('Dialog', () => {
+  it('should not crash', () => {
+    expect(() => render(makeDialogFixture())).not.toThrow()
+  })
+
+  it('should render content when isShown is true', () => {
+    const children = 'Content'
+    render(makeDialogFixture({ isShown: true, children }))
+
+    expect(screen.getByText(children)).toBeInTheDocument()
+  })
+
+  it('should not render content when isShown is false', () => {
+    const children = 'Content'
+
+    render(makeDialogFixture({ isShown: false, children }))
+
+    expect(() => screen.getByText(children)).toThrow()
+  })
+})

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -73,6 +73,7 @@ const Dialog = memo(function Dialog({
   onOpenComplete,
   overlayProps = emptyProps,
   preventBodyScrolling = false,
+  shouldAutoFocus = true,
   shouldCloseOnEscapePress = true,
   shouldCloseOnOverlayClick = true,
   sideOffset = '16px',
@@ -173,6 +174,7 @@ const Dialog = memo(function Dialog({
   return (
     <Overlay
       isShown={isShown}
+      shouldAutoFocus={shouldAutoFocus}
       shouldCloseOnClick={shouldCloseOnOverlayClick}
       shouldCloseOnEscapePress={shouldCloseOnEscapePress}
       onExited={onCloseComplete}
@@ -333,12 +335,20 @@ Dialog.propTypes = {
   cancelLabel: PropTypes.string,
 
   /**
+   * Controls whether the overlay should automatically try to bring focus inside.
+   * @default true
+   */
+  shouldAutoFocus: PropTypes.bool,
+
+  /**
    * Boolean indicating if clicking the overlay should close the overlay.
+   * @default true
    */
   shouldCloseOnOverlayClick: PropTypes.bool,
 
   /**
    * Boolean indicating if pressing the esc key should close the overlay.
+   * @default true
    */
   shouldCloseOnEscapePress: PropTypes.bool,
 
@@ -378,6 +388,7 @@ Dialog.propTypes = {
 
   /**
    * Whether or not to prevent scrolling in the outer body
+   * @default false
    */
   preventBodyScrolling: PropTypes.bool,
 

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -9,6 +9,7 @@ import { Combobox } from '../../combobox'
 import { Pane } from '../../layers'
 import { Popover } from '../../popover'
 import { SideSheet } from '../../side-sheet'
+import { TextInputField } from '../../text-input'
 import { Strong, Paragraph } from '../../typography'
 import DialogManager from './DialogManager'
 
@@ -192,6 +193,16 @@ storiesOf('dialog', module)
               </Paragraph>
             </Dialog>
             <Button onClick={show}>Show Dialog with overlay and escape key disabled</Button>
+          </Box>
+        )}
+      </DialogManager>
+      <DialogManager>
+        {({ hide, isShown, show }) => (
+          <Box marginBottom={16}>
+            <Dialog shouldAutoFocus={false} isShown={isShown} title="Dialog Title" onCloseComplete={hide}>
+              <TextInputField label="First name" />
+            </Dialog>
+            <Button onClick={show}>Show Dialog with autofocus disabled</Button>
           </Box>
         )}
       </DialogManager>

--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -68,6 +68,7 @@ const Overlay = memo(function Overlay({
   children,
   containerProps = emptyProps,
   preventBodyScrolling = false,
+  shouldAutoFocus = true,
   shouldCloseOnClick = true,
   shouldCloseOnEscapePress = true,
   onBeforeClose,
@@ -145,6 +146,7 @@ const Overlay = memo(function Overlay({
       // activeElement may be undefined in some rare cases in IE
 
       if (
+        !shouldAutoFocus ||
         containerRef.current == null || // eslint-disable-line eqeqeq, no-eq-null
         document.activeElement == null || // eslint-disable-line eqeqeq, no-eq-null
         !isShown
@@ -296,16 +298,25 @@ Overlay.propTypes = {
 
   /**
    * Whether or not to prevent body scrolling outside the context of the overlay
+   * @default false
    */
   preventBodyScrolling: PropTypes.bool,
 
   /**
+   * Controls whether the the overlay should automatically try to bring focus inside.
+   * @default true
+   */
+  shouldAutoFocus: PropTypes.bool,
+
+  /**
    * Boolean indicating if clicking the overlay should close the overlay.
+   * @default true
    */
   shouldCloseOnClick: PropTypes.bool,
 
   /**
    * Boolean indicating if pressing the esc key should close the overlay.
+   * @default true
    */
   shouldCloseOnEscapePress: PropTypes.bool,
 

--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -303,7 +303,7 @@ Overlay.propTypes = {
   preventBodyScrolling: PropTypes.bool,
 
   /**
-   * Controls whether the the overlay should automatically try to bring focus inside.
+   * Controls whether the overlay should automatically try to bring focus inside.
    * @default true
    */
   shouldAutoFocus: PropTypes.bool,

--- a/src/overlay/stories/index.stories.js
+++ b/src/overlay/stories/index.stories.js
@@ -121,3 +121,21 @@ storiesOf('overlay', module)
       </Box>
     )
   })
+  .add('Autofocus disabled', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <OverlayManager>
+        {({ hide, isShown, show }) => (
+          <Box>
+            <Overlay shouldAutoFocus={false} isShown={isShown} onExited={hide}>
+              <Button onClick={hide}>Close</Button>
+            </Overlay>
+            <Button onClick={show}>Show Overlay</Button>
+          </Box>
+        )}
+      </OverlayManager>
+    </Box>
+  ))

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -243,6 +243,7 @@ SideSheet.propTypes = {
 
   /**
    * Whether or not to prevent scrolling in the outer body
+   * @default false
    */
   preventBodyScrolling: PropTypes.bool
 }

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -136,6 +136,7 @@ const SideSheet = memo(function SideSheet(props) {
     onOpenComplete = noop,
     onCloseComplete = noop,
     onBeforeClose,
+    shouldAutoFocus = true,
     shouldCloseOnOverlayClick = true,
     shouldCloseOnEscapePress = true,
     position = Position.RIGHT,
@@ -145,6 +146,7 @@ const SideSheet = memo(function SideSheet(props) {
   return (
     <Overlay
       isShown={isShown}
+      shouldAutoFocus={shouldAutoFocus}
       shouldCloseOnClick={shouldCloseOnOverlayClick}
       shouldCloseOnEscapePress={shouldCloseOnEscapePress}
       onBeforeClose={onBeforeClose}
@@ -207,12 +209,20 @@ SideSheet.propTypes = {
   onBeforeClose: PropTypes.func,
 
   /**
+   * Controls whether the overlay should automatically try to bring focus inside.
+   * @default true
+   */
+  shouldAutoFocus: PropTypes.bool,
+
+  /**
    * Boolean indicating if clicking the overlay should close the overlay.
+   * @default true
    */
   shouldCloseOnOverlayClick: PropTypes.bool,
 
   /**
    * Boolean indicating if pressing the esc key should close the overlay.
+   * @default true
    */
   shouldCloseOnEscapePress: PropTypes.bool,
 

--- a/src/side-sheet/stories/index.stories.js
+++ b/src/side-sheet/stories/index.stories.js
@@ -9,7 +9,7 @@ import { PeopleIcon, CircleArrowRightIcon, TrashIcon, EditIcon } from '../../ico
 import { Card, Pane } from '../../layers'
 import Menu from '../../menu/src/Menu'
 import { Tab } from '../../tabs'
-import { TextInput } from '../../text-input'
+import { TextInput, TextInputField } from '../../text-input'
 import { Heading, Paragraph } from '../../typography'
 
 storiesOf('side-sheet', module)
@@ -352,6 +352,28 @@ storiesOf('side-sheet', module)
                   </Box>
                 )
               }}
+            </SideSheet>
+            <Button onClick={() => setState({ isShown: true })}>Show Side Sheet</Button>
+          </Box>
+        )}
+      </Component>
+    </Box>
+  ))
+  .add('Autofocus disabled', () => (
+    <Box padding={40}>
+      {(() => {
+        document.body.style.margin = '0'
+        document.body.style.height = '100vh'
+      })()}
+      <Component initialState={{ isShown: false }}>
+        {({ setState, state }) => (
+          <Box>
+            <SideSheet
+              isShown={state.isShown}
+              shouldAutoFocus={false}
+              onCloseComplete={() => setState({ isShown: false })}
+            >
+              <TextInputField label="First name" />
             </SideSheet>
             <Button onClick={() => setState({ isShown: true })}>Show Side Sheet</Button>
           </Box>


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

Resolves #1404 

**Overview**

This PR introduces a prop to `Overlay`, `SideSheet` and `Dialog` that allows a consumer to disable the default autofocus behavior that lives in `Overlay.js`. As noted in that task, there are certain cases where the behavior can be incorrect or undesirable but there's no obvious way to opt out of it. This PR addresses that - retaining the current behavior, but opening up a way to disable it if needed.


**Screenshots (if applicable)**

Behavior can be demoed in the respective Storybook areas:

https://deploy-preview-1535--evergreen-storybook.netlify.app/?path=/story/overlay--autofocus-disabled

https://deploy-preview-1535--evergreen-storybook.netlify.app/?path=/story/side-sheet--autofocus-disabled

(Scroll to bottom and click button 'Show Dialog with autofocus disabled')
https://deploy-preview-1535--evergreen-storybook.netlify.app/?path=/story/dialog--dialog


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
