### PR TITLE
Update ui-box from 5.3.0 to 5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.1",
     "tinycolor2": "^1.4.1",
-    "ui-box": "^5.3.0"
+    "ui-box": "^5.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/src/alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/src/alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -10,7 +10,7 @@ exports[`<Alert /> appearance snapshot 1`] = `
       class="ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
     >
       <svg
-        class="css-1ffn9ia ub-w_16px ub-h_16px ub-box-szg_border-box"
+        class="ub-fill_3366FF ub-w_16px ub-h_16px ub-box-szg_border-box"
         data-icon="info-sign"
         viewBox="0 0 16 16"
       >
@@ -46,7 +46,7 @@ exports[`<Alert /> basic snapshot 1`] = `
       class="ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
     >
       <svg
-        class="css-1ffn9ia ub-w_16px ub-h_16px ub-box-szg_border-box"
+        class="ub-fill_3366FF ub-w_16px ub-h_16px ub-box-szg_border-box"
         data-icon="info-sign"
         viewBox="0 0 16 16"
       >
@@ -82,7 +82,7 @@ exports[`<Alert /> intent snapshot 1`] = `
       class="ub-mr_16px ub-ml_2px ub-mt_-1px ub-dspl_flex ub-algn-itms_flex-start ub-box-szg_border-box"
     >
       <svg
-        class="css-tn1wco ub-w_16px ub-h_16px ub-box-szg_border-box"
+        class="ub-fill_D14343 ub-w_16px ub-h_16px ub-box-szg_border-box"
         data-icon="error"
         viewBox="0 0 16 16"
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -14012,10 +14012,10 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
-ui-box@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.3.0.tgz#f2b9e2450f93a09e06e8dae8d16327ac5cc26811"
-  integrity sha512-9eu83GoUoqyzsKuF/JZ99PlCwkkyncIWrUQDykan5AAz93wbhlRWaIJoIY4ufxilhSIyE8lgBWSMhzRu74NseA==
+ui-box@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.4.0.tgz#707c764fdf4be79cf2f50f356ca9583a491164ee"
+  integrity sha512-HuiJKUIOGW/I1VF7EgHl5/3OwywPdV5fwzsDOWfCGS/PORmXOyGetL3gJo9EQJZZZCkui9xf3a/UQhawA88yeQ==
   dependencies:
     "@emotion/hash" "^0.7.1"
     inline-style-prefixer "^5.0.4"


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

This PR updates `ui-box` from 5.3.0 to [5.4.0](https://github.com/segmentio/ui-box/releases/tag/v5.4.0), which includes bug fixes, additional selector support and exports some additional types. 

I don't think the selector uniqueness issue described in https://github.com/segmentio/ui-box/issues/126 is present in Evergreen at this point, but we should upgrade to be safe anyway.


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
