### PR TITLE
add prev and next aria-label on pagination

### DIFF
--- a/src/pagination/src/Pagination.js
+++ b/src/pagination/src/Pagination.js
@@ -115,7 +115,13 @@ const Pagination = memo(
       <Pane is="nav" role="navigation" aria-label="Pagination" {...rest} ref={ref}>
         <Pane is="ul" display="flex" alignItems="center" padding={0}>
           <Pane is="li" listStyle="none">
-            <IconButton appearance="minimal" icon={ChevronLeftIcon} disabled={page === 1} onClick={onPreviousPage} />
+            <IconButton
+              appearance="minimal"
+              icon={ChevronLeftIcon}
+              disabled={page === 1}
+              onClick={onPreviousPage}
+              aria-label="Prev"
+            />
           </Pane>
           {totalPages
             ? getPaginationButtonContent({ totalPages, page }).map((val, i) => {
@@ -142,6 +148,7 @@ const Pagination = memo(
               icon={ChevronRightIcon}
               disabled={totalPages ? page === totalPages : undefined}
               onClick={onNextPage}
+              aria-label="Next"
             />
           </Pane>
         </Pane>

--- a/src/pagination/src/Pagination.js
+++ b/src/pagination/src/Pagination.js
@@ -120,7 +120,7 @@ const Pagination = memo(
               icon={ChevronLeftIcon}
               disabled={page === 1}
               onClick={onPreviousPage}
-              aria-label="Prev"
+              aria-label="Previous page"
             />
           </Pane>
           {totalPages
@@ -148,7 +148,7 @@ const Pagination = memo(
               icon={ChevronRightIcon}
               disabled={totalPages ? page === totalPages : undefined}
               onClick={onNextPage}
-              aria-label="Next"
+              aria-label="Next page"
             />
           </Pane>
         </Pane>


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
I'm creating a component using Pagination and have an implementation with an event.
I would like to write test-code using `react-testing-library`, but the prev/next buttons don't have labels, so I can't get elements by queries.

I think this would not only contribute to testing, but also accessibility.

**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
