### PR TITLE
Add type union for Link target prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1398,9 +1398,9 @@ export interface LinkOwnProps extends TextOwnProps {
    */
   href?: string
   /**
-   * Target atrribute, common use case is target="_blank."
+   * Target attribute, common use case is target="_blank."
    */
-  target?: string
+  target?: '_self' | '_blank' | '_parent' | '_top'
   /**
    * The color (and styling) of the Link. Can be default, blue, green or neutral.
    */

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,17 @@
 import { expectAssignable, expectType, expectError } from 'tsd'
-import { defaultTheme, mergeTheme, StyleProps, Intent, Theme, Fill, Partial, Pick, Color, ComboboxProps } from '.'
+import {
+  defaultTheme,
+  mergeTheme,
+  StyleProps,
+  Intent,
+  Theme,
+  Fill,
+  Partial,
+  Pick,
+  Color,
+  ComboboxProps,
+  LinkProps
+} from '.'
 
 interface ThemeOverrides extends Partial<Pick<Theme, 'colors' | 'fills' | 'components'>> {
   colors: {
@@ -131,3 +143,5 @@ expectError(mergeTheme(defaultTheme, themeWithTopLevelColorsArray))
 expectError<ComboboxProps>({ autocompleteProps: { children: 'error' } })
 expectError<ComboboxProps>({ autocompleteProps: { onChange: () => {} } })
 expectError<ComboboxProps>({ autocompleteProps: { items: [] } })
+
+expectError<LinkProps>({ target: 'blank' })

--- a/src/typography/src/Link.js
+++ b/src/typography/src/Link.js
@@ -37,9 +37,9 @@ Link.propTypes = {
   href: PropTypes.string,
 
   /**
-   * Target atrribute, common use case is target="_blank."
+   * Target attribute, common use case is target="_blank."
    */
-  target: PropTypes.string,
+  target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
 
   /**
    * The color (and styling) of the Link. Can be default, blue, green or neutral.


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

Resolves #1642 

**Screenshots (if applicable)**


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
