### PR TITLE
issue 1649: dialog onBeforeClose

### DIFF
--- a/docs/documentation/components/dialog.mdx
+++ b/docs/documentation/components/dialog.mdx
@@ -53,7 +53,6 @@ function DefaultDialogExample() {
 }
 ```
 
-
 ## Default with a danger intent
 
 The `intent` prop determines the appearance of the confirm button, `danger` is red.
@@ -92,11 +91,7 @@ function InternalScrollingDialogExample() {
 
   return (
     <Pane>
-      <Dialog
-        isShown={isShown}
-        title="Internal scrolling"
-        onCloseComplete={() => setIsShown(false)}
-      >
+      <Dialog isShown={isShown} title="Internal scrolling" onCloseComplete={() => setIsShown(false)}>
         <Pane height={1800} width="100%" backgroundColor="#ddd" />
       </Dialog>
 
@@ -113,11 +108,7 @@ function SelfManagedCloseDialogExample() {
   const [isShown, setIsShown] = React.useState(false)
   return (
     <Pane>
-      <Dialog
-        isShown={isShown}
-        title="Self managed close"
-        onCloseComplete={() => setIsShown(false)}
-      >
+      <Dialog isShown={isShown} title="Self managed close" onCloseComplete={() => setIsShown(false)}>
         {({ close }) => (
           <Pane>
             <Paragraph>Manage your own buttons and close interaction</Paragraph>
@@ -144,12 +135,7 @@ function NoFooterDialogExample() {
   const [isShown, setIsShown] = React.useState(false)
   return (
     <Pane>
-      <Dialog
-        isShown={isShown}
-        title="No footer"
-        onCloseComplete={() => setIsShown(false)}
-        hasFooter={false}
-      >
+      <Dialog isShown={isShown} title="No footer" onCloseComplete={() => setIsShown(false)} hasFooter={false}>
         No footer
       </Dialog>
 
@@ -169,12 +155,7 @@ function NoHeaderDialogExample() {
   const [isShown, setIsShown] = React.useState(false)
   return (
     <Pane>
-      <Dialog
-        isShown={isShown}
-        title="No footer"
-        onCloseComplete={() => setIsShown(false)}
-        hasHeader={false}
-      >
+      <Dialog isShown={isShown} title="No footer" onCloseComplete={() => setIsShown(false)} hasHeader={false}>
         No header
       </Dialog>
 
@@ -200,6 +181,32 @@ function PreserveBodyScrollingDialogExample() {
         onCloseComplete={() => setIsShown(false)}
         preventBodyScrolling
         confirmLabel="Custom Label"
+      >
+        Dialog content
+      </Dialog>
+
+      <Button onClick={() => setIsShown(true)}>Show Dialog</Button>
+    </Pane>
+  )
+}
+```
+
+## Handle overlay/close clicks
+
+Use the `onBeforeClose` prop to handle overlay/close clicks. It is executed
+when dialog is about to close. Return `false` to prevent the sheet from closing.
+
+```jsx
+function PreserveBodyScrollingDialogExample() {
+  const [isShown, setIsShown] = React.useState(false)
+
+  return (
+    <Pane>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with onBeforeClose callback
+        onBeforeClose={() => confirm('Are you sure you want to close?')}
+        onCloseComplete={() => setIsShown(false)}
       >
         Dialog content
       </Dialog>

--- a/docs/documentation/components/dialog.mdx
+++ b/docs/documentation/components/dialog.mdx
@@ -53,6 +53,7 @@ function DefaultDialogExample() {
 }
 ```
 
+
 ## Default with a danger intent
 
 The `intent` prop determines the appearance of the confirm button, `danger` is red.
