### PR TITLE
Cancel animation frame on component unmount to avoid memory leaks

### DIFF
--- a/src/table/src/TableVirtualBody.js
+++ b/src/table/src/TableVirtualBody.js
@@ -1,4 +1,4 @@
-import React, { memo, useState, useEffect } from 'react'
+import React, { memo, useState, useEffect, useRef } from 'react'
 import VirtualList from '@segment/react-tiny-virtual-list'
 import debounce from 'lodash.debounce'
 import PropTypes from 'prop-types'
@@ -29,6 +29,7 @@ const TableVirtualBody = memo(function TableVirtualBody(props) {
   const [paneRef, setPaneRef] = useState()
   const [isIntegerHeight, setIsIntegerHeight] = useState(false)
   const [calculatedHeight, setCalculatedHeight] = useState(0)
+  const requestId = useRef(null)
 
   const updateOnResize = () => {
     autoHeights = []
@@ -52,7 +53,7 @@ const TableVirtualBody = memo(function TableVirtualBody(props) {
     }
 
     // When height is still 0 (or paneRef is not valid) try recursively until success.
-    requestAnimationFrame(() => {
+    requestId.current = requestAnimationFrame(() => {
       updateOnResize()
     })
   }
@@ -80,6 +81,7 @@ const TableVirtualBody = memo(function TableVirtualBody(props) {
 
     return () => {
       window.removeEventListener('resize', onResize)
+      cancelAnimationFrame(requestId.current)
     }
   }, [])
 


### PR DESCRIPTION
**Overview**
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in renowned SPA applications. 
While running the tool and analyzing the code of Evergreen, we saw that it does a very good job of ensuring that all async operations are cancelled when the component unmounts. However, as per Memlab execution results, we found that the cancellation of requestAnimationFrames is forgotten at certain places (TableVirtualBody being one of them) and was causing the memory to leak (screenshots below).

**Screenshots**
[before]
<img width="735" alt="Screen Shot 2023-01-22 at 6 44 55 PM" src="https://user-images.githubusercontent.com/56495631/213909807-2c69f67e-2c18-4fc7-b146-d9cb52699f0b.png">

<img width="917" alt="Screen Shot 2023-01-22 at 6 45 22 PM" src="https://user-images.githubusercontent.com/56495631/213909816-a6bcfcfa-b753-448e-bce0-bc726f2b0eda.png">
<br /><br />



Hence we added the fix by cancelling the frameRequest and you can see the heap size and # of leaks reducing noticeably:

<img width="699" alt="Screen Shot 2023-01-22 at 6 50 05 PM" src="https://user-images.githubusercontent.com/56495631/213909823-1947218b-f0b5-4a2c-a096-8acc84d77a0e.png">

<img width="674" alt="Screen Shot 2023-01-22 at 6 50 19 PM" src="https://user-images.githubusercontent.com/56495631/213909827-9e793ff7-4fa9-448b-b5a4-3c2742acd623.png">


You can test this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.
Following is a sample of the scenario file we used: 
[evergreen-scenario-memlab.txt](https://github.com/segmentio/evergreen/files/10474132/evergreen-scenario-memlab.txt)


Note that some other reported leaks originate from the Storybook library, hence ignored.
