### PR TITLE
Update ComponentStyles type to override selectors w/ typed keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -337,9 +337,11 @@ type PolymorphicBoxPropsOrTokens<T extends Components = Components> = Omit<
   TokenizableProps
 > & { [key in TokenizableProps]?: string }
 
-export type StyleProps<T extends Components = Components> = {
-  [key in ComponentPseudoSelectors<T>]: PolymorphicBoxPropsOrTokens<T>
-} & PolymorphicBoxPropsOrTokens<T>
+export type StyleProps<T extends Components = Components> = Omit<PolymorphicBoxPropsOrTokens<T>, 'selectors'> & {
+  selectors: {
+    [key in ComponentPseudoSelectors<T>]: PolymorphicBoxPropsOrTokens<T>
+  }
+}
 
 export type ComponentStyle<T extends Components = Components> = {
   baseStyle?: Partial<StyleProps<T>>

--- a/index.d.ts
+++ b/index.d.ts
@@ -338,9 +338,9 @@ type PolymorphicBoxPropsOrTokens<T extends Components = Components> = Omit<
 > & { [key in TokenizableProps]?: string }
 
 export type StyleProps<T extends Components = Components> = Omit<PolymorphicBoxPropsOrTokens<T>, 'selectors'> & {
-  selectors: {
+  selectors: Partial<{
     [key in ComponentPseudoSelectors<T>]: PolymorphicBoxPropsOrTokens<T>
-  }
+  }>
 }
 
 export type ComponentStyle<T extends Components = Components> = {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -34,11 +34,13 @@ const themeOverridesOrAdditions: ThemeOverrides = {
         primary: {
           color: 'white',
           backgroundColor: '#fc7ef8',
-          _hover: {
-            backgroundColor: '#fc03f0'
-          },
-          _focus: {
-            boxShadow: '0 0 0 2px #fccafa'
+          selectors: {
+            _hover: {
+              backgroundColor: '#fc03f0'
+            },
+            _focus: {
+              boxShadow: '0 0 0 2px #fccafa'
+            }
           }
         },
         warning: {


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

As noted in https://github.com/segmentio/evergreen/discussions/1608#discussioncomment-4871317, the types for the `Theme` are out of date as of the v7 release which moved selectors in the theme object. Tested it out in a local CRA instance using the code in the response.

**Screenshots (if applicable)**

<img width="753" alt="image" src="https://user-images.githubusercontent.com/11774799/216788924-0d0ffb08-a742-4fa9-a55b-4b2bc811ee41.png">

**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
