### PR TITLE
fix pseudo-state button styling in theming docs

### DIFF
--- a/docs/documentation/introduction/theming.mdx
+++ b/docs/documentation/introduction/theming.mdx
@@ -44,15 +44,17 @@ function CustomButtonExample() {
           paddingY: 8,
           borderRadius: 5,
           backgroundColor: 'indianred',
-          _hover: {
-            backgroundColor: 'firebrick',
-          },
-          _active: {
-            backgroundColor: 'darkred',
-          },
-          _focus: {
-            boxShadow: '0 0 0 2px lightcoral',
-          },
+          selectors: {
+            _hover: {
+              backgroundColor: 'firebrick',
+            },
+            _active: {
+              backgroundColor: 'darkred',
+            },
+            _focus: {
+              boxShadow: '0 0 0 2px lightcoral',
+            },
+          }
         },
       },
     },
@@ -82,15 +84,17 @@ function CustomAppearancesExample() {
             paddingY: 8,
             borderRadius: 5,
             backgroundColor: 'indianred',
-            _hover: {
-              backgroundColor: 'firebrick',
-            },
-            _active: {
-              backgroundColor: 'darkred',
-            },
-            _focus: {
-              boxShadow: '0 0 0 2px lightcoral',
-            },
+            selectors: {
+              _hover: {
+                backgroundColor: 'firebrick',
+              },
+              _active: {
+                backgroundColor: 'darkred',
+              },
+              _focus: {
+                boxShadow: '0 0 0 2px lightcoral',
+              },
+            }
           },
         },
       },


### PR DESCRIPTION
**Overview**
Theming docs examples are currently missing the `selectors` property that pseudo state styling is meant to be nested inside of

**Screenshots (if applicable)**
![beforeafter](https://user-images.githubusercontent.com/38604383/230868397-e5912905-2a6b-448f-8465-3ee30366a9d9.png)

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [x] Added / modified component docs
- [ ] Added / modified Storybook stories