@@ -91,7 +92,11 @@ function InternalScrollingDialogExample() {
 
   return (
     <Pane>
-      <Dialog isShown={isShown} title="Internal scrolling" onCloseComplete={() => setIsShown(false)}>
+      <Dialog
+        isShown={isShown}
+        title="Internal scrolling"
+        onCloseComplete={() => setIsShown(false)}
+      >
         <Pane height={1800} width="100%" backgroundColor="#ddd" />
       </Dialog>
 
@@ -108,7 +113,11 @@ function SelfManagedCloseDialogExample() {
   const [isShown, setIsShown] = React.useState(false)
   return (
     <Pane>
-      <Dialog isShown={isShown} title="Self managed close" onCloseComplete={() => setIsShown(false)}>
+      <Dialog
+        isShown={isShown}
+        title="Self managed close"
+        onCloseComplete={() => setIsShown(false)}
+      >
         {({ close }) => (
           <Pane>
             <Paragraph>Manage your own buttons and close interaction</Paragraph>
@@ -135,7 +144,12 @@ function NoFooterDialogExample() {
   const [isShown, setIsShown] = React.useState(false)
   return (
     <Pane>
-      <Dialog isShown={isShown} title="No footer" onCloseComplete={() => setIsShown(false)} hasFooter={false}>
+      <Dialog
+        isShown={isShown}
+        title="No footer"
+        onCloseComplete={() => setIsShown(false)}
+        hasFooter={false}
+      >
         No footer
       </Dialog>
 
@@ -155,7 +169,12 @@ function NoHeaderDialogExample() {
   const [isShown, setIsShown] = React.useState(false)
   return (
     <Pane>
-      <Dialog isShown={isShown} title="No footer" onCloseComplete={() => setIsShown(false)} hasHeader={false}>
+      <Dialog
+        isShown={isShown}
+        title="No footer"
+        onCloseComplete={() => setIsShown(false)}
+        hasHeader={false}
+      >
         No header
       </Dialog>
 
@@ -181,32 +200,6 @@ function PreserveBodyScrollingDialogExample() {
         onCloseComplete={() => setIsShown(false)}
         preventBodyScrolling
         confirmLabel="Custom Label"
-      >
-        Dialog content
-      </Dialog>
-
-      <Button onClick={() => setIsShown(true)}>Show Dialog</Button>
-    </Pane>
-  )
-}
-```
-
-## Handle overlay/close clicks
-
-Use the `onBeforeClose` prop to handle overlay/close clicks. It is executed
-when dialog is about to close. Return `false` to prevent the sheet from closing.
-
-```jsx
-function PreserveBodyScrollingDialogExample() {
-  const [isShown, setIsShown] = React.useState(false)
-
-  return (
-    <Pane>
-      <Dialog
-        isShown={isShown}
-        title="Dialog with onBeforeClose callback
-        onBeforeClose={() => confirm('Are you sure you want to close?')}
-        onCloseComplete={() => setIsShown(false)}
       >
         Dialog content
       </Dialog>

--- a/docs/documentation/components/dialog.mdx
+++ b/docs/documentation/components/dialog.mdx
@@ -209,3 +209,30 @@ function PreserveBodyScrollingDialogExample() {
   )
 }
 ```
+
+## Handle overlay/close clicks
+
+Use the `onBeforeClose` prop to handle overlay/close clicks. It is executed
+when dialog is about to close. Return `false` to prevent the sheet from closing.
+
+```jsx
+function PreserveBodyScrollingDialogExample() {
+  const [isShown, setIsShown] = React.useState(false)
+
+  return (
+    <Pane>
+      <Dialog
+        isShown={isShown}
+        title="Dialog with onBeforeClose callback
+        onBeforeClose={() => confirm('Are you sure you want to close?')}
+        onCloseComplete={() => setIsShown(false)}
+      >
+        Dialog content
+      </Dialog>
+
+      <Button onClick={() => setIsShown(true)}>Show Dialog</Button>
+    </Pane>
+  )
+}
+```
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -833,7 +833,10 @@ export interface CornerDialogProps {
 export declare const CornerDialog: React.FC<CornerDialogProps>
 
 export interface DialogProps
-  extends Pick<OverlayProps, 'isShown' | 'preventBodyScrolling' | 'shouldAutoFocus' | 'shouldCloseOnEscapePress'> {
+  extends Pick<
+    OverlayProps,
+    'isShown' | 'preventBodyScrolling' | 'shouldAutoFocus' | 'shouldCloseOnEscapePress' | 'onBeforeClose'
+  > {
   /**
    * Children can be a string, node or a function accepting `({ close })`.
    * When passing a string, <Paragraph /> is used to wrap the string.

--- a/src/dialog/src/Dialog.js
+++ b/src/dialog/src/Dialog.js
@@ -77,6 +77,7 @@ const Dialog = memo(function Dialog({
   isConfirmLoading = false,
   isShown = false,
   minHeightContent = 80,
+  onBeforeClose,
   onCancel = closeHandler,
   onCloseComplete,
   onConfirm = closeHandler,
@@ -195,6 +196,7 @@ const Dialog = memo(function Dialog({
         justifyContent: 'center',
         ...overlayProps
       }}
+      onBeforeClose={onBeforeClose}
       preventBodyScrolling={preventBodyScrolling}
     >
       {({ close, state }) => (
@@ -402,6 +404,13 @@ Dialog.propTypes = {
    * @default false
    */
   preventBodyScrolling: PropTypes.bool,
+
+  /**
+   * Function called when dialog is about to close.
+   * Return `false` to prevent the sheet from closing.
+   * type: `Function -> Boolean`
+   */
+  onBeforeClose: PropTypes.func,
 
   /**
    * Props that are passed to the Overlay component.

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -396,3 +396,22 @@ storiesOf('dialog', module)
       </DialogManager>
     </Box>
   ))
+  .add('Dialog with onBeforeClose', () => (
+    <Box padding={40}>
+      <DialogManager>
+        {({ hide, isShown, show }) => (
+          <Box marginBottom={16}>
+            <Dialog
+              isShown={isShown}
+              title="Dialog with Combobox"
+              onBeforeClose={() => confirm('Are you sure you want to close?')}
+              onCloseComplete={hide}
+            >
+              <Paragraph>onBeforeClose >> are you sure you want to close?</Paragraph>
+            </Dialog>
+            <Button onClick={show}>Show Dialog with onBeforeClose</Button>
+          </Box>
+        )}
+      </DialogManager>
+    </Box>
+  ))

--- a/src/dialog/stories/index.stories.js
+++ b/src/dialog/stories/index.stories.js
@@ -403,11 +403,11 @@ storiesOf('dialog', module)
           <Box marginBottom={16}>
             <Dialog
               isShown={isShown}
-              title="Dialog with Combobox"
+              title="Dialog with onBeforeClose callback"
               onBeforeClose={() => confirm('Are you sure you want to close?')}
               onCloseComplete={hide}
             >
-              <Paragraph>onBeforeClose >> are you sure you want to close?</Paragraph>
+              <Paragraph>onBeforeClose: are you sure you want to close?</Paragraph>
             </Dialog>
             <Button onClick={show}>Show Dialog with onBeforeClose</Button>
           </Box>


### PR DESCRIPTION
**Overview**
I needed the ability to handle overlay/close clicks in Dialog component in a personal project. I found the below issue

[https://github.com/segmentio/evergreen/issues/1649](url)

Implemented in the same way as component SideSheet by passing the function callback to the Overlay as a prop.

Thanks

**Screenshots (if applicable)**

![image](https://github.com/segmentio/evergreen/assets/38192940/ea8e9291-0bab-41cd-9cc7-48cc19d9ff0c)

confirmation is used here as an example

**Documentation**
- [X] Updated Typescript types and/or component PropTypes
- [X] Added / modified component docs
- [X] Added / modified Storybook stories
