### PR TITLE
Add PopoverRef type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1524,6 +1524,11 @@ export declare const Pill: BoxComponent<PillOwnProps, 'strong'>
 
 export type PopoverStatelessProps = BoxProps<'div'>
 
+export type PopoverRef = {
+  open: () => void
+  close: () => void
+}
+
 export interface PopoverProps {
   /**
    * The position the Popover is on. Smart positioning might override this.
@@ -1553,10 +1558,14 @@ export interface PopoverProps {
   children:
     | ((props: {
         toggle: () => void
-        getRef: (ref: React.RefObject<HTMLElement>) => void
+        getRef: (ref: React.RefObject<PopoverRef>) => void
         isShown: boolean
       }) => React.ReactNode)
     | React.ReactNode
+  /**
+   * Pass a ref to Popover.
+   */
+  ref?: React.RefObject<PopoverRef>
   /**
    * The display property passed to the Popover card.
    */


### PR DESCRIPTION
<!---
Hello! And thanks for contributing to Evergreen 🎉

We appreciate the time you took to open this pull request.
Please take a couple more minutes to document your pull request to ensure we can quickly review it and provide you feedback.

Unfortunately, if we do not have enough information or the feature doesn't align with our roadmap, we might respectfully thank you for your time and close the issue.

Please respect our [Code of Conduct](https://github.com/segmentio/evergreen/blob/master/.github/CODE_OF_CONDUCT.md).
--->

**Overview**

`Popover` supports a `ref` prop that doesn't seem to be documented or typed.

Here is a [codesandbox](https://codesandbox.io/s/beautiful-mcclintock-5d7m48?file=/src/App.tsx) that showcases the ref actually working at run time, but with type errors. This PR addresses those errors by:
* introducing a `PopoverRef` type that has the signatures for `open` and `close` methods
* adding an optional `ref` prop to `PopoverProps` 

I also tweaked the definition for `childred` prop. Specifically, the `getRef` prop passed to children to use the new `PopoverRef` instead of the generic `HTMLElement`.

The changes can be tested by trying to pass a ref created by `useRef<PopoverRef>` and making sure there are no type errors related to calling `open` or `close`.


**Documentation**
- [x] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
