### PR TITLE
Forward ref and box props to Pulsar to fix Tooltip rendering

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2058,22 +2058,19 @@ export type PreOwnProps = TextOwnProps
 export type PreProps = PolymorphicBoxProps<'pre', PreOwnProps>
 export declare const Pre: BoxComponent<PreOwnProps, 'pre'>
 
-export interface PulsarProps {
+export interface PulsarOwnProps {
   /**
-   * The position the Tooltip is on.
+   * The position the pulsar is displayed
    */
   position?: Exclude<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
   /**
    * The size of the pulsar
    */
   size?: number
-  /**
-   * Called when the Pulsar is clicked
-   */
-  onClick?: PaneProps['onClick']
 }
 
-export declare const Pulsar: React.FC<PulsarProps>
+export type PulsarProps = PolymorphicBoxProps<'div', PulsarOwnProps>
+export declare const Pulsar: BoxComponent<PulsarOwnProps, 'div'>
 
 export interface RadioOwnProps {
   /**

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "size": "size-limit",
     "storybook": "start-storybook -p 6006",
     "test": "yarn lint && yarn tsd && yarn jest",
-    "test:watch": "yarn run test -- --watch",
+    "test:watch": "yarn jest --watch",
     "update-docs": "cd docs && yarn add evergreen-ui@latest --exact && git add package.json yarn.lock && git show-branch --no-name HEAD | grep -E 'v[0-9]+.[0-9]+.[0-9]+' && git commit --amend --no-edit || git commit -m \"Updated doc site evergreen version\""
   },
   "engines": {

--- a/src/pulsar/__tests__/Pulsar.test.js
+++ b/src/pulsar/__tests__/Pulsar.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { mockRef } from '../../test/utils'
+import { Tooltip } from '../../tooltip'
+import { Pulsar } from '../src/Pulsar'
+
+const makePulsarFixture = (props = {}) => <Pulsar data-testid="Pulsar" {...props} />
+
+describe('Pulsar', () => {
+  it('should forward ref', () => {
+    const ref = mockRef()
+
+    render(makePulsarFixture({ ref }))
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+
+  it('should forward box props', () => {
+    const backgroundColor = 'red'
+
+    render(makePulsarFixture({ backgroundColor }))
+
+    expect(screen.getByTestId('Pulsar')).toHaveStyle({ backgroundColor })
+  })
+
+  it('should render Tooltip when wrapped and hovered', () => {
+    render(<Tooltip content="Hello world">{makePulsarFixture()}</Tooltip>)
+
+    userEvent.hover(screen.getByTestId('Pulsar'))
+
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+  })
+})

--- a/src/pulsar/src/Pulsar.js
+++ b/src/pulsar/src/Pulsar.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { keyframes } from 'ui-box'
 import Positions from '../../constants/src/Position'
@@ -21,7 +21,7 @@ const pulseAnimation = keyframes('pulseAnimation', {
 const animationTiming = 'cubic-bezier(0, 0, 0.58, 1)'
 const animationDuration = '1.8s'
 
-const pularAnimationStyles = {
+const pulsarAnimationStyles = {
   animation: `${pulseAnimation} ${animationDuration} ${animationTiming} both infinite`
 }
 
@@ -49,31 +49,35 @@ const getPositionProps = ({ position, size }) => {
   return props
 }
 
-export const Pulsar = memo(({ position = Positions.TOP_RIGHT, size = majorScale(1), onClick }) => {
-  const { colors } = useTheme()
-  const positionProps = getPositionProps({ position, size })
-  const outerPadding = size * 0.25
+export const Pulsar = memo(
+  forwardRef(({ position = Positions.TOP_RIGHT, size = majorScale(1), onClick, ...rest }, ref) => {
+    const { colors } = useTheme()
+    const positionProps = getPositionProps({ position, size })
+    const outerPadding = size * 0.25
 
-  return (
-    <Pane
-      position="absolute"
-      borderRadius="50%"
-      backgroundColor={colors.blue100}
-      boxSizing="content-box"
-      opacity={0.7}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      padding={outerPadding}
-      {...pularAnimationStyles}
-      onClick={onClick}
-      cursor={onClick ? 'pointer' : undefined}
-      {...positionProps}
-    >
-      <Pane width={size} height={size} backgroundColor={colors.blue200} borderRadius="50%" opacity={0.7} />
-    </Pane>
-  )
-})
+    return (
+      <Pane
+        ref={ref}
+        position="absolute"
+        borderRadius="50%"
+        backgroundColor={colors.blue100}
+        boxSizing="content-box"
+        opacity={0.7}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        padding={outerPadding}
+        {...pulsarAnimationStyles}
+        onClick={onClick}
+        cursor={onClick ? 'pointer' : undefined}
+        {...positionProps}
+        {...rest}
+      >
+        <Pane width={size} height={size} backgroundColor={colors.blue200} borderRadius="50%" opacity={0.7} />
+      </Pane>
+    )
+  })
+)
 
 Pulsar.propTypes = {
   /**

--- a/src/pulsar/src/Pulsar.js
+++ b/src/pulsar/src/Pulsar.js
@@ -1,6 +1,6 @@
 import React, { memo, forwardRef } from 'react'
 import PropTypes from 'prop-types'
-import { keyframes } from 'ui-box'
+import Box, { keyframes } from 'ui-box'
 import Positions from '../../constants/src/Position'
 import { Pane } from '../../layers'
 import { majorScale } from '../../scales'
@@ -81,6 +81,11 @@ export const Pulsar = memo(
 
 Pulsar.propTypes = {
   /**
+   * Composes the Box component as the base.
+   */
+  ...Box.propTypes,
+
+  /**
    * The position of the pulsar
    */
   position: PropTypes.oneOf([Positions.TOP_LEFT, Positions.TOP_RIGHT, Positions.BOTTOM_LEFT, Positions.BOTTOM_RIGHT]),
@@ -88,10 +93,5 @@ Pulsar.propTypes = {
   /**
    * The width/height of the dot
    */
-  size: PropTypes.number,
-
-  /**
-   * Called when the Pulsar is clicked
-   */
-  onClick: PropTypes.func
+  size: PropTypes.number
 }

--- a/src/pulsar/stories/index.stories.js
+++ b/src/pulsar/stories/index.stories.js
@@ -5,6 +5,7 @@ import { Button } from '../../buttons'
 import Position from '../../constants/src/Position'
 import { Popover } from '../../popover'
 import { minorScale } from '../../scales'
+import { Tooltip } from '../../tooltip'
 import { Link, Text } from '../../typography'
 import { Nudge } from '../src/Nudge'
 import { Pulsar } from '../src/Pulsar'
@@ -81,6 +82,12 @@ storiesOf('nudge', module)
       <Box position="relative" display="inline-block">
         <Box>Pulsar Custom Size</Box>
         <Pulsar size={4} />
+      </Box>
+      <Box position="relative">
+        <Box>Pulsar with Tooltip</Box>
+        <Tooltip content="Hello world">
+          <Pulsar />
+        </Tooltip>
       </Box>
     </Box>
   ))


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

This PR resolves the issue described in #1564 where `Tooltip`s aren't being rendered when wrapping the `Pulsar` component. The ts definitions/prop types have been updated to reflect that `Box` props can be forwarded to the top-level `Pane`.

**Screenshots (if applicable)**

![ezgif com-gif-maker](https://user-images.githubusercontent.com/11774799/205511761-6f4a4b06-1a46-442d-aaf7-effd02390d78.gif)


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [x] Added / modified Storybook stories
