### PR TITLE
Changed image storybook url. Previous link doesn't work.

### DIFF
--- a/src/image/stories/index.stories.js
+++ b/src/image/stories/index.stories.js
@@ -9,6 +9,6 @@ storiesOf('image', module).add('Image', () => (
       document.body.style.margin = '0'
       document.body.style.height = '100vh'
     })()}
-    <Image src="http://lorempixel.com/output/cats-q-c-640-480-5.jpg" />
+    <Image src="http://placekitten.com/640/480" />
   </Box>
 ))


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

I noticed that the image component src URL doesn't work and does not display on the storybook image section. I replaced the URL.

Files affected:

index.stories.js at evergreen\src\image\stories

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
