### PR TITLE
Tooltip: User defined id for aria-describedBy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3114,7 +3114,7 @@ export interface TooltipProps {
   /**
    * The id of the tooltip.
    */
-  id: string,
+  id?: string
   /**
    * The position the Tooltip is on.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -3112,6 +3112,10 @@ export interface TooltipProps {
    */
   appearance?: TooltipAppearance
   /**
+   * The id of the tooltip.
+   */
+  id: string,
+  /**
    * The position the Tooltip is on.
    */
   position?: PositionTypes

--- a/src/tooltip/src/Tooltip.js
+++ b/src/tooltip/src/Tooltip.js
@@ -22,7 +22,7 @@ const Tooltip = memo(function Tooltip(props) {
     statelessProps = emptyProps
   } = props
 
-  const id = useId('evergreen-tooltip')
+  const id = useId('evergreen-tooltip', props.id)
   const [isShown, setIsShown] = useState(propIsShown || false)
   const [isShownByTarget, setIsShownByTarget] = useState(false)
   const closeTimer = useRef(undefined)
@@ -152,6 +152,11 @@ Tooltip.propTypes = {
    * The appearance of the tooltip.
    */
   appearance: PropTypes.oneOf(['default', 'card']),
+
+  /**
+   * The id of the tooltip.
+   */
+  id: PropTypes.string,
 
   /**
    * The position the Popover is on.


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Using the tooltip in SSR (server-side rendering) applications cause an ugly error due to render comparison.
```
Warning: Prop `aria-describedby` did not match. Server: "evergreen-tooltip-40" Client: "evergreen-tooltip-2"
```

* Resolves #842

**Documentation**
- [X] Updated Typescript types and/or component PropTypes
- [X] Added / modified component docs
