### PR TITLE
Bump ui-box from 5.4.0 to 5.4.1 to fix primary link Tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.1",
     "tinycolor2": "^1.4.1",
-    "ui-box": "^5.4.0"
+    "ui-box": "^5.4.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/src/tabs/stories/index.stories.js
+++ b/src/tabs/stories/index.stories.js
@@ -33,6 +33,7 @@ class TabManager extends React.PureComponent {
   }
 }
 
+const appearances = ['primary', 'secondary']
 const tabs = ['Traits', 'Event History', 'Identities']
 
 storiesOf('tabs', module).add('Tab', () => (
@@ -99,13 +100,15 @@ storiesOf('tabs', module).add('Tab', () => (
       </StoryHeader>
 
       <Box>
-        <TabNavigation marginX={-4} marginBottom={16}>
-          {tabs.map((tab, index) => (
-            <Tab key={tab} is="a" href="#" id={tab} isSelected={index === 0}>
-              {tab}
-            </Tab>
-          ))}
-        </TabNavigation>
+        {appearances.map(appearance => (
+          <TabNavigation key={appearance} marginX={-4} marginBottom={16}>
+            {tabs.map((tab, index) => (
+              <Tab key={tab} appearance={appearance} is="a" href="#" id={tab} isSelected={index === 0}>
+                {tab}
+              </Tab>
+            ))}
+          </TabNavigation>
+        ))}
       </Box>
     </StorySection>
     <StorySection>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14424,10 +14424,10 @@ typescript@4.9.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
-ui-box@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.4.0.tgz#707c764fdf4be79cf2f50f356ca9583a491164ee"
-  integrity sha512-HuiJKUIOGW/I1VF7EgHl5/3OwywPdV5fwzsDOWfCGS/PORmXOyGetL3gJo9EQJZZZCkui9xf3a/UQhawA88yeQ==
+ui-box@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.4.1.tgz#34f497a143783a3513e850bd58379ac583e3f2fb"
+  integrity sha512-5p+b6kSh1q/bptvLANuAusyB/3fGIvnw8w6rSZNPHckQ8UdPfjIK4DvinmMXRKgdniOba22h8ypVqtkJ9zK/iQ==
   dependencies:
     "@emotion/hash" "^0.7.1"
     inline-style-prefixer "^5.0.4"


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves #1622

Due to a bug in the way `ui-box` expanded multiple/nested selectors, the `:before` selector for a primary link Tab was not being generated properly. This caused a visual regression for `<Tab is="a" appearance="primary">` instances.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/11774799/227253058-f62fa690-bf22-48b3-b4ff-a19b53ac9462.png) | ![image](https://user-images.githubusercontent.com/11774799/227252709-ac151252-2dee-4ebd-bffe-f6785413a535.png)
 | 


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
