### PR TITLE
Convert Portal to functional component, properly remove DOM element on unmount

### DIFF
--- a/src/portal/__tests__/Portal.test.js
+++ b/src/portal/__tests__/Portal.test.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Portal from '../src/Portal'
+
+describe('Portal', () => {
+  it('should append container to document body', () => {
+    render(<div>children</div>)
+    render(<Portal>children</Portal>)
+
+    const elements = screen.getAllByText('children')
+
+    expect(elements[1]).toHaveAttribute('evergreen-portal-container')
+  })
+
+  it('should render children', () => {
+    render(
+      <Portal>
+        <span data-testid="children">Hello world</span>
+      </Portal>
+    )
+
+    const children = screen.getByTestId('children')
+
+    expect(children).toHaveTextContent('Hello world')
+    expect(children.parentNode).toHaveAttribute('evergreen-portal-container')
+  })
+
+  it('should remove DOM element when unmounted', () => {
+    const { unmount } = render(<Portal>children</Portal>)
+
+    unmount()
+
+    expect(screen.queryByText('children')).toBeNull()
+    expect(document.querySelector('[evergreen-portal-container]')).toBeNull()
+  })
+})

--- a/src/portal/src/Portal.js
+++ b/src/portal/src/Portal.js
@@ -1,40 +1,37 @@
-import { Component } from 'react'
+import { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
-import ReactDOM from 'react-dom'
-import canUseDom from '../../lib/canUseDom'
+import { createPortal } from 'react-dom'
+import { useIsomorphicLayoutEffect } from '../../hooks'
 
-let portalContainer
+// Based on https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/Portal/Portal.tsx
+const Portal = props => {
+  const { children } = props
 
-export default class Portal extends Component {
-  constructor() {
-    super()
+  const [mounted, setMounted] = useState(false)
+  const ref = useRef()
 
-    // This fixes SSR
-    if (!canUseDom) return
+  useIsomorphicLayoutEffect(() => {
+    setMounted(true)
 
-    if (!portalContainer) {
-      portalContainer = document.createElement('div')
-      portalContainer.setAttribute('evergreen-portal-container', '')
-      document.body.appendChild(portalContainer)
+    ref.current = document.createElement('div')
+    ref.current.setAttribute('evergreen-portal-container', '')
+
+    document.body.appendChild(ref.current)
+
+    return () => {
+      document.body.removeChild(ref.current)
     }
+  }, [])
+
+  if (!mounted) {
+    return null
   }
 
-  componentDidMount() {
-    this.el = document.createElement('div')
-    portalContainer.appendChild(this.el)
-    this.forceUpdate()
-  }
-
-  componentWillUnmount() {
-    portalContainer.removeChild(this.el)
-  }
-
-  render() {
-    if (!this.el) return null
-    return ReactDOM.createPortal(this.props.children, this.el)
-  }
+  return createPortal(children, ref.current)
 }
 
 Portal.propTypes = {
   children: PropTypes.node.isRequired
 }
+
+export default Portal


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Resolves #1365

This PR implements proper cleanup for the container div that we create for the Portal component, refactors it to a functional component, and adds some test coverage for it. Note: This should maintain SSR compatibility (only attempts to run `createPortal` once the `useEffect` has been run on the client)

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
