### PR TITLE
Added type number to proptypes

### DIFF
--- a/src/select-menu/src/SelectedPropType.js
+++ b/src/select-menu/src/SelectedPropType.js
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types'
 
 /**
  * Selected can either be a string (single values)
+ * or can be a number ( single value)
  * or an array of string (multiple values)
  * NOTE: multiple values are not supported atm
  */
-const SelectedPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
+const SelectedPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.number])
 
 export default SelectedPropType


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Instead of making changes in the SelectMenu.js file, we can directly change the SelectedPropType.js file and add PropTypes.number to PropTypes.oneOfType() function

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
