### PR TITLE
Fix: Resolved inconsistent label styling issue (#1284)

### DIFF
--- a/src/radio/src/RadioGroup.js
+++ b/src/radio/src/RadioGroup.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { spacing, position, layout, dimensions } from 'ui-box'
 import { useId } from '../../hooks'
 import { Pane } from '../../layers'
-import { Text } from '../../typography'
+import { Label } from '../../typography'
 import Radio from './Radio'
 
 const noop = () => {}
@@ -32,11 +32,7 @@ const RadioGroup = memo(
 
     return (
       <Pane role="group" aria-label={label} {...rest} ref={ref}>
-        {label && (
-          <Text color="muted" fontWeight={500}>
-            {label}
-          </Text>
-        )}
+        {label && <Label fontWeight={500}>{label}</Label>}
         {options.map(item => (
           <Radio
             key={item.value}


### PR DESCRIPTION
In this commit, I've addressed the problem of inconsistent label styling reported in [issue #1284](https://github.com/segmentio/evergreen/issues/1284). The issue was related to inconsistencies in the styling of labels throughout the application.

#### Changes Made:

- Modified `RadioGroup.js` file by replacing the `Text` component with the `Label` component for displaying labels.

- Now both the `RadioGroup` and the `SelectField` components use:
  **Element:** `label`
  **Color:** `color: rgb(16, 24, 64);`

The label inconsistency was notable when using the two components together. This commit aims to improve the overall user experience by ensuring a consistent and polished visual appearance for labels.

Closes [issue #1284]