### PR TITLE
Add .ogg supported mime type

### DIFF
--- a/src/constants/src/MimeType.js
+++ b/src/constants/src/MimeType.js
@@ -15,6 +15,7 @@ const MimeType = {
   mp3: 'audio/mpeg',
   mp4: 'video/mp4',
   mpeg: 'video/mpeg',
+  ogg: 'audio/ogg',
   pdf: 'application/pdf',
   png: 'image/png',
   ppt: 'application/vnd.ms-powerpoint',


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**
Hey!
Really super quick PR to add the `.ogg` audio file format as a supported mime type for the File Uploader component.

I am currently using the File Uploader exclusively for `.ogg` files. It runs into problems when removing a file from the FileCard list because `rebaseFiles` tries to verify the remaining files against your list of supported mime types.

In future you could consider splitting this out into `.oga` (audio), `.ogv` (video) and `.ogx` (application) mime-types, but for now it's probably fine to use the more general `.ogg` for just audio.

Thanks!


**Screenshots (if applicable)**


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
