### PR TITLE
fix: add optional prop "name" to RadioGroupOwnProps in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1759,6 +1759,10 @@ export interface RadioGroupOwnProps extends PaneOwnProps {
    */
   options?: RadioGroupOption[]
   /**
+   * The name attribute for HTML radio button. Default to auto-generated string with 'RadioGroup' prefix.
+   */
+  name?: string
+  /**
    * The selected item value when controlled.
    */
   value?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -1759,10 +1759,6 @@ export interface RadioGroupOwnProps extends PaneOwnProps {
    */
   options?: RadioGroupOption[]
   /**
-   * The name attribute for HTML radio button. Default to auto-generated string with 'RadioGroup' prefix.
-   */
-  name?: string
-  /**
    * The selected item value when controlled.
    */
   value?: string
@@ -1778,6 +1774,10 @@ export interface RadioGroupOwnProps extends PaneOwnProps {
    * When true, the radio get the required attribute.
    */
   isRequired?: boolean
+  /**
+   * The name attribute for HTML radio button. Default to auto-generated string with 'RadioGroup' prefix.
+   */
+  name?: string
   /**
    * Function called when state changes.
    */


### PR DESCRIPTION
**Overview**

While attempting to set `name` prop on the <RadioGroup />; encountered a typing issue where `name` was not defined, however, based on the public docs/propTypes it should be allowed.

    <RadioGroup
      name="is_private"
      ...
    />

The type definition changes might have been introduced with https://github.com/segmentio/evergreen/pull/1344.

**Screenshots (if applicable)**

![Screenshot 2023-09-16 at 11 23 10 AM](https://github.com/segmentio/evergreen/assets/8839447/c642f2b0-4009-4d23-89eb-f3db61cfba94)

**Documentation**
- [X] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
