### PR TITLE
remove tinycolor2

### DIFF
--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2363,7 +2363,6 @@ evergreen-ui@7.1.5:
     prop-types "^15.6.2"
     react-fast-compare "^3.2.0"
     react-transition-group "^4.4.1"
-    tinycolor2 "^1.4.1"
     ui-box "^5.4.0"
 
 extend-shallow@^2.0.1:
@@ -4246,11 +4245,6 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
-tinycolor2@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
-  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"

--- a/examples/ssr-next/yarn.lock
+++ b/examples/ssr-next/yarn.lock
@@ -224,7 +224,6 @@ evergreen-ui@latest:
     react-scrollbar-size "^2.0.2"
     react-tiny-virtual-list "^2.1.4"
     react-transition-group "^4.4.1"
-    tinycolor2 "^1.4.1"
     ui-box "^4.0.0"
 
 fbjs@^0.8.12, fbjs@^0.8.16:
@@ -507,11 +506,6 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-tinycolor2@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
-  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.1",
-    "tinycolor2": "^1.4.1",
     "ui-box": "^5.4.0"
   },
   "peerDependencies": {
@@ -126,7 +125,6 @@
     "@types/node": "^17.0.21",
     "@types/react-is": "17.0.3",
     "@types/testing-library__jest-dom": "5.14.3",
-    "@types/tinycolor2": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "babel-core": "7.0.0-bridge.0",

--- a/src/themes/default/components/badge.js
+++ b/src/themes/default/components/badge.js
@@ -1,4 +1,3 @@
-import tinycolor from 'tinycolor2'
 import { get } from '../../../theme/src/theme-tools'
 
 const baseStyle = {
@@ -16,7 +15,7 @@ const appearances = {
   subtle: (theme, props) => {
     const scheme = get(theme, `fills.${props.color}`, {
       backgroundColor: props.color,
-      color: tinycolor(props.color).isLight() ? 'colors.dark' : 'white'
+      color: props.color,
     })
 
     return {

--- a/src/themes/default/components/badge.js
+++ b/src/themes/default/components/badge.js
@@ -15,7 +15,7 @@ const appearances = {
   subtle: (theme, props) => {
     const scheme = get(theme, `fills.${props.color}`, {
       backgroundColor: props.color,
-      color: props.color,
+      color: props.color
     })
 
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,11 +3436,6 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/tinycolor2@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.3.tgz#ed4a0901f954b126e6a914b4839c77462d56e706"
-  integrity sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==
-
 "@types/uglify-js@*":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.1.tgz#5e889e9e81e94245c75b6450600e1c5ea2878aea"
@@ -14119,11 +14114,6 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
-
-tinycolor2@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
-  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 tmp-promise@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Took out tinyColor 2 from the codebase and checked to see if I could pass arbitrary colors and was not able to. From this github issue [here]( https://github.com/segmentio/evergreen/issues/1592).

**Screenshots (if applicable)**

<img width="1109" alt="Screen Shot 2023-04-07 at 8 42 01 PM" src="https://user-images.githubusercontent.com/90116354/230701715-f749a24c-40dd-4ec9-b1ac-5fec59c26dce.png">


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
