### PR TITLE
Bug 1602 combobox button

### DIFF
--- a/src/buttons/src/IconButton.js
+++ b/src/buttons/src/IconButton.js
@@ -23,6 +23,7 @@ const IconButton = memo(
         ref={ref}
         paddingLeft={0}
         paddingRight={0}
+        intent={intent}
         flex="none"
         height={height}
         width={height}

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -186,7 +186,7 @@ Combobox.propTypes = {
   isLoading: PropTypes.bool,
 
   /**
-   * intent parent means it will take dafult border color from input.
+   * Default intent is 'input' means it will take dafault border color from input.
    */
   intent: PropTypes.string,
 

--- a/src/combobox/src/Combobox.js
+++ b/src/combobox/src/Combobox.js
@@ -14,6 +14,7 @@ const Combobox = memo(function Combobox(props) {
     height,
     initialSelectedItem,
     inputProps,
+    intent = 'input',
     isLoading = false,
     itemToString,
     items,
@@ -87,6 +88,7 @@ const Combobox = memo(function Combobox(props) {
           <IconButton
             color="muted"
             icon={isLoading ? undefined : CaretDownIcon}
+            intent={intent}
             appearance="default"
             height={height}
             marginTop={0}
@@ -182,6 +184,11 @@ Combobox.propTypes = {
    * When true, show a loading spinner. This also disables the button.
    */
   isLoading: PropTypes.bool,
+
+  /**
+   * intent parent means it will take dafult border color from input.
+   */
+  intent: PropTypes.string,
 
   size: PropTypes.oneOf(['small', 'medium', 'large'])
 }

--- a/src/themes/default/components/button.js
+++ b/src/themes/default/components/button.js
@@ -42,12 +42,12 @@ const colorKeyForIntent = intent => {
   }
 }
 
-const borderColorForIntent = (intent, isHover, ) => {
+const borderColorForIntent = (intent, isHover) => {
   if (intent === 'danger') {
     return `red${isHover ? 500 : 300}`
   } else if (intent === 'success') {
     return `green${isHover ? 400 : 300}`
-  } else if(intent === 'input') {
+  } else if (intent === 'input') {
     return `gray${isHover ? 600 : 400}`
   } else {
     return `gray${isHover ? 600 : 500}`
@@ -93,7 +93,7 @@ const appearances = {
     selectors: {
       _disabled: {
         color: 'colors.gray500',
-        borderColor: (_, props) => props.intent === 'input' ? 'colors.gray400' : 'colors.gray300'
+        borderColor: (_, props) => (props.intent === 'input' ? 'colors.gray400' : 'colors.gray300')
       },
 
       _hover: {

--- a/src/themes/default/components/button.js
+++ b/src/themes/default/components/button.js
@@ -42,11 +42,13 @@ const colorKeyForIntent = intent => {
   }
 }
 
-const borderColorForIntent = (intent, isHover) => {
+const borderColorForIntent = (intent, isHover, ) => {
   if (intent === 'danger') {
     return `red${isHover ? 500 : 300}`
   } else if (intent === 'success') {
     return `green${isHover ? 400 : 300}`
+  } else if(intent === 'input') {
+    return `gray${isHover ? 600 : 400}`
   } else {
     return `gray${isHover ? 600 : 500}`
   }
@@ -91,7 +93,7 @@ const appearances = {
     selectors: {
       _disabled: {
         color: 'colors.gray500',
-        borderColor: 'colors.gray300'
+        borderColor: (_, props) => props.intent === 'input' ? 'colors.gray400' : 'colors.gray300'
       },
 
       _hover: {


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
- Created a props named as intent (**type as string**) for **Combobox** component and set default value 'input'.
- For Button component styles set another if condition inside **borderColorForIntent** function which will check for intent is equal to 'input'. If satisfied it will add the borderColor same as TextArea border.
- For Button disabled same condition updated.
#1602 Reference Bug
**Screenshots (if applicable)**
<img width="1615" alt="evergreen-combobox" src="https://user-images.githubusercontent.com/54455309/216814808-9e66ff1e-9aac-49b5-8408-6715135eb974.png">


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
