### PR TITLE
Update ui-box, remove keyframes from bulk of remaining components

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.1",
     "tinycolor2": "^1.4.1",
-    "ui-box": "^5.2.1"
+    "ui-box": "^5.3.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/src/corner-dialog/src/CornerDialog.js
+++ b/src/corner-dialog/src/CornerDialog.js
@@ -1,8 +1,7 @@
 import React, { memo, useRef, useState, useEffect, useCallback } from 'react'
-import cx from 'classnames'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
+import { keyframes } from 'ui-box'
 import { Button, IconButton } from '../../buttons'
 import absolutePositions from '../../constants/src/AbsolutePosition'
 import positions from '../../constants/src/Position'
@@ -19,7 +18,7 @@ const animationEasing = {
 
 const ANIMATION_DURATION = 240
 
-const openAnimation = css.keyframes('openAnimation', {
+const openAnimation = keyframes('openAnimation', {
   from: {
     transform: 'translateY(100%)'
   },
@@ -28,7 +27,7 @@ const openAnimation = css.keyframes('openAnimation', {
   }
 })
 
-const closeAnimation = css.keyframes('closeAnimation', {
+const closeAnimation = keyframes('closeAnimation', {
   from: {
     transform: 'scale(1)',
     opacity: 1
@@ -39,12 +38,23 @@ const closeAnimation = css.keyframes('closeAnimation', {
   }
 })
 
+const enterAnimationProps = {
+  animationName: openAnimation,
+  animationDuration: ANIMATION_DURATION,
+  animationTimingFunction: animationEasing.spring,
+  animationFillMode: 'both'
+}
+
 const animationStyles = {
-  '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${animationEasing.spring} both`
-  },
-  '&[data-state="exiting"]': {
-    animation: `${closeAnimation} 120ms ${animationEasing.acceleration} both`
+  selectors: {
+    '&[data-state="entering"]': enterAnimationProps,
+    '&[data-state="entered"]': enterAnimationProps,
+    '&[data-state="exiting"]': {
+      animationName: closeAnimation,
+      animationDuration: 120,
+      animationTimingFunction: animationEasing.acceleration,
+      animationFillMode: 'both'
+    }
   }
 }
 
@@ -134,12 +144,13 @@ const CornerDialog = memo(function CornerDialog(props) {
       >
         {state => (
           <Card
+            {...animationStyles}
             ref={transitionRef}
             role="dialog"
             backgroundColor="white"
             elevation={4}
             width={width}
-            className={cx(css(animationStyles).toString(), containerClassName)}
+            className={containerClassName}
             data-state={state}
             padding={32}
             position="fixed"

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -1,7 +1,6 @@
 import React, { memo } from 'react'
-import cx from 'classnames'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
+import { keyframes } from 'ui-box'
 import { Button, IconButton } from '../../buttons'
 import { useStyleConfig } from '../../hooks'
 import { CrossIcon } from '../../icons'
@@ -16,7 +15,7 @@ const animationEasing = {
 
 const ANIMATION_DURATION = 200
 
-const openAnimation = css.keyframes('openAnimation', {
+const openAnimation = keyframes('openAnimation', {
   from: {
     transform: 'scale(0.8)',
     opacity: 0
@@ -27,7 +26,7 @@ const openAnimation = css.keyframes('openAnimation', {
   }
 })
 
-const closeAnimation = css.keyframes('closeAnimation', {
+const closeAnimation = keyframes('closeAnimation', {
   from: {
     transform: 'scale(1)',
     opacity: 1
@@ -37,13 +36,24 @@ const closeAnimation = css.keyframes('closeAnimation', {
     opacity: 0
   }
 })
+
+const enterAnimationProps = {
+  animationName: openAnimation,
+  animationDuration: ANIMATION_DURATION,
+  animationTimingFunction: animationEasing.deceleration,
+  animationFillMode: 'both'
+}
 
 const animationStyles = {
-  '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
-  },
-  '&[data-state="exiting"]': {
-    animation: `${closeAnimation} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
+  selectors: {
+    '&[data-state="entering"]': enterAnimationProps,
+    '&[data-state="entered"]': enterAnimationProps,
+    '&[data-state="exiting"]': {
+      animationName: closeAnimation,
+      animationDuration: ANIMATION_DURATION,
+      animationTimingFunction: animationEasing.acceleration,
+      animationFillMode: 'both'
+    }
   }
 }
 
@@ -189,6 +199,7 @@ const Dialog = memo(function Dialog({
     >
       {({ close, state }) => (
         <Pane
+          {...animationStyles}
           role="dialog"
           backgroundColor="white"
           elevation={4}
@@ -200,7 +211,7 @@ const Dialog = memo(function Dialog({
           marginY={topOffsetWithUnit}
           display="flex"
           flexDirection="column"
-          className={cx(css(animationStyles).toString(), containerClassName)}
+          className={containerClassName}
           data-state={state}
           {...remainingContainerProps}
         >

--- a/src/overlay/src/Overlay.js
+++ b/src/overlay/src/Overlay.js
@@ -1,9 +1,7 @@
 import React, { memo, useState, useEffect, useRef } from 'react'
-import cx from 'classnames'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
-import Box from 'ui-box'
+import Box, { keyframes } from 'ui-box'
 import { StackingOrder } from '../../constants'
 import preventBodyScroll from '../../lib/prevent-body-scroll'
 import safeInvoke from '../../lib/safe-invoke'
@@ -24,7 +22,7 @@ const animationEasing = {
 
 const ANIMATION_DURATION = 240
 
-const fadeInAnimation = css.keyframes('fadeInAnimation', {
+const fadeInAnimation = keyframes('fadeInAnimation', {
   from: {
     opacity: 0
   },
@@ -33,7 +31,7 @@ const fadeInAnimation = css.keyframes('fadeInAnimation', {
   }
 })
 
-const fadeOutAnimation = css.keyframes('fadeOutAnimation', {
+const fadeOutAnimation = keyframes('fadeOutAnimation', {
   from: {
     opacity: 1
   },
@@ -41,23 +39,37 @@ const fadeOutAnimation = css.keyframes('fadeOutAnimation', {
     opacity: 0
   }
 })
+
+const enterAnimationProps = {
+  animationName: fadeInAnimation,
+  animationDuration: ANIMATION_DURATION,
+  animationTimingFunction: animationEasing.deceleration,
+  animationFillMode: 'both'
+}
+
+const exitAnimationProps = {
+  animationName: fadeOutAnimation,
+  animationDuration: ANIMATION_DURATION,
+  animationTimingFunction: animationEasing.acceleration,
+  animationFillMode: 'both'
+}
 
 const animationStyles = backgroundColor => ({
-  '&::before': {
-    backgroundColor,
-    left: 0,
-    top: 0,
-    position: 'fixed',
-    display: 'block',
-    width: '100%',
-    height: '100%',
-    content: '" "'
-  },
-  '&[data-state="entering"]::before, &[data-state="entered"]::before': {
-    animation: `${fadeInAnimation} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
-  },
-  '&[data-state="exiting"]::before, &[data-state="exited"]::before': {
-    animation: `${fadeOutAnimation} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
+  selectors: {
+    '&::before': {
+      backgroundColor,
+      left: 0,
+      top: 0,
+      position: 'fixed',
+      display: 'block',
+      width: '100%',
+      height: '100%',
+      content: '" "'
+    },
+    '&[data-state="entering"]::before': enterAnimationProps,
+    '&[data-state="entered"]::before': enterAnimationProps,
+    '&[data-state="exiting"]::before': exitAnimationProps,
+    '&[data-state="exited"]::before': exitAnimationProps
   }
 })
 
@@ -267,7 +279,8 @@ const Overlay = memo(function Overlay({
                 zIndex={zIndex}
                 data-state={state}
                 {...containerProps}
-                className={cx(containerProps.className, css(animationStyles(colors.overlay)).toString())}
+                className={containerProps.className}
+                {...animationStyles(colors.overlay)}
               >
                 {typeof children === 'function' ? children({ state, close }) : children}
               </Box>

--- a/src/pulsar/src/Pulsar.js
+++ b/src/pulsar/src/Pulsar.js
@@ -1,19 +1,19 @@
 import React, { memo } from 'react'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
+import { keyframes } from 'ui-box'
 import Positions from '../../constants/src/Position'
 import { Pane } from '../../layers'
 import { majorScale } from '../../scales'
 import { useTheme } from '../../theme'
 
-const pulseAnimation = css.keyframes('pulseAnimation', {
-  '0%': {
+const pulseAnimation = keyframes('pulseAnimation', {
+  0: {
     transform: 'scale(1)'
   },
-  '50%': {
+  50: {
     transform: 'scale(1.9)'
   },
-  '100%': {
+  100: {
     transform: 'scale(1)'
   }
 })
@@ -21,9 +21,9 @@ const pulseAnimation = css.keyframes('pulseAnimation', {
 const animationTiming = 'cubic-bezier(0, 0, 0.58, 1)'
 const animationDuration = '1.8s'
 
-const pulsarAnimationClassName = css({
+const pularAnimationStyles = {
   animation: `${pulseAnimation} ${animationDuration} ${animationTiming} both infinite`
-}).toString()
+}
 
 const POSITION_KEYS = {
   [Positions.TOP_LEFT]: ['top', 'left'],
@@ -65,7 +65,7 @@ export const Pulsar = memo(({ position = Positions.TOP_RIGHT, size = majorScale(
       alignItems="center"
       justifyContent="center"
       padding={outerPadding}
-      className={pulsarAnimationClassName}
+      {...pularAnimationStyles}
       onClick={onClick}
       cursor={onClick ? 'pointer' : undefined}
       {...positionProps}

--- a/src/side-sheet/src/SheetClose.js
+++ b/src/side-sheet/src/SheetClose.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
-import Box from 'ui-box'
+import Box, { keyframes } from 'ui-box'
 import { Position } from '../../constants'
 import { CrossIcon } from '../../icons'
 
@@ -19,21 +18,27 @@ const sharedStyles = {
   cursor: 'pointer',
   backgroundColor: 'rgba(255, 255, 255, 0.4)',
   transition: 'background-color 120ms',
-  '&:hover': {
-    backgroundColor: 'rgba(255, 255, 255, 0.6)'
-  },
-  '&:active': {
-    backgroundColor: 'rgba(255, 255, 255, 0.4)'
+  selectors: {
+    '&:hover': {
+      backgroundColor: 'rgba(255, 255, 255, 0.6)'
+    },
+    '&:active': {
+      backgroundColor: 'rgba(255, 255, 255, 0.4)'
+    }
   }
 }
 
 const withAnimations = (animateIn, animateOut) => {
+  const enterAnimation = {
+    animation: `${animateIn} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
+  }
   return {
-    '&[data-state="entering"], &[data-state="entered"]': {
-      animation: `${animateIn} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
-    },
-    '&[data-state="exiting"]': {
-      animation: `${animateOut} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
+    selectors: {
+      '&[data-state="entering"]': enterAnimation,
+      '&[data-state="entered"]': enterAnimation,
+      '&[data-state="exiting"]': {
+        animation: `${animateOut} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
+      }
     }
   }
 }
@@ -45,11 +50,11 @@ const sheetCloseStyles = {
     marginTop: 12,
     transform: 'translateX(-100%)',
     ...withAnimations(
-      css.keyframes('rotate360InAnimation', {
+      keyframes('rotate360InAnimation', {
         from: { transform: 'translateX(100%) rotate(0deg)' },
         to: { transform: 'translateX(-100%) rotate(-360deg)' }
       }),
-      css.keyframes('rotate360OutAnimation', {
+      keyframes('rotate360OutAnimation', {
         from: { transform: 'translateX(-100%) rotate(0deg)' },
         to: { transform: 'translateX(100%) rotate(360deg)' }
       })
@@ -61,11 +66,11 @@ const sheetCloseStyles = {
     marginTop: 12,
     transform: 'translateX(100%)',
     ...withAnimations(
-      css.keyframes('leftRotate360InAnimation', {
+      keyframes('leftRotate360InAnimation', {
         from: { transform: 'translateX(-100%) rotate(0deg)' },
         to: { transform: 'translateX(100%), rotate(360deg)' }
       }),
-      css.keyframes('leftRotate360OutAnimation', {
+      keyframes('leftRotate360OutAnimation', {
         from: { transform: 'translateX(100%) rotate(0deg)' },
         to: { transform: 'translateX(-100%), rotate(360deg)' }
       })
@@ -78,11 +83,11 @@ const sheetCloseStyles = {
     marginTop: 12,
     transform: 'translateY(0)',
     ...withAnimations(
-      css.keyframes('topRotate360InAnimation', {
+      keyframes('topRotate360InAnimation', {
         from: { transform: 'translateY(-200%) rotate(0deg)' },
         to: { transform: 'translateY(0%), rotate(360deg)' }
       }),
-      css.keyframes('topRotate360OutAnimation', {
+      keyframes('topRotate360OutAnimation', {
         from: { transform: 'translateY(0%) rotate(0deg)' },
         to: { transform: 'translateY(-200%), rotate(360deg)' }
       })
@@ -95,29 +100,16 @@ const sheetCloseStyles = {
     marginBottom: 12,
     transform: 'translateY(0)',
     ...withAnimations(
-      css.keyframes('bottomRotate360InAnimation', {
+      keyframes('bottomRotate360InAnimation', {
         from: { transform: 'translateY(200%) rotate(0deg)' },
         to: { transform: 'translateY(0%), rotate(360deg)' }
       }),
-      css.keyframes('bottomRotate360OutAnimation', {
+      keyframes('bottomRotate360OutAnimation', {
         from: { transform: 'translateY(0%) rotate(0deg)' },
         to: { transform: 'translateY(200%), rotate(360deg)' }
       })
     )
   }
-}
-
-const sheetCloseClassNameCache = {}
-
-const getSheetCloseClassName = position => {
-  if (!sheetCloseClassNameCache[position]) {
-    sheetCloseClassNameCache[position] = css({
-      ...sheetCloseStyles[position],
-      ...sharedStyles
-    }).toString()
-  }
-
-  return sheetCloseClassNameCache[position]
 }
 
 export default class SheetClose extends PureComponent {
@@ -136,7 +128,8 @@ export default class SheetClose extends PureComponent {
         display="flex"
         alignItems="center"
         justifyContent="center"
-        className={getSheetCloseClassName(position)}
+        {...sheetCloseStyles[position]}
+        {...sharedStyles}
         {...props}
       >
         <CrossIcon color="#fff" />

--- a/src/side-sheet/src/SideSheet.js
+++ b/src/side-sheet/src/SideSheet.js
@@ -1,6 +1,6 @@
 import React, { memo } from 'react'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
+import { keyframes } from 'ui-box'
 import { Position } from '../../constants'
 import { Pane } from '../../layers'
 import { Overlay } from '../../overlay'
@@ -60,12 +60,17 @@ const animationEasing = {
 const ANIMATION_DURATION = 240
 
 const withAnimations = (animateIn, animateOut) => {
+  const enterAnimation = {
+    animation: `${animateIn} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
+  }
+
   return {
-    '&[data-state="entering"], &[data-state="entered"]': {
-      animation: `${animateIn} ${ANIMATION_DURATION}ms ${animationEasing.deceleration} both`
-    },
-    '&[data-state="exiting"]': {
-      animation: `${animateOut} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
+    selectors: {
+      '&[data-state="entering"]': enterAnimation,
+      '&[data-state="entered"]': enterAnimation,
+      '&[data-state="exiting"]': {
+        animation: `${animateOut} ${ANIMATION_DURATION}ms ${animationEasing.acceleration} both`
+      }
     }
   }
 }
@@ -74,11 +79,11 @@ const animationStylesClass = {
   [Position.LEFT]: {
     transform: 'translateX(-100%)',
     ...withAnimations(
-      css.keyframes('anchoredLeftSlideInAnimation', {
+      keyframes('anchoredLeftSlideInAnimation', {
         from: { transform: 'translateX(-100%)' },
         to: { transform: 'translateX(0)' }
       }),
-      css.keyframes('anchoredLeftSlideOutAnimation', {
+      keyframes('anchoredLeftSlideOutAnimation', {
         from: { transform: 'translateX(0)' },
         to: { transform: 'translateX(-100%)' }
       })
@@ -87,11 +92,11 @@ const animationStylesClass = {
   [Position.RIGHT]: {
     transform: 'translateX(100%)',
     ...withAnimations(
-      css.keyframes('anchoredRightSlideInAnimation', {
+      keyframes('anchoredRightSlideInAnimation', {
         from: { transform: 'translateX(100%)' },
         to: { transform: 'translateX(0)' }
       }),
-      css.keyframes('anchoredRightSlideOutAnimation', {
+      keyframes('anchoredRightSlideOutAnimation', {
         from: { transform: 'translateX(0)' },
         to: { transform: 'translateX(100%)' }
       })
@@ -100,11 +105,11 @@ const animationStylesClass = {
   [Position.TOP]: {
     transform: 'translateY(-100%)',
     ...withAnimations(
-      css.keyframes('anchoredTopSlideInAnimation', {
+      keyframes('anchoredTopSlideInAnimation', {
         from: { transform: 'translateY(-100%)' },
         to: { transform: 'translateY(0)' }
       }),
-      css.keyframes('anchoredTopSlideOutAnimation', {
+      keyframes('anchoredTopSlideOutAnimation', {
         from: { transform: 'translateY(0)' },
         to: { transform: 'translateY(-100%)' }
       })
@@ -113,11 +118,11 @@ const animationStylesClass = {
   [Position.BOTTOM]: {
     transform: 'translateY(100%)',
     ...withAnimations(
-      css.keyframes('anchoredBottomSlideInAnimation', {
+      keyframes('anchoredBottomSlideInAnimation', {
         from: { transform: 'translateY(100%)' },
         to: { transform: 'translateY(0)' }
       }),
-      css.keyframes('anchoredBottomSlideOutAnimation', {
+      keyframes('anchoredBottomSlideOutAnimation', {
         from: { transform: 'translateY(0)' },
         to: { transform: 'translateY(100%)' }
       })
@@ -155,12 +160,7 @@ const SideSheet = memo(function SideSheet(props) {
       preventBodyScrolling={preventBodyScrolling}
     >
       {({ close, state }) => (
-        <Pane
-          width={width}
-          {...paneProps[position]}
-          className={css(animationStylesClass[position]).toString()}
-          data-state={state}
-        >
+        <Pane width={width} {...paneProps[position]} {...animationStylesClass[position]} data-state={state}>
           <SheetClose position={position} data-state={state} isClosing={false} onClick={close} />
           <Pane
             elevation={4}

--- a/src/spinner/src/Spinner.js
+++ b/src/spinner/src/Spinner.js
@@ -28,6 +28,7 @@ const outerClass = css({
 
 const innerClass = color =>
   css({
+    // TODO: stroke* props are not yet supported in ui-box
     strokeDashoffset: 600,
     strokeDasharray: 300,
     strokeWidth: 12,

--- a/src/switch/src/Switch.js
+++ b/src/switch/src/Switch.js
@@ -1,5 +1,4 @@
 import React, { memo, forwardRef } from 'react'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import Box, { spacing, position, layout } from 'ui-box'
 import { useStyleConfig } from '../../hooks'
@@ -8,12 +7,7 @@ const animationEasing = {
   spring: 'cubic-bezier(0.175, 0.885, 0.320, 1.175)'
 }
 
-const handleStyleClass = css({
-  backgroundColor: '#fff',
-  borderRadius: 9999
-}).toString()
-
-const iconContainerStyleClass = css({
+const iconContainerStyles = {
   transition: `all 500ms ${animationEasing.spring}`,
   opacity: 0,
   display: 'flex',
@@ -21,26 +15,30 @@ const iconContainerStyleClass = css({
   alignItems: 'center',
   justifyContent: 'center',
   paddingLeft: 4,
-  '&[data-checked="true"]': {
-    opacity: 1,
-    transform: 'scale(1)'
-  },
-  '> svg': {
-    transition: `all 500ms ${animationEasing.spring}`,
-    transform: 'scale(0)'
-  },
-  '&[data-checked="true"] > svg': {
-    transform: 'scale(1)'
+  selectors: {
+    '&[data-checked="true"]': {
+      opacity: 1,
+      transform: 'scale(1)'
+    },
+    '> svg': {
+      transition: `all 500ms ${animationEasing.spring}`,
+      transform: 'scale(0)'
+    },
+    '&[data-checked="true"] > svg': {
+      transform: 'scale(1)'
+    }
   }
-}).toString()
+}
 
-const handleContainerStyleClass = css({
+const handleContainerStyles = {
   transition: 'transform 200ms ease-in-out',
   transform: 'translateX(0%)',
-  '&[data-checked="true"]': {
-    transform: 'translateX(50%)'
+  selectors: {
+    '&[data-checked="true"]': {
+      transform: 'translateX(50%)'
+    }
   }
-}).toString()
+}
 
 const CheckIcon = memo(function CheckIcon({ fill = 'currentColor', size, ...props }) {
   return (
@@ -83,10 +81,12 @@ const internalStyles = {
   whiteSpace: 'nowrap',
   width: '1px',
   opacity: '0',
-  '& + div > svg': { display: 'none' },
+  selectors: {
+    '& + div > svg': { display: 'none' },
 
-  [pseudoSelectors._base]: {
-    transition: 'all 120ms ease-in-out'
+    [pseudoSelectors._base]: {
+      transition: 'all 120ms ease-in-out'
+    }
   }
 }
 
@@ -127,12 +127,12 @@ const Switch = memo(
           onChange={onChange}
         />
         <Box height={height} width={height * 2} borderRadius={9999} cursor="pointer">
-          <Box height={height} width={height} data-checked={checked} className={iconContainerStyleClass}>
+          <Box height={height} width={height} data-checked={checked} {...iconContainerStyles}>
             {hasCheckIcon && <CheckIcon display={checked ? 'block' : undefined} size={height / 2 - 3} />}
           </Box>
-          <Box width={height * 2} display="flex" data-checked={checked} className={handleContainerStyleClass}>
+          <Box width={height * 2} display="flex" data-checked={checked} {...handleContainerStyles}>
             <Box flex={1} padding={2}>
-              <Box width={height - 4} height={height - 4} className={handleStyleClass} />
+              <Box width={height - 4} height={height - 4} backgroundColor="#fff" borderRadius={9999} />
             </Box>
           </Box>
         </Box>

--- a/src/toaster/src/Toast.js
+++ b/src/toaster/src/Toast.js
@@ -1,8 +1,7 @@
 import React, { memo, useMemo, useRef, useState, useEffect, useCallback } from 'react'
-import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
-import Box from 'ui-box'
+import Box, { keyframes } from 'ui-box'
 import Alert from '../../alert/src/Alert'
 
 const animationEasing = {
@@ -13,7 +12,7 @@ const animationEasing = {
 
 const ANIMATION_DURATION = 240
 
-const openAnimation = css.keyframes('openAnimation', {
+const openAnimation = keyframes('openAnimation', {
   from: {
     opacity: 0,
     transform: 'translateY(-120%)'
@@ -23,7 +22,7 @@ const openAnimation = css.keyframes('openAnimation', {
   }
 })
 
-const closeAnimation = css.keyframes('closeAnimation', {
+const closeAnimation = keyframes('closeAnimation', {
   from: {
     transform: 'scale(1)',
     opacity: 1
@@ -34,19 +33,30 @@ const closeAnimation = css.keyframes('closeAnimation', {
   }
 })
 
-const animationStyles = css({
+const enterAnimationProps = {
+  animationName: openAnimation,
+  animationDuration: ANIMATION_DURATION,
+  animationTimingFunction: animationEasing.spring,
+  animationFillMode: 'both'
+}
+
+const animationStyles = {
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   height: 0,
   transition: `all ${ANIMATION_DURATION}ms ${animationEasing.deceleration}`,
-  '&[data-state="entering"], &[data-state="entered"]': {
-    animation: `${openAnimation} ${ANIMATION_DURATION}ms ${animationEasing.spring} both`
-  },
-  '&[data-state="exiting"]': {
-    animation: `${closeAnimation} 120ms ${animationEasing.acceleration} both`
+  selectors: {
+    '&[data-state="entering"]': enterAnimationProps,
+    '&[data-state="entered"]': enterAnimationProps,
+    '&[data-state="exiting"]': {
+      animationName: closeAnimation,
+      animationDuration: 120,
+      animationTimingFunction: animationEasing.acceleration,
+      animationFillMode: 'both'
+    }
   }
-})
+}
 
 const Toast = memo(function Toast(props) {
   const {
@@ -130,13 +140,15 @@ const Toast = memo(function Toast(props) {
       onExited={onRemove}
     >
       {state => (
-        <div
+        <Box
+          {...animationStyles}
           ref={transitionRef}
           data-state={state}
-          className={animationStyles}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
-          style={styles}
+          // Styles object needs to be spread after animationStyles, otherwise the height/zIndex is overridden
+          // and earlier toasts will not be pushed down in the viewport
+          {...styles}
         >
           <Box ref={onRef} padding={8}>
             <Alert
@@ -152,7 +164,7 @@ const Toast = memo(function Toast(props) {
               {children}
             </Alert>
           </Box>
-        </div>
+        </Box>
       )}
     </Transition>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -14012,10 +14012,10 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
-ui-box@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.2.1.tgz#b38a583ed1951c6bfe547af3cdd744cb9c8da710"
-  integrity sha512-ZxiZSOTuvG9K3DAy+J9kcN2bBW9+pzg4pZOrMHcL8PsHu6S7MtOfJUjxqiBPaoHuGy8w5cn9W8leUC15D3Fw+A==
+ui-box@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.3.0.tgz#f2b9e2450f93a09e06e8dae8d16327ac5cc26811"
+  integrity sha512-9eu83GoUoqyzsKuF/JZ99PlCwkkyncIWrUQDykan5AAz93wbhlRWaIJoIY4ufxilhSIyE8lgBWSMhzRu74NseA==
   dependencies:
     "@emotion/hash" "^0.7.1"
     inline-style-prefixer "^5.0.4"


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

This PR is a follow-up to the last (#1543), which leverages the new `keyframes` function from `ui-box@5.3.0` to rip out more glamor references. 


There are ~3 references remaining that will probably require a breaking change in the `Positioner` component (which passes a `css` object as render props to the child), as well as a change in `useStyleConfig` that splits out compatible `Box` props and sends the rest to `css` from `glamor`. I'm thinking we'll need to construct a `style` object and pass that along. There will probably need to be some more rugged testing to make sure that those changes still work as intended. But as far as these changes, they should more or less be 1:1 to what is currently working.


**Screenshots (if applicable)**

The components that have been changed can be compared side-by-side with the production Storybook instance:

| Production                                                                                         | Branch                                                                                                                  | Reviewed |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- |
| [Corner Dialog](https://evergreen-storybook.netlify.app/?path=/story/corner-dialog--cornerdialog)  | [Corner Dialog](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/corner-dialog--cornerdialog)  | ✅       |
| [Dialog](https://evergreen-storybook.netlify.app/?path=/story/dialog--dialog)                      | [Dialog](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/dialog--dialog)                      | ✅       |
| [Overlay](https://evergreen-storybook.netlify.app/?path=/story/overlay--overlay)                   | [Overlay](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/overlay--overlay)                   | ✅       |
| [Pulsar](https://evergreen-storybook.netlify.app/?path=/story/nudge--pulsar)                       | [Pulsar](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/nudge--pulsar)                       | ✅       |
| [SideSheet](https://evergreen-storybook.netlify.app/?path=/story/side-sheet--title-sub-title-tabs) | [SideSheet](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/side-sheet--title-sub-title-tabs) | ✅       |
| [Switch](https://evergreen-storybook.netlify.app/?path=/story/switch--switch)                      | [Switch](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/switch--switch)                      | ✅       |
| [Toast](https://evergreen-storybook.netlify.app/?path=/story/toaster--examples)                    | [Toast](https://deploy-preview-1547--evergreen-storybook.netlify.app/?path=/story/toaster--examples)                    | ✅       |


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
