### PR TITLE
fix: `toaster` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2843,6 +2843,10 @@ export const toaster: {
    * Returns all visible Toasts.
    */
   getToasts: () => Toast[]
+  /**
+   * Removes toast with specific id
+   */
+  remove: (id: string) => void
 }
 
 export interface OverlayProps

--- a/index.d.ts
+++ b/index.d.ts
@@ -2822,19 +2822,19 @@ export const toaster: {
   /**
    * Opens a Toast with an intent of none.
    */
-  notify: (title: string, settings?: ToasterSettings) => void
+  notify: (title: React.ReactNode, settings?: ToasterSettings) => void
   /**
    * Opens a Toast with an intent of success.
    */
-  success: (title: string, settings?: ToasterSettings) => void
+  success: (title: React.ReactNode, settings?: ToasterSettings) => void
   /**
    * Opens a Toast with an intent of warning.
    */
-  warning: (title: string, settings?: ToasterSettings) => void
+  warning: (title: React.ReactNode, settings?: ToasterSettings) => void
   /**
    * Opens a Toast with an intent of danger.
    */
-  danger: (title: string, settings?: ToasterSettings) => void
+  danger: (title: React.ReactNode, settings?: ToasterSettings) => void
   /**
    * Closes all visible Toasts.
    */


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->
Hello ! :) 

**Overview**
This PR fixes the Typescript type of the `toaster` instance in the following way:
1. Retype `title` argument in `toaster`. The `title` was typed as only a `string` but instead, it can support `ReactNode`. Type `ReactNode` is for `title` also specified in [interface Toast](https://github.com/segmentio/evergreen/blob/b5efd40b271b386eb30e2cc053fa0cb7d733b11e/index.d.ts#L2794).
2. Add function `remove` to the `toaster`. Function `remove` is exposed in the toaster however it doesn't exist in types. Function `remove` is also already used in the storybook [here](https://github.com/segmentio/evergreen/blob/da12d7d7619da0a8797d137c2105957dfedcafd9/src/toaster/stories/index.stories.js#L124).

**Screenshots (if applicable)**
Documentation doesn't need a change since it's already considering that type `title` is a `node`.

![Screenshot 2023-02-09 at 10 40 03](https://user-images.githubusercontent.com/10739349/217775569-506b9c47-2d71-4c7e-80b9-8ad4a3c9b860.png)


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [x] Added / modified Storybook stories
