### PR TITLE
Update doc site to handle typescript files

### DIFF
--- a/docs/components/PropsTable.tsx
+++ b/docs/components/PropsTable.tsx
@@ -26,7 +26,7 @@ type PropType =
       value: PropType[]
     }
   | {
-      name: 'custom'
+      name: 'custom' | 'signature'
       raw: string
     }
 
@@ -87,6 +87,7 @@ const resolveReadableType = (type: PropType | undefined): string => {
     case 'union':
       return type.value.map((subType: PropType) => resolveReadableType(subType)).join(' | ')
     case 'custom':
+    case 'signature':
       return type.raw
     default:
       return (type as { name: string }).name

--- a/docs/components/PropsTable.tsx
+++ b/docs/components/PropsTable.tsx
@@ -3,23 +3,34 @@ import { Table, Pane, majorScale, Paragraph, Badge, Text, Heading } from 'evergr
 import InlineCode from './MDX/renderers/InlineCode'
 
 interface Props {
-  data: any
-}
-
-const resolveReadableType: (type: any) => string = (type) => {
-  switch (type.name) {
-    case 'enum':
-      return type.value.map(({ value }: { value: string }) => value).join(' | ')
-    case 'union':
-      return type.value.map((subType: any) => resolveReadableType(subType)).join(' | ')
-    case 'custom':
-      return type.raw
-    default:
-      return type.name
+  data: {
+    displayName: string
+    props: Record<string, PropDefinition>
   }
 }
 
-const COLUMNS = ['Property', 'Type', 'Description'] as const
+interface PropDefinition {
+  description: string
+  required: boolean
+  type?: PropType
+  tsType?: PropType
+}
+
+type PropType =
+  | {
+      name: 'enum'
+      value: Array<{ value: string }>
+    }
+  | {
+      name: 'union'
+      value: PropType[]
+    }
+  | {
+      name: 'custom'
+      raw: string
+    }
+
+const COLUMNS = ['Property', 'Type', 'Description']
 
 const PropsTable: React.FC<Props> = ({ data }) => {
   const { displayName, props } = data
@@ -38,18 +49,17 @@ const PropsTable: React.FC<Props> = ({ data }) => {
           </Table.Head>
           <Table.Body>
             {Object.keys(props).map((prop) => {
-              const { type, required, description } = props[prop]
+              const { type, tsType, required, description } = props[prop]
               return (
                 <Table.Row key={prop} minHeight={64} height="unset" paddingY={majorScale(2)}>
                   <Table.Cell>
                     <Pane display="flex" alignItems="center">
                       <InlineCode>{prop}</InlineCode>
-                      {/* <Heading size={400}>{prop}</Heading> */}
                       {required && <Badge marginLeft={majorScale(2)}>Required</Badge>}
                     </Pane>
                   </Table.Cell>
                   <Table.Cell>
-                    <Text>{resolveReadableType(type)}</Text>
+                    <Text>{resolveReadableType(tsType ?? type)}</Text>
                   </Table.Cell>
                   <Table.Cell>
                     <Paragraph>{description}</Paragraph>
@@ -64,6 +74,23 @@ const PropsTable: React.FC<Props> = ({ data }) => {
       )}
     </Pane>
   )
+}
+
+const resolveReadableType = (type: PropType | undefined): string => {
+  if (type == null) {
+    return 'unknown'
+  }
+
+  switch (type.name) {
+    case 'enum':
+      return type.value.map(({ value }) => value).join(' | ')
+    case 'union':
+      return type.value.map((subType: PropType) => resolveReadableType(subType)).join(' | ')
+    case 'custom':
+      return type.raw
+    default:
+      return (type as { name: string }).name
+  }
 }
 
 export default PropsTable

--- a/docs/components/PropsTable.tsx
+++ b/docs/components/PropsTable.tsx
@@ -59,7 +59,7 @@ const PropsTable: React.FC<Props> = ({ data }) => {
                     </Pane>
                   </Table.Cell>
                   <Table.Cell>
-                    <Text>{resolveReadableType(tsType ?? type)}</Text>
+                    <InlineCode>{resolveReadableType(tsType ?? type)}</InlineCode>
                   </Table.Cell>
                   <Table.Cell>
                     <Paragraph>{description}</Paragraph>

--- a/docs/lib/component-docs.ts
+++ b/docs/lib/component-docs.ts
@@ -12,13 +12,14 @@ const getComponentDocs = async (stem: string): Promise<any[]> => {
   })
 
   const props = await Promise.all(
-    componentFiles.map(async (name) => {
-      const data = await fs.readFileSync(path.join(stem, name)).toString()
+    componentFiles.map((name) => {
+      const filename = path.join(stem, name)
+      const data = fs.readFileSync(filename).toString()
       try {
-        const propsData = docgen.parse(data)
+        const propsData = docgen.parse(data, undefined, undefined, { filename })
         return propsData
-      } catch (e) {
-        console.error('There was an error parsing component documentation', e)
+      } catch (error) {
+        console.error(`Error parsing component documentation for ${filename}\n`, error)
         return []
       }
     })


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Resolves #1607

This PR updates the doc site to not crash when parsing *.tsx files (the build would still succeed anyway, but probably not good to leave it like this). There is a [`filename`](https://github.com/reactjs/react-docgen/blob/5.x/README.md#-filename) option in react-docgen that helps it resolve the babel config which resolves the main issue in #1607.

While I was in here, I also cleaned up the types in `PropsTable` and tested out to see how it parses TS definitions. I think we may need to tweak the config for components down the line since they are composed on top of `ui-box` - it seems to only parse top-level props as shown below. 

**Screenshots (if applicable)**

```tsx
export type ButtonProps = PolymorphicBoxProps<'button', ButtonOwnProps> & {
  onClickFoo?: () => void;
};
```

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/11774799/216783479-f603858c-39fb-4744-b1be-33024a48926f.png">


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
