### PR TITLE
Fix SelectMenu width & height docs

### DIFF
--- a/docs/documentation/components/select-menu.mdx
+++ b/docs/documentation/components/select-menu.mdx
@@ -39,9 +39,9 @@ function NoFilterAndTitleSelectedMenuExample() {
     <SelectMenu
       title="Select name"
       options={['Apple', 'Apricot', 'Banana', 'Cherry', 'Cucumber'].map((label) => ({ label, value: label }))}
-      selected={selected}
       hasFilter={false}
       hasTitle={false}
+      selected={selected}
       onSelect={(item) => setSelected(item.value)}
     >
       <Button>{selected || 'Select name...'}</Button>
@@ -50,7 +50,7 @@ function NoFilterAndTitleSelectedMenuExample() {
 }
 ```
 
-# Change the height and width
+# Change the width and height
 
 You can make the size of a **SelectMenu** custom via the **width** and **height** properties.
 
@@ -61,9 +61,9 @@ function CustomSizeSelectedMenuExample() {
     <SelectMenu
       title="Select name"
       options={['Apple', 'Apricot', 'Banana', 'Cherry', 'Cucumber'].map((label) => ({ label, value: label }))}
+      width={280}
+      height={200}
       selected={selected}
-      hasFilter={false}
-      hasTitle={false}
       onSelect={(item) => setSelected(item.value)}
     >
       <Button>{selected || 'Select name...'}</Button>


### PR DESCRIPTION
**Overview**
The width/height portion of the SelectMenu docs was simply a duplicate of the example above it about removing the title/filter. some small uniformity changes as well.

**Screenshots (if applicable)**
Before/after
![fix](https://user-images.githubusercontent.com/38604383/223709041-3ed7ae80-2d01-4086-b10f-8b2e746a51e0.png)


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
