### PR TITLE
Add PropsWithChildren interface to Tooltip component definition for React 18

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2714,7 +2714,7 @@ export interface TooltipProps {
   statelessProps?: PolymorphicBoxProps<'div', TooltipStatelessProps>
 }
 
-export declare const Tooltip: React.FC<TooltipProps>
+export declare const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>>
 
 export interface OrderedListOwnProps {
   /**


### PR DESCRIPTION


<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves #1617 

Tested it using a branch of the app on React 18.

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
