### PR TITLE
Wrap update in function to prevent event from being passed as value

### DIFF
--- a/src/positioner/src/Positioner.js
+++ b/src/positioner/src/Positioner.js
@@ -152,12 +152,13 @@ const Positioner = memo(function Positioner(props) {
   }
 
   useEffect(() => {
-    window.addEventListener('resize', update)
-    window.addEventListener('scroll', update)
+    const handleResizeOrScroll = () => update()
+    window.addEventListener('resize', handleResizeOrScroll)
+    window.addEventListener('scroll', handleResizeOrScroll)
 
     return () => {
-      window.removeEventListener('resize', update)
-      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', handleResizeOrScroll)
+      window.removeEventListener('scroll', handleResizeOrScroll)
     }
   })
 


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves #1556 - the event from `resize` and `scroll` events was being passed as the first parameter to `update`, which would cause a `NaN` error. Since we're not using the event for anything (just looking to recalculate the position when scrolling or resizing the window), I wrapped the `update` call in a function.

Tested using the minimal reproduction code linked in the issue.


**Screenshots (if applicable)**

![](https://user-images.githubusercontent.com/11774799/216786929-7c04b42d-4a61-41d2-a7e3-3e4c041c1eed.gif)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
